### PR TITLE
Harden package supply-chain checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -3409,9 +3409,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6136,9 +6136,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,9 @@
     "lint": "biome check --error-on-warnings .",
     "format": "biome check --write .",
     "test": "vitest --run",
+    "supply-chain:guard": "tsx scripts/supply-chain-guard.ts",
     "check": "npm run lint && npm run typecheck && npm test",
-    "prepublishOnly": "npm run check && npm run clean && npm run build"
+    "prepublishOnly": "npm run check && npm run clean && npm run build && npm run supply-chain:guard"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/scripts/supply-chain-guard.ts
+++ b/scripts/supply-chain-guard.ts
@@ -1,0 +1,217 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { basename, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const installLifecycleScripts = new Set(["preinstall", "install", "postinstall", "prepare"]);
+const runtimeDependencySections = new Set([
+  "dependencies",
+  "optionalDependencies",
+  "bundleDependencies",
+  "bundledDependencies",
+]);
+const dependencySections = [
+  "dependencies",
+  "devDependencies",
+  "optionalDependencies",
+  "peerDependencies",
+  "bundleDependencies",
+  "bundledDependencies",
+  "overrides",
+];
+
+const nonRegistrySpecPrefixes = [
+  "git:",
+  "git+",
+  "github:",
+  "gitlab:",
+  "bitbucket:",
+  "http:",
+  "https:",
+  "file:",
+  "link:",
+  "workspace:",
+  "npm:",
+  "../",
+  "./",
+];
+
+const allowedPackageFiles = [
+  /^package\.json$/,
+  /^README\.md$/,
+  /^LICENSE$/,
+  /^dist\/(?:cache|cost|discover|index|litellm|types)\.(?:js|d\.ts)$/,
+];
+
+export interface SupplyChainGuardOptions {
+  checkPackageContents?: boolean;
+}
+
+export interface SupplyChainGuardResult {
+  ok: boolean;
+  errors: string[];
+  packageFiles: string[];
+}
+
+interface PackageManifest {
+  scripts?: Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface PackageLock {
+  packages?: Record<string, { resolved?: unknown }>;
+}
+
+interface PackResult {
+  files?: Array<{ path?: string }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readJson<T>(path: string, errors: string[]): Promise<T | undefined> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as T;
+  } catch (error) {
+    errors.push(`${path}: could not parse JSON (${error instanceof Error ? error.message : String(error)})`);
+    return undefined;
+  }
+}
+
+function hasNonRegistrySpec(spec: unknown): boolean {
+  if (typeof spec !== "string") return false;
+
+  const normalized = spec.trim().toLowerCase();
+  return nonRegistrySpecPrefixes.some((prefix) => normalized.startsWith(prefix));
+}
+
+function checkDependencyValue(section: string, value: unknown, errors: string[], path = section): void {
+  if (Array.isArray(value)) {
+    if (runtimeDependencySections.has(section) && value.length > 0) {
+      errors.push(`package.json: ${section} is not allowed in the published package (${value.join(", ")})`);
+    }
+    return;
+  }
+
+  if (!isRecord(value)) return;
+
+  const entries = Object.entries(value);
+  if (runtimeDependencySections.has(section) && entries.length > 0) {
+    errors.push(
+      `package.json: ${section} is not allowed in this runtime-dependency-free provider (${entries
+        .map(([name]) => name)
+        .join(", ")})`,
+    );
+  }
+
+  for (const [name, spec] of entries) {
+    const nextPath = `${path}.${name}`;
+    if (hasNonRegistrySpec(spec)) {
+      errors.push(`package.json: ${nextPath} uses a non-registry dependency spec (${String(spec)})`);
+    } else if (isRecord(spec) || Array.isArray(spec)) {
+      checkDependencyValue(section, spec, errors, nextPath);
+    }
+  }
+}
+
+function checkManifest(manifest: PackageManifest, errors: string[]): void {
+  for (const [name] of Object.entries(manifest.scripts ?? {})) {
+    if (installLifecycleScripts.has(name)) {
+      errors.push(`package.json: scripts.${name} runs during package installation`);
+    }
+  }
+
+  for (const section of dependencySections) {
+    checkDependencyValue(section, manifest[section], errors);
+  }
+}
+
+async function checkLockfile(root: string, errors: string[]): Promise<void> {
+  const lockfilePath = join(root, "package-lock.json");
+  if (!existsSync(lockfilePath)) {
+    errors.push("package-lock.json: required for reproducible npm installs and audit");
+    return;
+  }
+
+  const lockfile = await readJson<PackageLock>(lockfilePath, errors);
+  for (const [packagePath, entry] of Object.entries(lockfile?.packages ?? {})) {
+    if (typeof entry.resolved !== "string") continue;
+    if (entry.resolved.startsWith("https://registry.npmjs.org/")) continue;
+
+    errors.push(`package-lock.json: ${packagePath} has non-registry resolved URL (${entry.resolved})`);
+  }
+}
+
+async function listPackageFiles(root: string, errors: string[]): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+      cwd: root,
+      maxBuffer: 1024 * 1024 * 10,
+    });
+    const packResults = JSON.parse(stdout) as PackResult[];
+    return packResults.flatMap((result) => result.files?.map((file) => file.path).filter(Boolean) ?? []) as string[];
+  } catch (error) {
+    errors.push(
+      `npm pack --dry-run --json --ignore-scripts failed (${error instanceof Error ? error.message : error})`,
+    );
+    return [];
+  }
+}
+
+function checkPackageFiles(files: string[], errors: string[]): void {
+  for (const file of files) {
+    if (!allowedPackageFiles.some((pattern) => pattern.test(file))) {
+      errors.push(`npm package: unexpected published file ${file}`);
+    }
+
+    const filename = basename(file);
+    if (filename.endsWith(".sh") || filename.endsWith(".cjs") || filename.endsWith(".mjs")) {
+      errors.push(`npm package: executable-style payload file is not expected (${file})`);
+    }
+  }
+}
+
+export async function checkSupplyChain(
+  root = process.cwd(),
+  options: SupplyChainGuardOptions = {},
+): Promise<SupplyChainGuardResult> {
+  const checkPackageContents = options.checkPackageContents ?? true;
+  const resolvedRoot = resolve(root);
+  const errors: string[] = [];
+  const manifest = await readJson<PackageManifest>(join(resolvedRoot, "package.json"), errors);
+
+  if (manifest) {
+    checkManifest(manifest, errors);
+  }
+  await checkLockfile(resolvedRoot, errors);
+
+  const packageFiles = checkPackageContents ? await listPackageFiles(resolvedRoot, errors) : [];
+  if (checkPackageContents) {
+    checkPackageFiles(packageFiles, errors);
+  }
+
+  return { ok: errors.length === 0, errors, packageFiles };
+}
+
+async function main(): Promise<void> {
+  const result = await checkSupplyChain();
+  if (!result.ok) {
+    console.error("Supply-chain guard failed:");
+    for (const error of result.errors) {
+      console.error(`- ${error}`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Supply-chain guard passed (${result.packageFiles.length} package files checked).`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  void main();
+}

--- a/tests/supply-chain-guard.test.ts
+++ b/tests/supply-chain-guard.test.ts
@@ -1,0 +1,76 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { checkSupplyChain } from "../scripts/supply-chain-guard.js";
+
+describe("supply-chain guard", () => {
+  it("rejects install hooks, optional runtime dependencies, Git specs, and packaged payloads", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-guard-"));
+
+    try {
+      await writeFile(
+        join(fixture, "package.json"),
+        JSON.stringify(
+          {
+            name: "malicious-fixture",
+            version: "1.0.0",
+            files: ["payload.js"],
+            scripts: {
+              postinstall: "node payload.js",
+            },
+            optionalDependencies: {
+              "telemetry-helper": "git+https://github.com/attacker/telemetry-helper.git#deadbeef",
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        join(fixture, "package-lock.json"),
+        JSON.stringify(
+          {
+            name: "malicious-fixture",
+            version: "1.0.0",
+            lockfileVersion: 3,
+            packages: {
+              "": {
+                name: "malicious-fixture",
+                version: "1.0.0",
+                optionalDependencies: {
+                  "telemetry-helper": "git+https://github.com/attacker/telemetry-helper.git#deadbeef",
+                },
+              },
+              "node_modules/telemetry-helper": {
+                version: "1.0.0",
+                resolved: "git+https://github.com/attacker/telemetry-helper.git#deadbeef",
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(join(fixture, "payload.js"), "console.log('payload');\n");
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.ok).toBe(false);
+      expect(result.errors.join("\n")).toContain("postinstall");
+      expect(result.errors.join("\n")).toContain("optionalDependencies.telemetry-helper");
+      expect(result.errors.join("\n")).toContain("non-registry resolved URL");
+      expect(result.errors.join("\n")).toContain("payload.js");
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts this package policy while keeping the publish build gate", async () => {
+    const result = await checkSupplyChain(process.cwd(), { checkPackageContents: false });
+
+    expect(result.errors).toEqual([]);
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a dedicated supply-chain guard for the package publish path. The guard rejects install-time lifecycle hooks, runtime dependencies, Git/URL/file-style dependency specs, non-registry lockfile resolutions, and unexpected files in the npm tarball.

It is wired into `prepublishOnly` after the build so the packed artifact is checked before publishing. The lockfile is also refreshed to pick up fixed dev transitive versions for the current `brace-expansion` and `ws` advisories.

The GitHub Actions workflows are also prepared for a SHA-pinning policy: `actions/checkout` is updated to `v6.0.2`, `actions/setup-node` is updated to `v6.4.0`, and all workflow `uses:` entries now pin the full 40-character commit SHA with the upstream version kept in a comment. Dependabot is configured for both npm and GitHub Actions updates so future pinned-action updates are visible.

## Why

The previous local hardening work was sitting untracked and broke the normal project checks. This turns it into a branch-scoped, tested package gate that matches the existing published package shape.

The workflow updates make the repo compatible with GitHub Actions settings that restrict allowed actions and require full-length SHA pins. The non-`balcsida` actions currently required by this repo are `actions/checkout` and `actions/setup-node`.

## Validation

- `npm run build`
- `npm run check`
- `npm run supply-chain:guard`
- `npm audit --audit-level=moderate`
- `npm pack --dry-run --json --ignore-scripts`
- `rg -n -P "uses:\s*[^@\s]+@(?![0-9a-f]{40}(?:\s|$))" .github/workflows || true`
