### PR TITLE
Fix Kimi compatibility and security alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pi-provider-litellm
 
-LiteLLM proxy provider extension for [pi-mono](https://github.com/badlogic/pi-mono).
+LiteLLM proxy provider extension for [Pi](https://pi.dev).
 
 Discovers models from a self-hosted LiteLLM proxy and registers them under the `litellm` provider. Supports `/login litellm` and `/litellm-refresh`. Tries `/model/info` first (admin endpoint with rich metadata), falls back to `/v1/models` (OpenAI-compatible) on 401/403/404.
 
@@ -32,14 +32,7 @@ npm run build
 
 ## Configure
 
-### Option A — environment variables
-
-```bash
-export LITELLM_BASE_URL="https://litellm.your-domain.com"
-export LITELLM_API_KEY="sk-..."
-```
-
-### Option B — interactive login
+### Option A — interactive login
 
 Inside pi:
 
@@ -49,15 +42,20 @@ Inside pi:
 
 You'll be prompted for the base URL and API key. Credentials are persisted to `~/.pi/agent/auth.json`.
 
+### Option B — environment variables
+
+```bash
+export LITELLM_BASE_URL="https://litellm.your-domain.com"
+export LITELLM_API_KEY="sk-..."
+```
+
 Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the environment key is used when no saved credential exists. `LITELLM_BASE_URL` is used when no saved login base URL exists.
 
 ## Use
 
 ```
-/model litellm/anthropic/claude-3-5-sonnet
+/model
 ```
-
-(Whatever model IDs your proxy exposes — see the discovered list at startup.)
 
 ## Optional environment variables
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 ## Cache
 
-The model list is cached at `~/.pi/agent/litellm-models.json` with a sha256 fingerprint of the base URL + API key. Changing either invalidates the cache automatically.
+The model list is cached at `~/.pi/agent/litellm-models.json` with a keyed fingerprint of the base URL + API key. Changing either invalidates the cache automatically.
 
 ## Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,80 +1879,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -3456,9 +3382,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-6.0.1.tgz",
+      "integrity": "sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3999,9 +3925,9 @@
       }
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -4011,7 +3937,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -5119,23 +5046,13 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.2.1.tgz",
+      "integrity": "sha512-qD8KPh/2Zj/Kpx6nxhbCZ9TrXVhVBVkC/UNBVA2AWADc1JewcwIhNKUo+j0kiA6PqzTje8Ojc3D+hhmzy2+jkQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -6238,6 +6155,22 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0"
   },
