### PR TITLE
Rename to unscoped pi-provider-litellm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- README install instructions now use `pi install npm:@balcsida/pi-provider-litellm` (and `pi -e` for ephemeral trials), with the source-clone path kept as a fallback.
+- Renamed package from `@balcsida/pi-provider-litellm` to unscoped `pi-provider-litellm` to match the `pi-provider-*` convention used by other extensions in the pi-mono ecosystem. The previous scoped name was published as 0.1.0 only.
+- README install instructions now use `pi install npm:pi-provider-litellm` (and `pi -e` for ephemeral trials), with the source-clone path kept as a fallback.
 
 ## [0.1.0] - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# @balcsida/pi-provider-litellm
+# pi-provider-litellm
 
-[![npm version](https://img.shields.io/npm/v/@balcsida/pi-provider-litellm.svg)](https://www.npmjs.com/package/@balcsida/pi-provider-litellm)
+[![npm version](https://img.shields.io/npm/v/pi-provider-litellm.svg)](https://www.npmjs.com/package/pi-provider-litellm)
 
 LiteLLM proxy provider extension for [pi-mono](https://github.com/badlogic/pi-mono).
 
@@ -9,7 +9,7 @@ Discovers models from a self-hosted LiteLLM proxy and registers them under the `
 ## Install
 
 ```bash
-pi install npm:@balcsida/pi-provider-litellm
+pi install npm:pi-provider-litellm
 ```
 
 Pi fetches the package from npm and registers it. Add `-l` to install into project settings (`.pi/settings.json`) instead of global.
@@ -17,7 +17,7 @@ Pi fetches the package from npm and registers it. Add `-l` to install into proje
 To try it without installing (one-off, current run only):
 
 ```bash
-pi -e npm:@balcsida/pi-provider-litellm
+pi -e npm:pi-provider-litellm
 ```
 
 <details>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@balcsida/pi-provider-litellm",
-  "version": "0.1.0",
+  "name": "pi-provider-litellm",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@balcsida/pi-provider-litellm",
-      "version": "0.1.0",
+      "name": "pi-provider-litellm",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@balcsida/pi-provider-litellm",
+  "name": "pi-provider-litellm",
   "version": "0.1.1",
   "description": "LiteLLM proxy provider extension for pi-mono.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Renames the npm package from `@balcsida/pi-provider-litellm` to unscoped `pi-provider-litellm`, matching the `pi-provider-*` naming convention used across the pi-mono ecosystem (`pi-provider-kiro`, `pi-provider-bedrock`, `pi-provider-cc-sdk`, etc.).
- Updates the README badge, install commands, and CHANGELOG entry to reference the new name.
- Regenerates `package-lock.json` with the new name.

The previous scoped name `@balcsida/pi-provider-litellm@0.1.0` remains on npm; 0.1.1 will be the first version published under the new name.

## Test plan
- [x] `npm run check` (lint + typecheck + 28 tests) passes
- [x] Verified remaining `balcsida/pi-provider-litellm` matches in the tree are GitHub repo URLs only
- [ ] After merge: `npm publish` and confirm the package surfaces at https://pi.dev/packages?name=litellm

🤖 Generated with [Claude Code](https://claude.com/claude-code)