### PR TITLE
Surface package in pi.dev gallery + polish install docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-04-28
+
+### Added
+
+- `pi-package` keyword so the package surfaces in the [pi.dev/packages](https://pi.dev/packages) gallery.
+
+### Changed
+
+- README install instructions now use `pi install npm:@balcsida/pi-provider-litellm` (and `pi -e` for ephemeral trials), with the source-clone path kept as a fallback.
+
 ## [0.1.0] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,12 +1,27 @@
 # @balcsida/pi-provider-litellm
 
+[![npm version](https://img.shields.io/npm/v/@balcsida/pi-provider-litellm.svg)](https://www.npmjs.com/package/@balcsida/pi-provider-litellm)
+
 LiteLLM proxy provider extension for [pi-mono](https://github.com/badlogic/pi-mono).
 
 Discovers models from a self-hosted LiteLLM proxy and registers them under the `litellm` provider. Supports `/login litellm` and `/litellm-refresh`. Tries `/model/info` first (admin endpoint with rich metadata), falls back to `/v1/models` (OpenAI-compatible) on 401/403/404.
 
 ## Install
 
-Pi loads extensions from `~/.pi/agent/extensions/` (global) or `<cwd>/.pi/extensions/` (project-local). Until pi adds npm-package resolution, the install path is a clone:
+```bash
+pi install npm:@balcsida/pi-provider-litellm
+```
+
+Pi fetches the package from npm and registers it. Add `-l` to install into project settings (`.pi/settings.json`) instead of global.
+
+To try it without installing (one-off, current run only):
+
+```bash
+pi -e npm:@balcsida/pi-provider-litellm
+```
+
+<details>
+<summary>Alternative: install from source</summary>
 
 ```bash
 git clone https://github.com/balcsida/pi-provider-litellm.git ~/.pi/agent/extensions/pi-provider-litellm
@@ -15,7 +30,7 @@ npm install
 npm run build
 ```
 
-After this, pi will discover the extension on next start.
+</details>
 
 ## Configure
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@balcsida/pi-provider-litellm",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "LiteLLM proxy provider extension for pi-mono.",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "bugs": "https://github.com/balcsida/pi-provider-litellm/issues",
   "keywords": [
     "pi-mono",
+    "pi-package",
     "litellm",
     "llm",
     "extension",


### PR DESCRIPTION
## Summary
- Adds the `pi-package` keyword so the package surfaces at https://pi.dev/packages.
- Replaces the clone-only install instructions with `pi install npm:@balcsida/pi-provider-litellm` (and `pi -e` for ephemeral trials); source-clone path kept as a collapsed fallback.
- Bumps version to 0.1.1 with a CHANGELOG entry.

## Test plan
- [x] `npm run check` (lint + typecheck + 28 tests) passes
- [ ] After merge: `npm publish` and confirm the package appears at https://pi.dev/packages?name=litellm

🤖 Generated with [Claude Code](https://claude.com/claude-code)