### PR TITLE
[codex] port LiteLLM parity features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "0.1.4",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "0.1.4",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,42 +10,21 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@mariozechner/pi-ai": "^0.70.0",
-        "@mariozechner/pi-coding-agent": "^0.70.0",
-        "@types/node": "^24.3.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0",
+        "@types/node": "^24.12.3",
         "@typescript/native-preview": "7.0.0-dev.20260120.1",
         "shx": "^0.4.0",
         "tsx": "^4.21.0",
-        "typescript": "^5.7.3",
+        "typescript": "^5.9.3",
         "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@mariozechner/pi-ai": "^0.70.0",
-        "@mariozechner/pi-coding-agent": "^0.70.0"
-      }
-    },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.90.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.90.0.tgz",
-      "integrity": "sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-coding-agent": "^0.74.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -1039,6 +1018,126 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.74.0.tgz",
+      "integrity": "sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.74.0",
+        "typebox": "^1.1.24"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.74.0.tgz",
+      "integrity": "sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.74.0.tgz",
+      "integrity": "sha512-Q5GikbB5vRBrsrrf/uvet53rPSQ1sn5I5mO+l7sIobdXYpS04/X2oOc2UHFm90fNdkl3yU+ANTZL0zOtHbnqRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.74.0",
+        "@earendil-works/pi-ai": "^0.74.0",
+        "@earendil-works/pi-tui": "^0.74.0",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "typebox": "^1.1.24",
+        "undici": "^7.19.1",
+        "uuid": "^14.0.0",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.5"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.74.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.74.0.tgz",
+      "integrity": "sha512-1aIfXZp7D/z+1VlZX8BZcs6pgO8rjmil7kwyhctNDsWvce3Yfl8GVgu4eq+I0Mjhr8Cj+ipBiv9CLIzdoyCOIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
@@ -1513,9 +1612,9 @@
       "license": "MIT"
     },
     "node_modules/@mariozechner/clipboard": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.3.tgz",
-      "integrity": "sha512-e7jASirzfm+ROiOGFh843+cFZTy3DfzP+jldCvh8RnEk0C3QihDTn7dd7Yh7KAJydwIJ18FJSZ2swHvCJhk18g==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.5.tgz",
+      "integrity": "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1523,22 +1622,22 @@
         "node": ">= 10"
       },
       "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.3",
-        "@mariozechner/clipboard-darwin-universal": "0.3.3",
-        "@mariozechner/clipboard-darwin-x64": "0.3.3",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.3",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.3",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.3",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.3",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.3"
+        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
+        "@mariozechner/clipboard-darwin-universal": "0.3.2",
+        "@mariozechner/clipboard-darwin-x64": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
       }
     },
     "node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.3.tgz",
-      "integrity": "sha512-+zhuZGXqVrdkbIRdnwiZNbTJ7V3elq/A+C5d5laJoyhJgWs41eO5NUMkBkj6f23F2L4PRXEhdn5/ktlPx+bG3Q==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
       "cpu": [
         "arm64"
       ],
@@ -1553,9 +1652,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.3.tgz",
-      "integrity": "sha512-x9aRfTyndVqpEQ44LNNCK/EXZd9y8rWkLQgNhmWpby9PXrjPhNxfjUc2Db4mt4nJjU/4zzO8F5v/XyzlUGSdhQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1567,9 +1666,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.3.tgz",
-      "integrity": "sha512-6ut/NawB0KiYPCwrirgNp6Br62LntL978q7G6d/Rs2pmPvQb53bP96eUMYl+Y3a7Qk13bGZ4w9rVPFxRE9m9ag==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
       "cpu": [
         "x64"
       ],
@@ -1584,9 +1683,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.3.tgz",
-      "integrity": "sha512-gf3dH4kBddU1AOyHVB53mjLUFfJAKlTmxTMw51jdeg7eE7IjfEBXVvM4bifMtBxbWkT0eA0FUZ1C0KQ6Z5l6pw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
       "cpu": [
         "arm64"
       ],
@@ -1604,9 +1703,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.3.tgz",
-      "integrity": "sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
       "cpu": [
         "arm64"
       ],
