### PR TITLE
[codex] Scope LiteLLM session id injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENTS.md
+
+## LiteLLM Request Hooks
+
+- `before_provider_request` is a global Pi hook. Only mutate provider payloads when `ctx.model?.provider === "litellm"`.
+- Do not add user-facing flags or environment variables to hide provider-scoping bugs.
+- `litellm_session_id` is optional LiteLLM session grouping metadata. If a LiteLLM server rejects it for LiteLLM-routed requests, keep Pi requests working first and document the admin-facing recommendation separately.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,39 @@
-# AGENTS.md
+# Agent Notes
+
+## Project Shape
+
+- This package is a Pi extension that registers a `litellm` provider from `src/index.ts`.
+- Source is TypeScript ESM under `src/`; tests are Vitest specs under `tests/`.
+- Build output is `dist/`; do not edit generated output by hand.
+- The package entrypoint is `./dist/index.js`, and the Pi extension registration comes from `package.json` `pi.extensions`.
+
+## Commands
+
+- Use `npm test` for the full test suite.
+- Use `npm test -- tests/<file>.test.ts` for a focused Vitest run.
+- Use `npm run check` before committing code changes; it runs Biome, typecheck, and tests.
+- Use `npm run build` when changing exported/runtime code.
+
+## Discovery And Credentials
+
+- Model discovery lives in `src/discover.ts`.
+- Prefer `/model/info` for rich metadata; fallback to `/v1/models` only on 401, 403, or 404.
+- Keep `LITELLM_OFFLINE` and `LITELLM_DISCOVERY_TIMEOUT_MS` behavior compatible with README docs.
+- Stored Pi `/login litellm` credentials take precedence over `LITELLM_API_KEY`.
 
 ## LiteLLM Request Hooks
 
 - `before_provider_request` is a global Pi hook. Only mutate provider payloads when `ctx.model?.provider === "litellm"`.
 - Do not add user-facing flags or environment variables to hide provider-scoping bugs.
 - `litellm_session_id` is optional LiteLLM session grouping metadata. If a LiteLLM server rejects it for LiteLLM-routed requests, keep Pi requests working first and document the admin-facing recommendation separately.
