### PR TITLE
Add real LiteLLM smoke workflow

### DIFF
--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -79,7 +79,7 @@ jobs:
           model_list:
             - model_name: github-models-openai
               litellm_params:
-                model: openai/${GH_MODELS_SMOKE_MODEL}
+                model: ${GH_MODELS_SMOKE_MODEL}
                 api_base: https://models.github.ai/inference
                 api_key: os.environ/GITHUB_TOKEN
           YAML

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -1,0 +1,183 @@
+name: LiteLLM Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      require_vendors:
+        description: Fail unless OpenAI, Anthropic, and Gemini secrets are configured
+        required: false
+        type: boolean
+        default: false
+  schedule:
+    - cron: '23 4 * * 1'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/litellm-smoke.yml'
+      - 'package-lock.json'
+      - 'package.json'
+      - 'scripts/smoke*.ts'
+      - 'src/**'
+      - 'tests/**'
+
+permissions:
+  contents: read
+  models: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      LITELLM_BASE_URL: http://127.0.0.1:4000
+      LITELLM_API_KEY: sk-ci-litellm-smoke
+      LITELLM_MASTER_KEY: sk-ci-litellm-smoke
+      LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
+      GH_MODELS_SMOKE_MODEL: ${{ vars.GH_MODELS_SMOKE_MODEL || 'openai/gpt-4o-mini' }}
+      OPENAI_SMOKE_MODEL: ${{ vars.OPENAI_SMOKE_MODEL || 'gpt-4.1-nano' }}
+      ANTHROPIC_SMOKE_MODEL: ${{ vars.ANTHROPIC_SMOKE_MODEL || 'claude-haiku-4-5-20251001' }}
+      GEMINI_SMOKE_MODEL: ${{ vars.GEMINI_SMOKE_MODEL || 'gemini-2.5-flash-lite' }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - run: npm ci
+      - run: npm run build
+
+      - name: Write LiteLLM smoke config
+        id: config
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          REQUIRE_VENDORS: ${{ github.event_name == 'workflow_dispatch' && inputs.require_vendors && '1' || '0' }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$REQUIRE_VENDORS" == "1" ]]; then
+            missing=()
+            [[ -n "${OPENAI_API_KEY:-}" ]] || missing+=("OPENAI_API_KEY")
+            [[ -n "${ANTHROPIC_API_KEY:-}" ]] || missing+=("ANTHROPIC_API_KEY")
+            [[ -n "${GEMINI_API_KEY:-}" ]] || missing+=("GEMINI_API_KEY")
+            if (( ${#missing[@]} > 0 )); then
+              printf 'Missing required vendor secrets: %s\n' "${missing[*]}" >&2
+              exit 1
+            fi
+          fi
+
+          mkdir -p .tmp
+          smoke_models=("github-models-openai")
+
+          cat > .tmp/litellm_config.yaml <<YAML
+          model_list:
+            - model_name: github-models-openai
+              litellm_params:
+                model: openai/${GH_MODELS_SMOKE_MODEL}
+                api_base: https://models.github.ai/inference
+                api_key: os.environ/GITHUB_TOKEN
+          YAML
+
+          if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+            smoke_models+=("openai-direct")
+            cat >> .tmp/litellm_config.yaml <<YAML
+            - model_name: openai-direct
+              litellm_params:
+                model: openai/${OPENAI_SMOKE_MODEL}
+                api_key: os.environ/OPENAI_API_KEY
+          YAML
+          else
+            echo "Skipping OpenAI direct smoke: OPENAI_API_KEY is not configured."
+          fi
+
+          if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+            smoke_models+=("anthropic-direct")
+            cat >> .tmp/litellm_config.yaml <<YAML
+            - model_name: anthropic-direct
+              litellm_params:
+                model: anthropic/${ANTHROPIC_SMOKE_MODEL}
+                api_key: os.environ/ANTHROPIC_API_KEY
+          YAML
+          else
+            echo "Skipping Anthropic direct smoke: ANTHROPIC_API_KEY is not configured."
+          fi
+
+          if [[ -n "${GEMINI_API_KEY:-}" ]]; then
+            smoke_models+=("gemini-direct")
+            cat >> .tmp/litellm_config.yaml <<YAML
+            - model_name: gemini-direct
+              litellm_params:
+                model: gemini/${GEMINI_SMOKE_MODEL}
+                api_key: os.environ/GEMINI_API_KEY
+          YAML
+          else
+            echo "Skipping Gemini direct smoke: GEMINI_API_KEY is not configured."
+          fi
+
+          cat >> .tmp/litellm_config.yaml <<YAML
+          general_settings:
+            master_key: ${LITELLM_MASTER_KEY}
+          YAML
+
+          {
+            echo 'models<<EOF'
+            printf '%s\n' "${smoke_models[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Start LiteLLM proxy
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+        run: |
+          set -euo pipefail
+          docker run -d \
+            --name litellm-smoke \
+            -p 4000:4000 \
+            -v "$PWD/.tmp/litellm_config.yaml:/app/config.yaml:ro" \
+            -e GITHUB_TOKEN \
+            -e OPENAI_API_KEY \
+            -e ANTHROPIC_API_KEY \
+            -e GEMINI_API_KEY \
+            -e LITELLM_MASTER_KEY \
+            "$LITELLM_IMAGE" \
+            --config /app/config.yaml
+
+      - name: Wait for LiteLLM proxy
+        shell: bash
+        run: |
+          set -euo pipefail
+          for _ in {1..60}; do
+            if curl -fsS \
+              -H "Authorization: Bearer $LITELLM_API_KEY" \
+              "$LITELLM_BASE_URL/v1/models" >/tmp/litellm-models.json; then
+              cat /tmp/litellm-models.json
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs litellm-smoke >&2 || true
+          exit 1
+
+      - name: Run provider smoke
+        env:
+          LITELLM_SMOKE_MODELS: ${{ steps.config.outputs.models }}
+          LITELLM_SMOKE_TIMEOUT_MS: '60000'
+        run: npx tsx scripts/smoke.ts
+
+      - name: Dump LiteLLM logs
+        if: failure()
+        run: docker logs litellm-smoke || true
+
+      - name: Stop LiteLLM proxy
+        if: always()
+        run: docker rm -f litellm-smoke || true

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The required baseline route uses GitHub Models with the workflow `GITHUB_TOKEN` 
 | `ANTHROPIC_API_KEY` | `claude-haiku-4-5-20251001` | Cheap direct Claude route |
 | `GEMINI_API_KEY` | `gemini-2.5-flash-lite` | Cheap/free-tier-friendly Gemini route |
 
-Optional repository variables override model choices without editing the workflow:
+Optional repository variables override model choices without editing the workflow. `GH_MODELS_SMOKE_MODEL` is a complete LiteLLM model id for the GitHub Models OpenAI-compatible route. The direct vendor variables are bare model names and the workflow adds their provider prefixes.
 
 | Variable | Default |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -66,6 +66,29 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` only disables startup and refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
 
+## Real LiteLLM smoke workflow
+
+The `LiteLLM Smoke` GitHub Actions workflow starts a real LiteLLM proxy on the runner, discovers models through this extension's smoke runner, and sends real `/v1/chat/completions` requests through the proxy.
+
+The required baseline route uses GitHub Models with the workflow `GITHUB_TOKEN` and `models: read` permission, so it can run without adding provider secrets. Direct vendor routes are added only when these repository secrets exist:
+
+| Secret | Default smoke model | Notes |
+|---|---|---|
+| `OPENAI_API_KEY` | `gpt-4.1-nano` | Cheap direct OpenAI/GPT route |
+| `ANTHROPIC_API_KEY` | `claude-haiku-4-5-20251001` | Cheap direct Claude route |
+| `GEMINI_API_KEY` | `gemini-2.5-flash-lite` | Cheap/free-tier-friendly Gemini route |
+
+Optional repository variables override model choices without editing the workflow:
+
+| Variable | Default |
+|---|---|
+| `GH_MODELS_SMOKE_MODEL` | `openai/gpt-4o-mini` |
+| `OPENAI_SMOKE_MODEL` | `gpt-4.1-nano` |
+| `ANTHROPIC_SMOKE_MODEL` | `claude-haiku-4-5-20251001` |
+| `GEMINI_SMOKE_MODEL` | `gemini-2.5-flash-lite` |
+
+Manual runs include a `require_vendors` input. When enabled, the workflow fails before starting LiteLLM unless all three direct vendor secrets are configured. Scheduled and push runs keep the GitHub Models baseline required and skip missing direct vendors.
+
 ## Slash commands
 
 - `/litellm-refresh` — force re-fetch the model list, ignoring cache

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -1,0 +1,134 @@
+import { discoverModels, normalizeBaseUrl } from "../src/discover.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const SMOKE_PROMPT = "Reply with one short word.";
+
+export type SmokeCompletion = {
+  modelId: string;
+  content: string;
+};
+
+export type SmokeResult = {
+  source: "model_info" | "models_list";
+  discoveredCount: number;
+  completions: SmokeCompletion[];
+};
+
+export type SmokeOptions = {
+  baseUrl: string;
+  apiKey: string;
+  modelIds: string[];
+  timeoutMs?: number;
+};
+
+type ChatCompletionResponse = {
+  choices?: Array<{
+    message?: {
+      content?: unknown;
+    };
+  }>;
+};
+
+export function parseSmokeModels(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(/[,\s]+/)
+    .map((model) => model.trim())
+    .filter((model) => model.length > 0);
+}
+
+function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timer),
+  };
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const body = await response.text();
+    return body ? `: ${body.slice(0, 500)}` : "";
+  } catch {
+    return "";
+  }
+}
+
+async function smokeChatCompletion(
+  baseUrl: string,
+  apiKey: string,
+  modelId: string,
+  timeoutMs: number,
+): Promise<SmokeCompletion> {
+  const { signal, cancel } = withTimeout(timeoutMs);
+  try {
+    const response = await fetch(`${baseUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: SMOKE_PROMPT }],
+        max_tokens: 16,
+        temperature: 0,
+      }),
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error(`/v1/chat/completions for ${modelId} returned ${response.status}${await readErrorBody(response)}`);
+    }
+    const data = (await response.json()) as ChatCompletionResponse;
+    const content = data.choices?.[0]?.message?.content;
+    if (typeof content !== "string" || content.trim().length === 0) {
+      throw new Error(`/v1/chat/completions for ${modelId} returned no assistant text`);
+    }
+    return { modelId, content };
+  } finally {
+    cancel();
+  }
+}
+
+export async function runSmoke(options: SmokeOptions): Promise<SmokeResult> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (options.modelIds.length === 0) {
+    throw new Error("At least one smoke model must be configured in LITELLM_SMOKE_MODELS");
+  }
+
+  const discovery = await discoverModels(baseUrl, options.apiKey, { timeoutMs });
+  const discovered = new Set(discovery.models.map((model) => model.id));
+  const missing = options.modelIds.filter((modelId) => !discovered.has(modelId));
+  if (missing.length > 0) {
+    throw new Error(`Requested smoke models were not discovered: ${missing.join(", ")}`);
+  }
+
+  const completions: SmokeCompletion[] = [];
+  for (const modelId of options.modelIds) {
+    completions.push(await smokeChatCompletion(baseUrl, options.apiKey, modelId, timeoutMs));
+  }
+
+  return {
+    source: discovery.source,
+    discoveredCount: discovery.models.length,
+    completions,
+  };
+}
+
+export async function runSmokeFromEnv(env: NodeJS.ProcessEnv = process.env): Promise<SmokeResult> {
+  const baseUrl = env.LITELLM_BASE_URL?.trim();
+  const apiKey = env.LITELLM_API_KEY?.trim();
+  if (!baseUrl || !apiKey) {
+    throw new Error("LITELLM_BASE_URL and LITELLM_API_KEY must be set");
+  }
+
+  const timeoutMs = env.LITELLM_SMOKE_TIMEOUT_MS ? Number.parseInt(env.LITELLM_SMOKE_TIMEOUT_MS, 10) : DEFAULT_TIMEOUT_MS;
+  return runSmoke({
+    baseUrl,
+    apiKey,
+    modelIds: parseSmokeModels(env.LITELLM_SMOKE_MODELS),
+    timeoutMs: Number.isNaN(timeoutMs) || timeoutMs <= 0 ? DEFAULT_TIMEOUT_MS : timeoutMs,
+  });
+}

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -78,7 +78,9 @@ async function smokeChatCompletion(
       signal,
     });
     if (!response.ok) {
-      throw new Error(`/v1/chat/completions for ${modelId} returned ${response.status}${await readErrorBody(response)}`);
+      throw new Error(
+        `/v1/chat/completions for ${modelId} returned ${response.status}${await readErrorBody(response)}`,
+      );
     }
     const data = (await response.json()) as ChatCompletionResponse;
     const content = data.choices?.[0]?.message?.content;