@@ -1624,9 +1723,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.3.tgz",
-      "integrity": "sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
       "cpu": [
         "riscv64"
       ],
@@ -1644,9 +1743,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.3.tgz",
-      "integrity": "sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
       "cpu": [
         "x64"
       ],
@@ -1664,9 +1763,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.3.tgz",
-      "integrity": "sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
       "cpu": [
         "x64"
       ],
@@ -1684,9 +1783,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.3.tgz",
-      "integrity": "sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
       "cpu": [
         "arm64"
       ],
@@ -1701,9 +1800,9 @@
       }
     },
     "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.3.tgz",
-      "integrity": "sha512-5hvaEq/bgYovTIGx43O/S7loIHYV3ue90WcV1dz0wdMXroVKZKeU/yfwM0PALQA1OcrEHiGXGySFReXr72lGtA==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
       "cpu": [
         "x64"
       ],
@@ -1715,119 +1814,6 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@mariozechner/jiti": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
-      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "std-env": "^3.10.0",
-        "yoctocolors": "^2.1.2"
-      },
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
-    "node_modules/@mariozechner/pi-agent-core": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.70.5.tgz",
-      "integrity": "sha512-ZUnJ7fFeJog97KG8FewEyqaObY2sLWvfDurKHl9kImVEbgt3l1LJ9A5pb+4/5KXnCVsoF/Brd0h+7yBEd1Aj5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/pi-ai": "^0.70.5",
-        "typebox": "^1.1.24"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-ai": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.70.5.tgz",
-      "integrity": "sha512-eyeyOfu/YiqzY6q391oRYdmnPIIU1VTKAn3hWIvzqkRHkcArd41/YynG8mw6bgoLdmCnIBoY3fD6nzEHEHLIMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "^0.90.0",
-        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-        "@google/genai": "^1.40.0",
-        "@mistralai/mistralai": "^2.2.0",
-        "chalk": "^5.6.2",
-        "openai": "6.26.0",
-        "partial-json": "^0.1.7",
-        "proxy-agent": "^6.5.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "zod-to-json-schema": "^3.24.6"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@mariozechner/pi-coding-agent": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.70.5.tgz",
-      "integrity": "sha512-5sQjY2LQLvYfMjo4Dn6P6iy3LFm3MZYgrYmgCQSwQSUM5yqzWceidYYXS4knloW7gNkko+nnhKB2u4NF3w+dVw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@mariozechner/jiti": "^2.6.2",
-        "@mariozechner/pi-agent-core": "^0.70.5",
-        "@mariozechner/pi-ai": "^0.70.5",
-        "@mariozechner/pi-tui": "^0.70.5",
-        "@silvia-odwyer/photon-node": "^0.3.4",
-        "chalk": "^5.5.0",
-        "cli-highlight": "^2.1.11",
-        "diff": "^8.0.2",
-        "extract-zip": "^2.0.1",
-        "file-type": "^21.1.1",
-        "glob": "^13.0.1",
-        "hosted-git-info": "^9.0.2",
-        "ignore": "^7.0.5",
-        "marked": "^15.0.12",
-        "minimatch": "^10.2.3",
-        "proper-lockfile": "^4.1.2",
-        "strip-ansi": "^7.1.0",
-        "typebox": "^1.1.24",
-        "undici": "^7.19.1",
-        "uuid": "^14.0.0",
-        "yaml": "^2.8.2"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.6.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "^0.3.3"
-      }
-    },
-    "node_modules/@mariozechner/pi-tui": {
-      "version": "0.70.5",
-      "resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.70.5.tgz",
-      "integrity": "sha512-5Ol9weTqpsQ85gg1C6Mo8M8o/HYz4uN7nM7QTPrw/Rm/UoFgO1/T/Irago5aGfzlIj/nmsGcqb7NlkWtT4vXUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/mime-types": "^2.1.4",
-        "chalk": "^5.5.0",
-        "get-east-asian-width": "^1.3.0",
-        "marked": "^15.0.12",
-        "mime-types": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "optionalDependencies": {
-        "koffi": "^2.9.0"
       }
     },
     "node_modules/@mistralai/mistralai": {
@@ -3110,9 +3096,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.12.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
-      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4537,6 +4523,16 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -6308,19 +6304,6 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -54,18 +54,18 @@
     "node": ">=20.0.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-ai": "^0.70.0",
-    "@mariozechner/pi-coding-agent": "^0.70.0"
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0"
   },
   "devDependencies": {
+    "@earendil-works/pi-ai": "^0.74.0",
+    "@earendil-works/pi-coding-agent": "^0.74.0",
     "@biomejs/biome": "^1.9.4",
-    "@mariozechner/pi-ai": "^0.70.0",
-    "@mariozechner/pi-coding-agent": "^0.70.0",
-    "@types/node": "^24.3.0",
+    "@types/node": "^24.12.3",
     "@typescript/native-preview": "7.0.0-dev.20260120.1",
     "shx": "^0.4.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "0.1.4",
+  "version": "1.2.0",
   "description": "LiteLLM proxy provider extension for pi-mono.",
   "type": "module",
   "license": "MIT",

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,0 +1,172 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { discoverModels } from "./discover.js";
+import { resolveCredentials } from "./litellm.js";
+
+export interface ModelCostInfo {
+  inputCostPerToken: number;
+  outputCostPerToken: number;
+  cacheReadCostPerToken: number;
+  cacheWriteCostPerToken: number;
+}
+
+export function setupLiteLLMCostTracking(pi: ExtensionAPI): void {
+  const modelCosts = new Map<string, ModelCostInfo>();
+  let lastResponseCost: number | null = null;
+
+  pi.on("session_start", async (_event, ctx) => {
+    try {
+      const config = await resolveCredentials();
+      if (!config.baseUrl || !config.apiKey) {
+        ctx.ui?.notify?.("LiteLLM cost extension: no credentials configured", "warning");
+        return;
+      }
+
+      const response = await fetch(`${config.baseUrl}/model/info`, {
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          Accept: "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        ctx.ui?.notify?.(`LiteLLM cost extension: /model/info returned ${response.status}`, "warning");
+        return;
+      }
+
+      const payload = (await response.json()) as {
+        data: Array<{
+          model_name: string;
+          litellm_params?: { model?: string };
+          model_info?: {
+            input_cost_per_token?: number;
+            output_cost_per_token?: number;
+            cache_read_input_token_cost?: number;
+            cache_creation_input_token_cost?: number;
+          };
+        }>;
+      };
+
+      for (const entry of payload.data) {
+        const info = entry.model_info;
+        if (!info) continue;
+
+        const costInfo: ModelCostInfo = {
+          inputCostPerToken: info.input_cost_per_token ?? 0,
+          outputCostPerToken: info.output_cost_per_token ?? 0,
+          cacheReadCostPerToken: info.cache_read_input_token_cost ?? 0,
+          cacheWriteCostPerToken: info.cache_creation_input_token_cost ?? 0,
+        };
+
+        modelCosts.set(entry.model_name, costInfo);
+        if (entry.litellm_params?.model) {
+          modelCosts.set(entry.litellm_params.model, costInfo);
+        }
+      }
+
+      if (modelCosts.size > 0) {
+        ctx.ui?.notify?.(`LiteLLM cost: loaded pricing for ${modelCosts.size} model(s)`, "info");
+      }
+    } catch (error) {
+      ctx.ui?.notify?.(
+        `LiteLLM cost extension: could not fetch /model/info (${error instanceof Error ? error.message : String(error)})`,
+        "warning",
+      );
+    }
+  });
+
+  pi.on("after_provider_response", (event) => {
+    const costHeader = event.headers?.["x-litellm-response-cost"] ?? event.headers?.["X-Litellm-Response-Cost"];
+    if (costHeader) {
+      const cost = Number.parseFloat(String(costHeader));
+      if (!Number.isNaN(cost)) {
+        lastResponseCost = cost;
+        return;
+      }
+    }
+    lastResponseCost = null;
+  });
+
+  pi.on("message_end", async (event) => {
+    if (event.message.role !== "assistant") return;
+
+    const usage = event.message.usage;
+    if (!usage) return;
+
+    let totalCost: number | null = null;
+    if (lastResponseCost !== null) {
+      totalCost = lastResponseCost;
+      lastResponseCost = null;
+    }
+
+    if (totalCost === null) {
+      const modelId = event.message.model;
+      const costInfo = modelId ? modelCosts.get(modelId) : undefined;
+      if (costInfo) {
+        const inputCost = costInfo.inputCostPerToken * usage.input;
+        const outputCost = costInfo.outputCostPerToken * usage.output;
+        const cacheReadCost = costInfo.cacheReadCostPerToken * (usage.cacheRead ?? 0);
+        const cacheWriteCost = costInfo.cacheWriteCostPerToken * (usage.cacheWrite ?? 0);
+        totalCost = inputCost + outputCost + cacheReadCost + cacheWriteCost;
+        return {
+          message: {
+            ...event.message,
+            usage: {
+              ...usage,
+              cost: {
+                input: inputCost,
+                output: outputCost,
+                cacheRead: cacheReadCost,
+                cacheWrite: cacheWriteCost,
+                total: totalCost,
+              },
+            },
+          },
+        };
+      }
+    }
+
+    if (totalCost !== null) {
+      const totalTokens = usage.input + usage.output + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
+      if (totalTokens > 0) {
+        const inputFraction = usage.input / totalTokens;
+        const outputFraction = usage.output / totalTokens;
+        const cacheReadFraction = (usage.cacheRead ?? 0) / totalTokens;
+        const cacheWriteFraction = (usage.cacheWrite ?? 0) / totalTokens;
+
+        return {
+          message: {
+            ...event.message,
+            usage: {
+              ...usage,
+              cost: {
+                input: totalCost * inputFraction,
+                output: totalCost * outputFraction,
+                cacheRead: totalCost * cacheReadFraction,
+                cacheWrite: totalCost * cacheWriteFraction,
+                total: totalCost,
+              },
+            },
+          },
+        };
+      }
+
+      return {
+        message: {
+          ...event.message,
+          usage: {
+            ...usage,
+            cost: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              total: totalCost,
+            },
+          },
+        },
+      };
+    }
+
+    return;
+  });
+}

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,4 +1,4 @@
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type {
   DiscoveryOptions,
   DiscoveryResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { Api, Model, OAuthCredentials, OAuthLoginCallbacks } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ProviderModelConfig } from "@mariozechner/pi-coding-agent";
-import { AuthStorage, getAgentDir } from "@mariozechner/pi-coding-agent";
+import type { Api, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
+import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, normalizeBaseUrl } from "./discover.js";
+import { getSessionIdFromFile } from "./litellm.js";
 import type { AuthFileEntry, CacheFile, DiscoveryOptions, DiscoveryResult, ResolvedCredentials } from "./types.js";
 
 const PROVIDER_NAME = "litellm";
@@ -230,5 +232,21 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         ctx.ui.notify(`LiteLLM refresh failed: ${message}`, "error");
       }
     },