+  "overrides": {
+    "basic-ftp": "6.0.1",
+    "fast-xml-builder": "1.2.0",
+    "protobufjs": "8.2.1"
+  },
   "devDependencies": {
     "@earendil-works/pi-ai": "^0.74.0",
     "@earendil-works/pi-coding-agent": "^0.74.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pi-provider-litellm",
   "version": "1.2.0",
-  "description": "LiteLLM proxy provider extension for pi-mono.",
+  "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",
   "author": "Dávid Balatoni <balcsida@gmail.com>",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,12 +1,12 @@
-import { createHmac } from "node:crypto";
+import { scryptSync } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { CacheFile } from "./types.js";
 
-const FINGERPRINT_KEY = "pi-provider-litellm-cache-fingerprint-v1";
+const FINGERPRINT_SALT = "pi-provider-litellm-cache-fingerprint-v1";
 
 export function fingerprint(apiKey: string): string {
-  return createHmac("sha256", FINGERPRINT_KEY).update(apiKey).digest("hex");
+  return scryptSync(apiKey, FINGERPRINT_SALT, 32).toString("hex");
 }
 
 export function isCacheValid(cache: CacheFile | null, baseUrl: string, apiKey: string): boolean {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,10 +1,12 @@
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { CacheFile } from "./types.js";
 
+const FINGERPRINT_KEY = "pi-provider-litellm-cache-fingerprint-v1";
+
 export function fingerprint(apiKey: string): string {
-  return createHash("sha256").update(apiKey).digest("hex");
+  return createHmac("sha256", FINGERPRINT_KEY).update(apiKey).digest("hex");
 }
 
 export function isCacheValid(cache: CacheFile | null, baseUrl: string, apiKey: string): boolean {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -22,8 +22,18 @@ export function normalizeBaseUrl(input: string): string {
 // `cacheControlFormat: "anthropic"` flag, pi never relays cache_control markers
 // through the proxy, so prompt caching silently no-ops on Claude models.
 const ANTHROPIC_MODEL_PATTERN = /^(anthropic\/|claude|opus|sonnet|haiku)/i;
+const MOONSHOT_MODEL_PATTERN = /^(moonshotai\/|moonshot\/|kimi[-/])/i;
 
 export function buildCompat(modelId: string): ProviderModelConfig["compat"] {
+  if (MOONSHOT_MODEL_PATTERN.test(modelId)) {
+    return {
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    };
+  }
   if (ANTHROPIC_MODEL_PATTERN.test(modelId)) {
     return { supportsStore: false, cacheControlFormat: "anthropic" };
   }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,7 +7,7 @@ import { fingerprint, isCacheValid, readCache, writeCache } from "../src/cache.j
 import type { CacheFile } from "../src/types.js";
 
 describe("fingerprint", () => {
-  it("produces a stable sha256 hex digest", () => {
+  it("produces a stable keyed hex digest", () => {
     expect(fingerprint("secret")).toBe(fingerprint("secret"));
     expect(fingerprint("secret")).toHaveLength(64);
     expect(fingerprint("secret")).toMatch(/^[a-f0-9]+$/);
@@ -14,6 +15,12 @@ describe("fingerprint", () => {
 
   it("differs across inputs", () => {
     expect(fingerprint("a")).not.toBe(fingerprint("b"));
+  });
+
+  it("does not store the raw sha256 digest of the API key", () => {
+    const rawDigest = createHash("sha256").update("secret").digest("hex");
+
+    expect(fingerprint("secret")).not.toBe(rawDigest);
   });
 });
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -41,8 +41,24 @@ describe("buildCompat", () => {
   it("returns supportsStore: false for non-anthropic models", () => {
     expect(buildCompat("openai/gpt-4o")).toEqual({ supportsStore: false });
     expect(buildCompat("gemini/gemini-2.0-flash")).toEqual({ supportsStore: false });
-    expect(buildCompat("kimi-k2.6")).toEqual({ supportsStore: false });
     expect(buildCompat("gpt-5.5")).toEqual({ supportsStore: false });
+  });
+
+  it("adds Moonshot-compatible tool calling flags for Kimi models", () => {
+    expect(buildCompat("kimi-k2.6")).toEqual({
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
+    expect(buildCompat("moonshotai/kimi-k2")).toEqual({
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
   });
 
   it("adds cacheControlFormat for anthropic-prefixed models", () => {

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -18,3 +18,15 @@ describe("package gallery metadata", () => {
     expect(readme).not.toContain("https://img.shields.io/npm/v/pi-provider-litellm.svg");
   });
 });
+
+describe("dependency security overrides", () => {
+  it("keeps vulnerable transitive dependencies above alerted ranges", async () => {
+    const lockfile = JSON.parse(await readFile("package-lock.json", "utf8")) as {
+      packages?: Record<string, { version?: string }>;
+    };
+
+    expect(lockfile.packages?.["node_modules/basic-ftp"]?.version).toBe("6.0.1");
+    expect(lockfile.packages?.["node_modules/protobufjs"]?.version).toBe("8.2.1");
+    expect(lockfile.packages?.["node_modules/fast-xml-builder"]?.version).toBe("1.2.0");
+  });
+});


### PR DESCRIPTION
## Summary

- add LiteLLM/Kimi tool-call compatibility flags
- update Pi package wording after stash resolution
- pin secure transitive dependency versions for Dependabot alerts
- use keyed cache fingerprints instead of raw SHA-256 API-key hashes
- restrict CI workflow token permissions to read-only contents

## Validation

- npm run check
- npm audit --audit-level=moderate
- npm ls protobufjs fast-xml-builder basic-ftp --all