+
+## Compatibility Rules
+
+- Provider-specific request compatibility belongs in discovered model `compat` metadata, not broad runtime mutation.
+- Kimi/Moonshot-style models are handled in `buildCompat()`; keep regression tests with model discovery changes.
+- Anthropic-backed aliases need `cacheControlFormat: "anthropic"` so Pi forwards prompt-cache markers through LiteLLM.
+
+## Package Metadata
+
+- Keep the Pi gallery image URL in `package.json` exactly as declared unless the user asks to change it.
+- Do not include gallery assets in the npm package unless explicitly requested; verify packaging with `npm pack --dry-run` when package contents change.

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -23,9 +23,18 @@ export function normalizeBaseUrl(input: string): string {
 // through the proxy, so prompt caching silently no-ops on Claude models.
 const ANTHROPIC_MODEL_PATTERN = /^(anthropic\/|claude|opus|sonnet|haiku)/i;
 const MOONSHOT_MODEL_PATTERN = /^(moonshotai\/|moonshot\/|kimi[-/])/i;
+const FORCED_THINKING_MODEL_PATTERN = /(?:^|[-/])thinking(?:[-/]|$)/i;
+
+export function isMoonshotModel(modelId: string): boolean {
+  return MOONSHOT_MODEL_PATTERN.test(modelId);
+}
+
+export function shouldSuppressReasoningContent(modelId: string): boolean {
+  return isMoonshotModel(modelId) && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+}
 
 export function buildCompat(modelId: string): ProviderModelConfig["compat"] {
-  if (MOONSHOT_MODEL_PATTERN.test(modelId)) {
+  if (isMoonshotModel(modelId)) {
     return {
       supportsStore: false,
       supportsDeveloperRole: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,8 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     sessionId = getSessionIdFromFile(ctx.sessionManager.getSessionFile());
   });
 
-  pi.on("before_provider_request", (event) => {
+  pi.on("before_provider_request", (event, ctx) => {
+    if (ctx.model?.provider !== PROVIDER_NAME) return;
     if (!sessionId) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
     return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-codin
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
-import { discoverModels, normalizeBaseUrl } from "./discover.js";
+import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
 import { getSessionIdFromFile } from "./litellm.js";
 import type { AuthFileEntry, CacheFile, DiscoveryOptions, DiscoveryResult, ResolvedCredentials } from "./types.js";
 
@@ -129,6 +129,33 @@ function modifyLiteLLMModels(models: Model<Api>[], cred: OAuthCredentials): Mode
   return models.map((m) => (m.provider === PROVIDER_NAME ? { ...m, baseUrl: `${baseUrl}/v1` } : m));
 }
 
+function prepareLiteLLMRequestPayload(
+  payload: Record<string, unknown>,
+  modelId: string | undefined,
+  sessionId: string | undefined,
+): Record<string, unknown> | undefined {
+  let next: Record<string, unknown> | undefined;
+  const update = (key: string, value: unknown): void => {
+    if (payload[key] !== undefined) return;
+    next ??= { ...payload };
+    next[key] = value;
+  };
+
+  if (modelId && shouldSuppressReasoningContent(modelId)) {
+    update("include_reasoning", false);
+    update("reasoning_content", false);
+    update("merge_reasoning_content_in_choices", true);
+    update("thinking", { type: "disabled" });
+  }
+
+  if (sessionId) {
+    next ??= { ...payload };
+    next.litellm_session_id = sessionId;
+  }
+
+  return next;
+}
+
 export default async function (pi: ExtensionAPI): Promise<void> {
   const creds = await resolveCredentials();
   const cache = await readCache(getCachePath());
@@ -243,11 +270,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   pi.on("before_provider_request", (event, ctx) => {
     if (ctx.model?.provider !== PROVIDER_NAME) return;
-    if (!sessionId) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
-    return {
-      ...(event.payload as Record<string, unknown>),
-      litellm_session_id: sessionId,
-    };
+    return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model?.id, sessionId);
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { Api, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
+import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
@@ -156,6 +156,68 @@ function prepareLiteLLMRequestPayload(
   return next;
 }
 
+function normalizeThinkTags(message: AssistantMessage): AssistantMessage | undefined {
+  if (message.provider !== PROVIDER_NAME || !shouldSuppressReasoningContent(message.model)) return;
+
+  let changed = false;
+  const content: AssistantMessage["content"] = [];
+  const appendText = (text: string): void => {
+    if (!text) return;
+    const last = content.at(-1);
+    if (last?.type === "text") {
+      last.text += text;
+      return;
+    }
+    content.push({ type: "text", text });
+  };
+  const appendThinking = (thinking: string): void => {
+    if (!thinking) return;
+    const last = content.at(-1);
+    if (last?.type === "thinking") {
+      last.thinking += thinking;
+      return;
+    }
+    content.push({ type: "thinking", thinking });
+  };
+
+  for (let blockIndex = 0; blockIndex < message.content.length; blockIndex++) {
+    const block = message.content[blockIndex];
+    if (block.type !== "text") {
+      content.push(block);
+      continue;
+    }
+
+    let index = 0;
+    while (index < block.text.length) {
+      const start = block.text.indexOf("<think>", index);
+      if (start === -1) {
+        appendText(block.text.slice(index));
+        break;
+      }
+
+      changed = true;
+      appendText(block.text.slice(index, start));
+      const thinkingStart = start + "<think>".length;
+      const end = block.text.indexOf("</think>", thinkingStart);
+      if (end === -1) {
+        const isBeforeNonTextContent = message.content
+          .slice(blockIndex + 1)
+          .some((nextBlock) => nextBlock.type !== "text");
+        if (isBeforeNonTextContent) appendThinking(block.text.slice(thinkingStart));
+        else appendText(block.text.slice(thinkingStart));
+        index = block.text.length;
+        break;
+      }
+
+      appendThinking(block.text.slice(thinkingStart, end));
+      index = end + "</think>".length;
+    }
+  }
+
+  if (!changed) return;
+  return { ...message, content };
+}
+
 export default async function (pi: ExtensionAPI): Promise<void> {
   const creds = await resolveCredentials();
   const cache = await readCache(getCachePath());
@@ -272,5 +334,12 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     if (ctx.model?.provider !== PROVIDER_NAME) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
     return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model?.id, sessionId);
+  });
+
+  pi.on("message_end", (event) => {
+    if (event.message.role !== "assistant") return;
+    const message = normalizeThinkTags(event.message as AssistantMessage);
+    if (!message) return;
+    return { message };
   });
 }

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildCompat, discoverModels, normalizeBaseUrl } from "../src/discover.js";
+import { buildCompat, discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "../src/discover.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -86,6 +86,21 @@ describe("buildCompat", () => {
       supportsStore: false,
       cacheControlFormat: "anthropic",
     });
+  });
+});
+
+describe("shouldSuppressReasoningContent", () => {
+  it("suppresses separate reasoning streams for Kimi/Moonshot aliases", () => {
+    expect(shouldSuppressReasoningContent("kimi-k2.6")).toBe(true);
+    expect(shouldSuppressReasoningContent("moonshotai/kimi-k2")).toBe(true);
+  });
+
+  it("does not suppress explicit forced-thinking models", () => {
+    expect(shouldSuppressReasoningContent("kimi-k2-thinking")).toBe(false);
+  });
+
+  it("does not suppress unrelated models", () => {
+    expect(shouldSuppressReasoningContent("openai/gpt-4o")).toBe(false);
   });
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -120,6 +120,37 @@ describe("feature parity", () => {
     expect(pi.handlers.has("before_provider_request")).toBe(true);
     expect(pi.handlers.has("after_provider_response")).toBe(true);
     expect(pi.handlers.has("message_end")).toBe(true);
+  });
+
+  it("does not inject LiteLLM session ids into non-LiteLLM provider requests", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "anthropic/claude-3-5-sonnet",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+                cache_read_input_token_cost: 0.0000003,
+                cache_creation_input_token_cost: 0.00000375,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
 
     const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
     for (const handler of sessionStartHandlers) {
@@ -134,7 +165,57 @@ describe("feature parity", () => {
     }
 
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const updated = beforeRequest?.({ payload: { messages: [] } });
+    const updated = beforeRequest?.(
+      { payload: { messages: [] } },
+      { model: { provider: "openai-codex", id: "gpt-5.5" } },
+    );
+    expect(updated).toBeUndefined();
+  });
+
+  it("injects LiteLLM session ids into LiteLLM provider requests", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "anthropic/claude-3-5-sonnet",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+                cache_read_input_token_cost: 0.0000003,
+                cache_creation_input_token_cost: 0.00000375,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler(
+        { reason: "reload" },
+        {
+          sessionManager: {
+            getSessionFile: () => join(agentDir, "2026-05-11T16-00-00-000Z_123e4567-e89b-12d3-a456-426614174000.jsonl"),
+          },
+        },
+      );
+    }
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.({ payload: { messages: [] } }, { model: { provider: "litellm", id: "kimi-k2.6" } });
     expect(updated).toMatchObject({
       messages: [],
       litellm_session_id: "123e4567-e89b-12d3-a456-426614174000",

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -218,7 +218,46 @@ describe("feature parity", () => {
     const updated = beforeRequest?.({ payload: { messages: [] } }, { model: { provider: "litellm", id: "kimi-k2.6" } });
     expect(updated).toMatchObject({
       messages: [],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+      thinking: { type: "disabled" },
       litellm_session_id: "123e4567-e89b-12d3-a456-426614174000",
+    });
+  });
+
+  it("suppresses separate Kimi reasoning streams before session ids are available", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "kimi-k2.6",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.({ payload: { messages: [] } }, { model: { provider: "litellm", id: "kimi-k2.6" } });
+    expect(updated).toEqual({
+      messages: [],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+      thinking: { type: "disabled" },
     });
   });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -261,6 +261,87 @@ describe("feature parity", () => {
     });
   });
 
+  it("normalizes Kimi think tags into Pi thinking blocks", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "kimi-k2.6",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    let message: any = {
+      role: "assistant",
+      provider: "litellm",
+      model: "kimi-k2.6",
+      content: [{ type: "text", text: "<think>internal reasoning</think>DONE" }],
+      usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+    };
+    for (const handler of pi.handlers.get("message_end") ?? []) {
+      const result = await handler({ message });
+      if (result?.message) message = result.message;
+    }
+
+    expect(message.content).toEqual([
+      { type: "thinking", thinking: "internal reasoning" },
+      { type: "text", text: "DONE" },
+    ]);
+  });
+
+  it("keeps final Kimi text visible when a dangling think tag prefixes it", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "kimi-k2.6",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    let message: any = {
+      role: "assistant",
+      provider: "litellm",
+      model: "kimi-k2.6",
+      content: [{ type: "text", text: "<think>DONE" }],
+      usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 },
+    };
+    for (const handler of pi.handlers.get("message_end") ?? []) {
+      const result = await handler({ message });
+      if (result?.message) message = result.message;
+    }
+
+    expect(message.content).toEqual([{ type: "text", text: "DONE" }]);
+  });
+
   it("overrides assistant cost from LiteLLM response metadata", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";


### PR DESCRIPTION
## Summary

- Scope `litellm_session_id` injection to requests whose active Pi model provider is `litellm`.
- Add Kimi/Moonshot request shaping so LiteLLM-routed Kimi tool calls do not stall after model switches.
- Normalize Kimi `<think>` tag text into Pi `thinking` blocks while keeping final visible text intact.
- Add regression coverage for non-LiteLLM requests, LiteLLM-routed requests, Kimi request shaping, and think-tag normalization.
- Expand `AGENTS.md` with repo-local build, discovery, compatibility, and hook-scoping guidance.

## Root Cause

`before_provider_request` is a global Pi hook. The provider extension was adding LiteLLM-specific session metadata to every provider payload after session start, so switching to a non-LiteLLM provider could send `litellm_session_id` to an API path that rejects it.

The live Kimi path also returned reasoning either as separate provider reasoning content or as literal `<think>` tags in normal text. Pi expects provider reasoning to be represented as `thinking` content blocks, not visible tag text.

## Validation

- `npm run check`
- `npm run build`
- `npm pack --dry-run`
- Live LiteLLM discovery against the supplied proxy
- Live Pi smoke: `litellm/kimi-k2.6` tool call
- Live Pi smoke: `litellm/gpt-5.5` then `--continue --model litellm/kimi-k2.6` tool call