+  });
+
+  setupLiteLLMCostTracking(pi);
+
+  let sessionId: string | undefined;
+  pi.on("session_start", async (_event, ctx) => {
+    sessionId = getSessionIdFromFile(ctx.sessionManager.getSessionFile());
+  });
+
+  pi.on("before_provider_request", (event) => {
+    if (!sessionId) return;
+    if (typeof event.payload !== "object" || event.payload === null) return;
+    return {
+      ...(event.payload as Record<string, unknown>),
+      litellm_session_id: sessionId,
+    };
   });
 }

--- a/src/litellm.ts
+++ b/src/litellm.ts
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { OAuthCredentials } from "@earendil-works/pi-ai";
+import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { normalizeBaseUrl } from "./discover.js";
+import type { AuthFileEntry, ResolvedCredentials } from "./types.js";
+
+export const PROVIDER_NAME = "litellm";
+export const ENV_BASE_URL = "LITELLM_BASE_URL";
+export const ENV_API_KEY = "LITELLM_API_KEY";
+export const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
+export const ENV_OFFLINE = "LITELLM_OFFLINE";
+export const DEFAULT_TIMEOUT_MS = 5000;
+export const LOGIN_TIMEOUT_MS = 10_000;
+export const CACHE_FILENAME = "litellm-models.json";
+
+export function getAuthPath(): string {
+  return join(getAgentDir(), "auth.json");
+}
+
+export function getCachePath(): string {
+  return join(getAgentDir(), CACHE_FILENAME);
+}
+
+async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
+  try {
+    const raw = await readFile(getAuthPath(), "utf8");
+    const parsed = JSON.parse(raw) as Record<string, AuthFileEntry>;
+    return parsed?.[PROVIDER_NAME];
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveCredentials(): Promise<ResolvedCredentials> {
+  const entry = await readAuthEntry();
+  const envBase = process.env[ENV_BASE_URL]?.trim();
+  const envKey = process.env[ENV_API_KEY]?.trim();
+  const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
+  const authKey =
+    entry?.type === "oauth"
+      ? entry.access?.trim()
+      : entry?.type === "api_key"
+        ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
+        : undefined;
+  const rawBase = authBase || envBase;
+  return {
+    baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
+    apiKey: authKey || envKey || undefined,
+  };
+}
+
+export function getDiscoveryTimeoutMs(): number {
+  const raw = process.env[ENV_TIMEOUT];
+  if (raw === undefined) return DEFAULT_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return DEFAULT_TIMEOUT_MS;
+  return parsed;
+}
+
+export function isOffline(): boolean {
+  return process.env[ENV_OFFLINE] === "1";
+}
+
+export function isListModelsMode(): boolean {
+  return process.argv.includes("--list-models");
+}
+
+export function getSessionIdFromFile(sessionFile?: string): string | undefined {
+  if (!sessionFile) return undefined;
+  const filename = sessionFile
+    .split("/")
+    .pop()
+    ?.replace(/\.jsonl$/i, "");
+  if (!filename) return undefined;
+  const uuidMatch = filename.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
+  return uuidMatch?.[1] ?? filename;
+}
+
+export type { OAuthCredentials };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ProviderModelConfig } from "@mariozechner/pi-coding-agent";
+import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
 export type DiscoverySource = "model_info" | "models_list";
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1,0 +1,201 @@
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+type TestProviderConfig = {
+  baseUrl?: string;
+  apiKey?: string;
+  api?: string;
+  models?: Array<{ id: string; compat?: unknown }>;
+  oauth?: unknown;
+};
+
+type TestCommand = {
+  description: string;
+  handler: (args: string[], ctx: { ui: { notify: (message: string, type: string) => void } }) => Promise<void> | void;
+};
+
+type TestPi = {
+  providers: Array<{ name: string; config: TestProviderConfig }>;
+  commands: Map<string, TestCommand>;
+  handlers: Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>;
+  registerProvider(name: string, config: TestProviderConfig): void;
+  registerCommand(name: string, command: TestCommand): void;
+  on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<void>> {
+  vi.resetModules();
+  vi.doMock("@earendil-works/pi-coding-agent", () => {
+    class TestAuthStorage {
+      constructor(private readonly authPath: string) {}
+
+      static create(authPath: string): TestAuthStorage {
+        return new TestAuthStorage(authPath);
+      }
+
+      async getApiKey(provider: string): Promise<string | undefined> {
+        const parsed = JSON.parse(await readFile(this.authPath, "utf8")) as Record<
+          string,
+          { type: "api_key"; key: string } | { type: "oauth"; access: string; expires: number; refresh: string }
+        >;
+        const entry = parsed[provider];
+        if (entry?.type === "api_key") return process.env[entry.key] || entry.key;
+        if (entry?.type === "oauth") return entry.access;
+        return undefined;
+      }
+    }
+
+    return { AuthStorage: TestAuthStorage, getAgentDir: () => agentDir };
+  });
+  const mod = await import("../src/index.js");
+  return mod.default as unknown as (pi: TestPi) => Promise<void>;
+}
+
+function createPi(): TestPi {
+  return {
+    providers: [],
+    commands: new Map(),
+    handlers: new Map(),
+    registerProvider(name: string, config: TestProviderConfig) {
+      this.providers.push({ name, config });
+    },
+    registerCommand(name: string, command: TestCommand) {
+      this.commands.set(name, command);
+    },
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
+    },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  vi.unmock("@earendil-works/pi-coding-agent");
+  process.env.LITELLM_BASE_URL = undefined;
+  process.env.LITELLM_API_KEY = undefined;
+  process.env.LITELLM_DISCOVERY_TIMEOUT_MS = undefined;
+});
+
+describe("feature parity", () => {
+  it("registers cost tracking and session grouping handlers", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "anthropic/claude-3-5-sonnet",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+                cache_read_input_token_cost: 0.0000003,
+                cache_creation_input_token_cost: 0.00000375,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.handlers.has("before_provider_request")).toBe(true);
+    expect(pi.handlers.has("after_provider_response")).toBe(true);
+    expect(pi.handlers.has("message_end")).toBe(true);
+
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler(
+        { reason: "reload" },
+        {
+          sessionManager: {
+            getSessionFile: () => join(agentDir, "2026-05-11T16-00-00-000Z_123e4567-e89b-12d3-a456-426614174000.jsonl"),
+          },
+        },
+      );
+    }
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.({ payload: { messages: [] } });
+    expect(updated).toMatchObject({
+      messages: [],
+      litellm_session_id: "123e4567-e89b-12d3-a456-426614174000",
+    });
+  });
+
+  it("overrides assistant cost from LiteLLM response metadata", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "anthropic/claude-3-5-sonnet",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+                cache_read_input_token_cost: 0.0000003,
+                cache_creation_input_token_cost: 0.00000375,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+
+    const responseHandler = pi.handlers.get("after_provider_response")?.[0];
+    responseHandler?.({ headers: { "x-litellm-response-cost": "0.42" } });
+
+    const endHandler = pi.handlers.get("message_end")?.[0];
+    const result = await endHandler?.({
+      message: {
+        role: "assistant",
+        model: "anthropic/claude-3-5-sonnet",
+        usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5 },
+      },
+    });
+
+    expect(result).toMatchObject({
+      message: {
+        usage: {
+          cost: {
+            total: 0.42,
+          },
+        },
+      },
+    });
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -29,7 +29,7 @@ async function makeAgentDir(): Promise<string> {
 
 async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<void>> {
   vi.resetModules();
-  vi.doMock("@mariozechner/pi-coding-agent", () => {
+  vi.doMock("@earendil-works/pi-coding-agent", () => {
     class TestAuthStorage {
       constructor(private readonly authPath: string) {}
 
@@ -59,11 +59,15 @@ function createPi(): TestPi {
   return {
     providers: [],
     commands: new Map(),
+    handlers: new Map(),
     registerProvider(name: string, config: TestProviderConfig) {
       this.providers.push({ name, config });
     },
     registerCommand(name: string, command: TestCommand) {
       this.commands.set(name, command);
+    },
+    on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
+      this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
     },
   };
 }
@@ -71,19 +75,21 @@ function createPi(): TestPi {
 type TestPi = {
   providers: Array<{ name: string; config: TestProviderConfig }>;
   commands: Map<string, TestCommand>;
+  handlers: Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>;
   registerProvider(name: string, config: TestProviderConfig): void;
   registerCommand(name: string, command: TestCommand): void;
+  on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
 };
 
 afterEach(() => {
   for (const key of ENV_KEYS) {
     const original = ORIGINAL_ENV.get(key);
-    if (original === undefined) delete process.env[key];
+    if (original === undefined) process.env[key] = undefined;
     else process.env[key] = original;
   }
   vi.restoreAllMocks();
   vi.resetModules();
-  vi.unmock("@mariozechner/pi-coding-agent");
+  vi.unmock("@earendil-works/pi-coding-agent");
 });
 
 describe("extension startup", () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "declarationMap": false,
+    "sourceMap": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "tests", "scripts"]


### PR DESCRIPTION
## Summary
- Ports the LiteLLM provider parity work into `balcsida/pi-provider-litellm`.
- Adds model discovery from `/model/info` with `/v1/models` fallback.
- Adds LiteLLM cost tracking and session grouping hooks.
- Trims the published tarball by disabling source maps and declaration maps in the build output.
- Bumps the package version to `1.2.0` for the release.

## Validation
- `npm run check`
- `npm pack --dry-run --json`

## Package size
- Before the build-output trim: 11.4 kB packed, 38.8 kB unpacked.
- After the trim: 8.9 kB packed, 32.3 kB unpacked.