@@ -124,7 +126,9 @@ export async function runSmokeFromEnv(env: NodeJS.ProcessEnv = process.env): Pro
     throw new Error("LITELLM_BASE_URL and LITELLM_API_KEY must be set");
   }
 
-  const timeoutMs = env.LITELLM_SMOKE_TIMEOUT_MS ? Number.parseInt(env.LITELLM_SMOKE_TIMEOUT_MS, 10) : DEFAULT_TIMEOUT_MS;
+  const timeoutMs = env.LITELLM_SMOKE_TIMEOUT_MS
+    ? Number.parseInt(env.LITELLM_SMOKE_TIMEOUT_MS, 10)
+    : DEFAULT_TIMEOUT_MS;
   return runSmoke({
     baseUrl,
     apiKey,

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,29 +1,19 @@
-// Manual integration smoke test against a real LiteLLM proxy.
-// Reads credentials from env (LITELLM_BASE_URL, LITELLM_API_KEY).
+// Manual and CI integration smoke test against a real LiteLLM proxy.
+// Reads LITELLM_BASE_URL, LITELLM_API_KEY, and LITELLM_SMOKE_MODELS.
 // Run: npx tsx scripts/smoke.ts
-//
-// Prints discovered models. Does not write to the cache file.
 
-import { discoverModels, normalizeBaseUrl } from "../src/discover.js";
+import { runSmokeFromEnv } from "./smoke-runner.js";
 
 async function main(): Promise<void> {
-  const baseUrl = process.env.LITELLM_BASE_URL?.trim();
-  const apiKey = process.env.LITELLM_API_KEY?.trim();
-  if (!baseUrl || !apiKey) {
-    console.error("LITELLM_BASE_URL and LITELLM_API_KEY must be set.");
-    process.exit(2);
-  }
-  const result = await discoverModels(normalizeBaseUrl(baseUrl), apiKey, {
-    timeoutMs: 10_000,
-  });
+  const result = await runSmokeFromEnv();
   console.log(`Source: ${result.source}`);
-  console.log(`Discovered ${result.models.length} models:`);
-  for (const m of result.models) {
-    console.log(`  - ${m.id}  (ctx=${m.contextWindow}, max=${m.maxTokens}, compat=${JSON.stringify(m.compat)})`);
+  console.log(`Discovered ${result.discoveredCount} models.`);
+  for (const completion of result.completions) {
+    console.log(`Smoke OK: ${completion.modelId} -> ${JSON.stringify(completion.content)}`);
   }
 }
 
 main().catch((err) => {
-  console.error(err);
+  console.error(err instanceof Error ? err.message : err);
   process.exit(1);
 });

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -14,6 +14,9 @@ const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
+const FALLBACK_METADATA_OVERRIDES: Record<string, Partial<ProviderModelConfig>> = {
+  "openai/gpt-5.5": { contextWindow: 1_050_000 },
+};
 
 export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
@@ -79,6 +82,11 @@ function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined 
   return undefined;
 }
 
+function getFallbackOverrideKey(id: string, ownedBy?: string): string {
+  const provider = toKnownProvider(ownedBy) ?? toKnownProvider(id.split("/")[0]);
+  return provider && !id.includes("/") ? `${provider}/${id}` : id;
+}
+
 function withTimeout(timeoutMs: number, signal?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
   const controller = new AbortController();
   const onAbort = () => controller.abort(signal?.reason);
@@ -142,6 +150,7 @@ function mapFromModelsList(entry: ModelsListEntry): ProviderModelConfig | undefi
   const id = entry.id;
   if (!id) return undefined;
   const catalogModel = findCatalogModel(id, entry.owned_by);
+  const fallbackOverride = FALLBACK_METADATA_OVERRIDES[getFallbackOverrideKey(id, entry.owned_by)] ?? {};
   return {
     id,
     name: catalogModel?.name ?? `${id} (no metadata)`,
@@ -152,6 +161,7 @@ function mapFromModelsList(entry: ModelsListEntry): ProviderModelConfig | undefi
     contextWindow: catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
+    ...fallbackOverride,
   };
 }
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,3 +1,5 @@
+import { getModels, getProviders } from "@earendil-works/pi-ai";
+import type { Api, KnownProvider, Model } from "@earendil-works/pi-ai";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type {
   DiscoveryOptions,
@@ -11,6 +13,7 @@ import type {
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
+const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
 
 export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
@@ -47,6 +50,33 @@ export function buildCompat(modelId: string): ProviderModelConfig["compat"] {
     return { supportsStore: false, cacheControlFormat: "anthropic" };
   }
   return { supportsStore: false };
+}
+
+function toKnownProvider(provider: string | undefined): KnownProvider | undefined {
+  if (!provider) return undefined;
+  const normalized = provider.toLowerCase();
+  return KNOWN_PROVIDER_SET.has(normalized) ? (normalized as KnownProvider) : undefined;
+}
+
+function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined {
+  const prefixProvider = toKnownProvider(id.split("/")[0]);
+  const candidates = [toKnownProvider(ownedBy), prefixProvider].filter(
+    (provider): provider is KnownProvider => provider !== undefined,
+  );
+
+  for (const provider of candidates) {
+    const exact = getModels(provider).find((model) => model.id === id);
+    if (exact) return exact;
+    const providerQualified = getModels(provider).find((model) => model.id === `${provider}/${id}`);
+    if (providerQualified) return providerQualified;
+  }
+
+  for (const provider of getProviders()) {
+    const exact = getModels(provider).find((model) => model.id === id);
+    if (exact) return exact;
+  }
+
+  return undefined;
 }
 
 function withTimeout(timeoutMs: number, signal?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
@@ -111,14 +141,16 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
 function mapFromModelsList(entry: ModelsListEntry): ProviderModelConfig | undefined {
   const id = entry.id;
   if (!id) return undefined;
+  const catalogModel = findCatalogModel(id, entry.owned_by);
   return {
     id,
-    name: `${id} (no metadata)`,
-    reasoning: false,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_WINDOW,
-    maxTokens: DEFAULT_MAX_TOKENS,
+    name: catalogModel?.name ?? `${id} (no metadata)`,
+    reasoning: catalogModel?.reasoning ?? false,
+    thinkingLevelMap: catalogModel?.thinkingLevelMap,
+    input: catalogModel?.input ?? ["text"],
+    cost: catalogModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
   };
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -14,9 +14,29 @@ const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
-const FALLBACK_METADATA_OVERRIDES: Record<string, Partial<ProviderModelConfig>> = {
-  "openai/gpt-5.5": { contextWindow: 1_050_000 },
-};
+const MODELS_DEV_URL = "https://models.dev/api.json";
+let modelsDevCatalog: ModelsDevResponse | undefined;
+
+interface ModelsDevModel {
+  name?: string;
+  reasoning?: boolean;
+  modalities?: {
+    input?: string[];
+  };
+  limit?: {
+    context?: number;
+    input?: number;
+    output?: number;
+  };
+  cost?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+}
+
+type ModelsDevResponse = Record<string, { models?: Record<string, ModelsDevModel> }>;
 
 export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
@@ -82,9 +102,23 @@ function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined 
   return undefined;
 }
 
-function getFallbackOverrideKey(id: string, ownedBy?: string): string {
-  const provider = toKnownProvider(ownedBy) ?? toKnownProvider(id.split("/")[0]);
-  return provider && !id.includes("/") ? `${provider}/${id}` : id;
+function getFallbackProviderAndModel(id: string, ownedBy?: string): { provider?: string; modelId: string } {
+  const [prefix, ...rest] = id.split("/");
+  const prefixProvider = toKnownProvider(prefix);
+  if (prefixProvider && rest.length > 0) {
+    return { provider: prefixProvider, modelId: rest.join("/") };
+  }
+  return { provider: toKnownProvider(ownedBy), modelId: id };
+}
+
+function findModelsDevModel(
+  catalog: ModelsDevResponse | undefined,
+  id: string,
+  ownedBy?: string,
+): ModelsDevModel | undefined {
+  const { provider, modelId } = getFallbackProviderAndModel(id, ownedBy);
+  if (!provider) return undefined;
+  return catalog?.[provider]?.models?.[modelId];
 }
 
 function withTimeout(timeoutMs: number, signal?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
@@ -124,6 +158,53 @@ async function fetchJson<T>(
   }
 }
 
+async function fetchPublicJson<T>(url: string, options: DiscoveryOptions): Promise<T> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const { signal, cancel } = withTimeout(timeoutMs, options.signal);
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal,
+    });
+    if (!response.ok) throw new Error(`${url} returned ${response.status}`);
+    return (await response.json()) as T;
+  } finally {
+    cancel();
+  }
+}
+
+async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
+  if (modelsDevCatalog) return modelsDevCatalog;
+  try {
+    modelsDevCatalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
+    return modelsDevCatalog;
+  } catch {
+    return undefined;
+  }
+}
+
+function mapModelsDevMetadata(model: ModelsDevModel | undefined): Partial<ProviderModelConfig> {
+  if (!model) return {};
+  const metadata: Partial<ProviderModelConfig> = {};
+  if (model.name) metadata.name = model.name;
+  if (model.reasoning !== undefined) metadata.reasoning = model.reasoning;
+  if (model.modalities?.input) {
+    metadata.input = model.modalities.input.includes("image") ? ["text", "image"] : ["text"];
+  }
+  const contextWindow = model.limit?.context ?? model.limit?.input;
+  if (contextWindow !== undefined) metadata.contextWindow = contextWindow;
+  if (model.limit?.output !== undefined) metadata.maxTokens = model.limit.output;
+  if (model.cost) {
+    metadata.cost = {
+      input: model.cost.input ?? 0,
+      output: model.cost.output ?? 0,
+      cacheRead: model.cost.cache_read ?? 0,
+      cacheWrite: model.cost.cache_write ?? 0,
+    };
+  }
+  return metadata;
+}
+
 function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefined {
   const id = entry.model_name;
   if (!id) return undefined;
@@ -146,22 +227,24 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   };
 }
 
-function mapFromModelsList(entry: ModelsListEntry): ProviderModelConfig | undefined {
+function mapFromModelsList(
+  entry: ModelsListEntry,
+  modelsDev: ModelsDevResponse | undefined,
+): ProviderModelConfig | undefined {
   const id = entry.id;
   if (!id) return undefined;
   const catalogModel = findCatalogModel(id, entry.owned_by);
-  const fallbackOverride = FALLBACK_METADATA_OVERRIDES[getFallbackOverrideKey(id, entry.owned_by)] ?? {};
+  const modelsDevMetadata = mapModelsDevMetadata(findModelsDevModel(modelsDev, id, entry.owned_by));
   return {
     id,
-    name: catalogModel?.name ?? `${id} (no metadata)`,
-    reasoning: catalogModel?.reasoning ?? false,
+    name: modelsDevMetadata.name ?? catalogModel?.name ?? `${id} (no metadata)`,
+    reasoning: modelsDevMetadata.reasoning ?? catalogModel?.reasoning ?? false,
     thinkingLevelMap: catalogModel?.thinkingLevelMap,
-    input: catalogModel?.input ?? ["text"],
-    cost: catalogModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
-    maxTokens: catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
+    input: modelsDevMetadata.input ?? catalogModel?.input ?? ["text"],
+    cost: modelsDevMetadata.cost ?? catalogModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: modelsDevMetadata.contextWindow ?? catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: modelsDevMetadata.maxTokens ?? catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
-    ...fallbackOverride,
   };
 }
 
@@ -185,8 +268,9 @@ export async function discoverModels(
   if (!listResult.ok) {
     throw new Error(`/v1/models returned ${listResult.status}`);
   }
+  const modelsDev = await getModelsDevCatalog(options);
   const models = (listResult.data.data ?? [])
-    .map(mapFromModelsList)
+    .map((entry) => mapFromModelsList(entry, modelsDev))
     .filter((m): m is ProviderModelConfig => m !== undefined);
   return { source: "models_list", models };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,6 +41,7 @@ export interface ModelInfoResponse {
 
 export interface ModelsListEntry {
   id?: string;
+  owned_by?: string;
 }
 
 export interface ModelsListResponse {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -214,7 +214,7 @@ describe("discoverModels fallback to /v1/models", () => {
       reasoning: true,
       thinkingLevelMap: { off: null, xhigh: "xhigh" },
       input: ["text", "image"],
-      contextWindow: 272000,
+      contextWindow: 1050000,
       maxTokens: 128000,
       compat: { supportsStore: false },
     });

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -192,6 +192,34 @@ describe("discoverModels fallback to /v1/models", () => {
     });
   }
 
+  it("uses catalog metadata when LiteLLM returns provider ownership", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, {
+          data: [{ id: "gpt-5.5", object: "model", owned_by: "openai" }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("models_list");
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      reasoning: true,
+      thinkingLevelMap: { off: null, xhigh: "xhigh" },
+      input: ["text", "image"],
+      contextWindow: 272000,
+      maxTokens: 128000,
+      compat: { supportsStore: false },
+    });
+  });
+
   it("throws when /model/info returns a non-401/403/404 error", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 500 }));
     await expect(discoverModels("https://litellm.example.com", "sk-test", {})).rejects.toThrow(/500/);

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -192,13 +192,31 @@ describe("discoverModels fallback to /v1/models", () => {
     });
   }
 
-  it("uses catalog metadata when LiteLLM returns provider ownership", async () => {
+  it("uses models.dev metadata when LiteLLM returns provider ownership", async () => {
+    const urls: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = input instanceof URL ? input.toString() : String(input);
+      urls.push(url);
       if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
       if (url.endsWith("/v1/models")) {
         return jsonResponse(200, {
           data: [{ id: "gpt-5.5", object: "model", owned_by: "openai" }],
+        });
+      }
+      if (url === "https://models.dev/api.json") {
+        return jsonResponse(200, {
+          openai: {
+            models: {
+              "gpt-5.5": {
+                id: "gpt-5.5",
+                name: "GPT-5.5",
+                reasoning: true,
+                modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+                limit: { context: 1_050_000, input: 922_000, output: 128_000 },
+                cost: { input: 5, output: 30, cache_read: 0.5 },
+              },
+            },
+          },
         });
       }
       throw new Error(`unexpected URL: ${url}`);
@@ -206,6 +224,7 @@ describe("discoverModels fallback to /v1/models", () => {
 
     const result = await discoverModels("https://litellm.example.com", "sk-test", {});
 
+    expect(urls).toContain("https://models.dev/api.json");
     expect(result.source).toBe("models_list");
     expect(result.models).toHaveLength(1);
     expect(result.models[0]).toMatchObject({
@@ -218,6 +237,7 @@ describe("discoverModels fallback to /v1/models", () => {
       maxTokens: 128000,
       compat: { supportsStore: false },
     });
+    expect(result.models[0]?.cost).toEqual({ input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 });
   });
 
   it("throws when /model/info returns a non-401/403/404 error", async () => {

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function readWorkflow(): string {
+  return readFileSync(resolve(repoRoot, ".github/workflows/litellm-smoke.yml"), "utf8");
+}
+
+describe("LiteLLM smoke workflow", () => {
+  it("uses the GitHub Models smoke model as a complete LiteLLM model id", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("GH_MODELS_SMOKE_MODEL: ${{ vars.GH_MODELS_SMOKE_MODEL || 'openai/gpt-4o-mini' }}");
+    expect(workflow).toContain("model: ${GH_MODELS_SMOKE_MODEL}");
+    expect(workflow).not.toContain("model: openai/${GH_MODELS_SMOKE_MODEL}");
+  });
+});

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { parseSmokeModels, runSmoke } from "../scripts/smoke-runner.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("parseSmokeModels", () => {
+  it("parses comma and whitespace separated model ids", () => {
+    expect(parseSmokeModels(" github-gpt-4.1-mini,openai-gpt-5.4-nano\nanthropic-claude-haiku ")).toEqual([
+      "github-gpt-4.1-mini",
+      "openai-gpt-5.4-nano",
+      "anthropic-claude-haiku",
+    ]);
+  });
+});
+
+describe("runSmoke", () => {
+  it("discovers models and sends a chat completion request to each requested model", async () => {
+    const requests: Array<{ url: string; body?: unknown }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      requests.push({
+        url,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            { model_name: "github-gpt-4.1-mini", model_info: { mode: "chat" } },
+            { model_name: "gemini-flash", model_info: { mode: "chat" } },
+          ],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, {
+          choices: [{ message: { content: "pong" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await runSmoke({
+      baseUrl: "http://127.0.0.1:4000/v1",
+      apiKey: "sk-smoke",
+      modelIds: ["github-gpt-4.1-mini", "gemini-flash"],
+      timeoutMs: 1000,
+    });
+
+    expect(result).toEqual({
+      source: "model_info",
+      discoveredCount: 2,
+      completions: [
+        { modelId: "github-gpt-4.1-mini", content: "pong" },
+        { modelId: "gemini-flash", content: "pong" },
+      ],
+    });
+    expect(requests.filter((request) => request.url.endsWith("/v1/chat/completions"))).toMatchObject([
+      {
+        url: "http://127.0.0.1:4000/v1/chat/completions",
+        body: {
+          model: "github-gpt-4.1-mini",
+          messages: [{ role: "user", content: "Reply with one short word." }],
+          max_tokens: 16,
+          temperature: 0,
+        },
+      },
+      {
+        url: "http://127.0.0.1:4000/v1/chat/completions",
+        body: {
+          model: "gemini-flash",
+          messages: [{ role: "user", content: "Reply with one short word." }],
+          max_tokens: 16,
+          temperature: 0,
+        },
+      },
+    ]);
+  });
+
+  it("fails before completion calls when a requested model is not discovered", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-gpt-4.1-mini", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["anthropic-claude-haiku"],
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/Requested smoke models were not discovered: anthropic-claude-haiku/);
+  });
+});

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { parseSmokeModels, runSmoke } from "../scripts/smoke-runner.js";
+import { parseSmokeModels, runSmoke, runSmokeFromEnv } from "../scripts/smoke-runner.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -103,5 +103,72 @@ describe("runSmoke", () => {
         timeoutMs: 1000,
       }),
     ).rejects.toThrow(/Requested smoke models were not discovered: anthropic-claude-haiku/);
+  });
+
+  it("includes provider response bodies in chat completion failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(429, { error: "rate limited" });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["github-models-openai"],
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/\/v1\/chat\/completions for github-models-openai returned 429.*rate limited/);
+  });
+});
+
+describe("runSmokeFromEnv", () => {
+  it("loads LiteLLM smoke settings from the environment", async () => {
+    const requests: Array<{ url: string; headers?: Record<string, string> }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      requests.push({
+        url,
+        headers: init?.headers as Record<string, string>,
+      });
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, {
+          choices: [{ message: { content: "pong" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await runSmokeFromEnv({
+      LITELLM_BASE_URL: " http://127.0.0.1:4000/v1 ",
+      LITELLM_API_KEY: " sk-env ",
+      LITELLM_SMOKE_MODELS: "github-models-openai",
+      LITELLM_SMOKE_TIMEOUT_MS: "1000",
+    });
+
+    expect(result.completions).toEqual([{ modelId: "github-models-openai", content: "pong" }]);
+    expect(requests[0]).toMatchObject({
+      url: "http://127.0.0.1:4000/model/info",
+      headers: { Authorization: "Bearer sk-env" },
+    });
+  });
+
+  it("requires LiteLLM base URL and API key settings", async () => {
+    await expect(runSmokeFromEnv({ LITELLM_BASE_URL: "http://127.0.0.1:4000" })).rejects.toThrow(
+      /LITELLM_BASE_URL and LITELLM_API_KEY must be set/,
+    );
   });
 });

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, afterEach } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseSmokeModels, runSmoke } from "../scripts/smoke-runner.js";
 
 function jsonResponse(status: number, body: unknown): Response {


### PR DESCRIPTION
## Summary

Adds a real LiteLLM smoke pipeline that starts a LiteLLM proxy on the GitHub Actions runner, verifies model discovery through the provider smoke runner, and sends real `/v1/chat/completions` requests through the proxy.

The workflow always includes a GitHub Models baseline route using `GITHUB_TOKEN` with `models: read`. Direct OpenAI, Anthropic, and Gemini routes are added only when their repository secrets are configured. Manual runs can set `require_vendors` to fail early unless all direct vendor secrets are present.

## Details

- Adds a reusable `scripts/smoke-runner.ts` with tested discovery and completion-call behavior.
- Updates `scripts/smoke.ts` to use the shared runner.
- Adds `.github/workflows/litellm-smoke.yml` for Docker-backed LiteLLM smoke testing.
- Documents required secrets, optional model override variables, and default cheap/free-friendly model choices in the README.

## Validation

- `npm run check`
- `npm run clean && npm run build`
- `npm pack --dry-run`
- `actionlint .github/workflows/litellm-smoke.yml`

Note: the actual live GitHub Actions smoke depends on the Actions `GITHUB_TOKEN` with `models: read` and any configured vendor secrets, so it needs to run in GitHub Actions to exercise the baseline route.