### PR TITLE
refactor(cost): Periodically fetch /model/info

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ This keeps the LiteLLM integration path under test but does not call real LLM AP
 
 The model list is cached at `~/.pi/agent/litellm-models.json` with a keyed fingerprint of the base URL + API key. Changing either invalidates the cache automatically.
 
+If the cache is older than 24 hours, the extension refreshes it in the background on session start (non-blocking). Failures are silent — the cached models remain in use. Run `/litellm-refresh` to force an immediate refresh.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,5 +1,4 @@
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { resolveCredentials } from "./litellm.js";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
 export interface ModelCostInfo {
   inputCostPerToken: number;
@@ -8,70 +7,28 @@ export interface ModelCostInfo {
   cacheWriteCostPerToken: number;
 }
 
-export function setupLiteLLMCostTracking(pi: ExtensionAPI): void {
+export function setupLiteLLMCostTracking(
+  pi: ExtensionAPI,
+  models: ProviderModelConfig[],
+): (models: ProviderModelConfig[]) => void {
   const modelCosts = new Map<string, ModelCostInfo>();
   let lastResponseCost: number | null = null;
 
-  pi.on("session_start", async (_event, ctx) => {
-    try {
-      const config = await resolveCredentials();
-      if (!config.baseUrl || !config.apiKey) {
-        ctx.ui?.notify?.("LiteLLM cost extension: no credentials configured", "warning");
-        return;
-      }
-
-      const response = await fetch(`${config.baseUrl}/model/info`, {
-        headers: {
-          Authorization: `Bearer ${config.apiKey}`,
-          Accept: "application/json",
-        },
+  // pi reports model costs per million tokens; cost lookups multiply by raw token counts.
+  const updateCosts = (newModels: ProviderModelConfig[]): void => {
+    modelCosts.clear();
+    for (const model of newModels) {
+      if (!model.cost) continue;
+      modelCosts.set(model.id, {
+        inputCostPerToken: (model.cost.input ?? 0) / 1_000_000,
+        outputCostPerToken: (model.cost.output ?? 0) / 1_000_000,
+        cacheReadCostPerToken: (model.cost.cacheRead ?? 0) / 1_000_000,
+        cacheWriteCostPerToken: (model.cost.cacheWrite ?? 0) / 1_000_000,
       });
-
-      if (!response.ok) {
-        ctx.ui?.notify?.(`LiteLLM cost extension: /model/info returned ${response.status}`, "warning");
-        return;
-      }
-
-      const payload = (await response.json()) as {
-        data: Array<{
-          model_name: string;
-          litellm_params?: { model?: string };
-          model_info?: {
-            input_cost_per_token?: number;
-            output_cost_per_token?: number;
-            cache_read_input_token_cost?: number;
-            cache_creation_input_token_cost?: number;
-          };
-        }>;
-      };
-
-      for (const entry of payload.data) {
-        const info = entry.model_info;
-        if (!info) continue;
-
-        const costInfo: ModelCostInfo = {
-          inputCostPerToken: info.input_cost_per_token ?? 0,
-          outputCostPerToken: info.output_cost_per_token ?? 0,
-          cacheReadCostPerToken: info.cache_read_input_token_cost ?? 0,
-          cacheWriteCostPerToken: info.cache_creation_input_token_cost ?? 0,
-        };
-
-        modelCosts.set(entry.model_name, costInfo);
-        if (entry.litellm_params?.model) {
-          modelCosts.set(entry.litellm_params.model, costInfo);
-        }
-      }
-
-      if (modelCosts.size > 0) {
-        ctx.ui?.notify?.(`LiteLLM cost: loaded pricing for ${modelCosts.size} model(s)`, "info");
-      }
-    } catch (error) {
-      ctx.ui?.notify?.(
-        `LiteLLM cost extension: could not fetch /model/info (${error instanceof Error ? error.message : String(error)})`,
-        "warning",
-      );
     }
-  });
+  };
+
+  updateCosts(models);
 
   pi.on("after_provider_response", (event) => {
     const costHeader = event.headers?.["x-litellm-response-cost"] ?? event.headers?.["X-Litellm-Response-Cost"];
@@ -168,4 +125,6 @@ export function setupLiteLLMCostTracking(pi: ExtensionAPI): void {
 
     return;
   });
+
+  return updateCosts;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ const ENV_OFFLINE = "LITELLM_OFFLINE";
 const DEFAULT_TIMEOUT_MS = 5000;
 const LOGIN_TIMEOUT_MS = 10_000;
 const CACHE_FILENAME = "litellm-models.json";
+const CACHE_STALE_MS = 24 * 60 * 60 * 1000;
 
 function getAuthPath(): string {
   return join(getAgentDir(), "auth.json");
@@ -222,6 +223,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   const creds = await resolveCredentials();
   const cache = await readCache(getCachePath());
   const fp = creds.apiKey ? fingerprint(creds.apiKey) : undefined;
+  let cacheFetchedAt = cache?.fetchedAt ?? 0;
 
   const cacheValid =
     cache !== null &&
@@ -258,6 +260,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
           models: result.models,
         };
         await writeCache(getCachePath(), next);
+        cacheFetchedAt = next.fetchedAt;
         if (isListModelsMode()) {
           process.stderr.write(`LiteLLM: ${result.models.length} models discovered (source: ${result.source}).\n`);
         }
@@ -273,48 +276,59 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     modifyModels: modifyLiteLLMModels,
   };
 
-  pi.registerProvider(PROVIDER_NAME, {
-    baseUrl: creds.baseUrl ? `${creds.baseUrl}/v1` : "https://litellm.example.com/v1",
-    apiKey: ENV_API_KEY,
-    api: "openai-completions",
-    models,
-    oauth,
-  });
+  function registerProvider(baseUrl: string | undefined, models: ProviderModelConfig[]): void {
+    pi.registerProvider(PROVIDER_NAME, {
+      baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
+      apiKey: ENV_API_KEY,
+      api: "openai-completions",
+      models,
+      oauth,
+    });
+  }
+
+  registerProvider(creds.baseUrl, models);
+
+  const updateCosts = setupLiteLLMCostTracking(pi, models);
+
+  let refreshInProgress: Promise<unknown> | null = null;
+
+  function discoveryDisabledReason(): string | null {
+    if (isOffline()) return `${ENV_OFFLINE}=1`;
+    if (getDiscoveryTimeoutMs() === 0) return `${ENV_TIMEOUT}=0`;
+    return null;
+  }
+
+  async function refreshModelsAndCosts(): Promise<{ models: ProviderModelConfig[]; source: string }> {
+    const fresh = await resolveCredentials();
+    const freshFp = fresh.apiKey ? fingerprint(fresh.apiKey) : undefined;
+    if (!fresh.baseUrl || !fresh.apiKey || !freshFp) {
+      throw new Error("no credentials. Run /login litellm or set env vars.");
+    }
+    const result = await discoverModels(fresh.baseUrl, fresh.apiKey, { timeoutMs: getDiscoveryTimeoutMs() });
+    const now = Date.now();
+    await writeCache(getCachePath(), {
+      baseUrl: fresh.baseUrl,
+      apiKeyFingerprint: freshFp,
+      fetchedAt: now,
+      source: result.source,
+      models: result.models,
+    });
+    registerProvider(fresh.baseUrl, result.models);
+    updateCosts(result.models);
+    cacheFetchedAt = now;
+    return { models: result.models, source: result.source };
+  }
 
   pi.registerCommand("litellm-refresh", {
     description: "Re-discover models from the LiteLLM proxy.",
     handler: async (_args, ctx) => {
-      if (isOffline()) {
-        ctx.ui.notify(`LiteLLM refresh disabled (${ENV_OFFLINE}=1)`, "warning");
-        return;
-      }
-      const timeoutMs = getDiscoveryTimeoutMs();
-      if (timeoutMs === 0) {
-        ctx.ui.notify(`LiteLLM refresh disabled (${ENV_TIMEOUT}=0)`, "warning");
-        return;
-      }
-      const fresh = await resolveCredentials();
-      const freshFp = fresh.apiKey ? fingerprint(fresh.apiKey) : undefined;
-      if (!fresh.baseUrl || !fresh.apiKey || !freshFp) {
-        ctx.ui.notify("LiteLLM refresh failed: no credentials. Run /login litellm or set env vars.", "error");
+      const disabledReason = discoveryDisabledReason();
+      if (disabledReason) {
+        ctx.ui.notify(`LiteLLM refresh disabled (${disabledReason})`, "warning");
         return;
       }
       try {
-        const result = await discoverModels(fresh.baseUrl, fresh.apiKey, { timeoutMs });
-        await writeCache(getCachePath(), {
-          baseUrl: fresh.baseUrl,
-          apiKeyFingerprint: freshFp,
-          fetchedAt: Date.now(),
-          source: result.source,
-          models: result.models,
-        });
-        pi.registerProvider(PROVIDER_NAME, {
-          baseUrl: `${fresh.baseUrl}/v1`,
-          apiKey: ENV_API_KEY,
-          api: "openai-completions",
-          models: result.models,
-          oauth,
-        });
+        const result = await refreshModelsAndCosts();
         ctx.ui.notify(`LiteLLM: ${result.models.length} models refreshed (source: ${result.source})`, "info");
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -323,11 +337,17 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     },
   });
 
-  setupLiteLLMCostTracking(pi);
-
   let sessionId: string | undefined;
-  pi.on("session_start", async (_event, ctx) => {
+  pi.on("session_start", (_event, ctx) => {
     sessionId = getSessionIdFromFile(ctx.sessionManager.getSessionFile());
+
+    if (discoveryDisabledReason() || !cacheFetchedAt || Date.now() - cacheFetchedAt <= CACHE_STALE_MS) return;
+    if (refreshInProgress) return;
+    refreshInProgress = refreshModelsAndCosts()
+      .catch(() => undefined)
+      .finally(() => {
+        refreshInProgress = null;
+      });
   });
 
   pi.on("before_provider_request", (event, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,7 +87,10 @@ async function discoverWithFallback(
   }
 }
 
-async function loginLiteLLM(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
+async function loginLiteLLM(
+  callbacks: OAuthLoginCallbacks,
+  onCacheWrite?: (cache: CacheFile) => void,
+): Promise<OAuthCredentials> {
   const rawBaseUrl = (
     await callbacks.onPrompt({
       message: "Enter LiteLLM proxy URL (no trailing /v1):",
@@ -103,13 +106,15 @@ async function loginLiteLLM(callbacks: OAuthLoginCallbacks): Promise<OAuthCreden
     signal: callbacks.signal,
   });
 
-  await writeCache(getCachePath(), {
+  const cache: CacheFile = {
     baseUrl,
     apiKeyFingerprint: fingerprint(apiKey),
     fetchedAt: Date.now(),
     source,
     models,
-  });
+  };
+  await writeCache(getCachePath(), cache);
+  onCacheWrite?.(cache);
   callbacks.onProgress?.(`LiteLLM: ${models.length} models discovered (source: ${source})`);
 
   return {
@@ -270,7 +275,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   const oauth = {
     name: "LiteLLM",
-    login: loginLiteLLM,
+    login: (callbacks: OAuthLoginCallbacks) =>
+      loginLiteLLM(callbacks, (next) => {
+        cacheFetchedAt = next.fetchedAt;
+      }),
     refreshToken: refreshLiteLLM,
     getApiKey: (cred: OAuthCredentials) => cred.access,
     modifyModels: modifyLiteLLMModels,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,8 @@ const LOGIN_TIMEOUT_MS = 10_000;
 const CACHE_FILENAME = "litellm-models.json";
 const CACHE_STALE_MS = 24 * 60 * 60 * 1000;
 
+type RefreshResult = { models: ProviderModelConfig[]; source: string };
+
 function getAuthPath(): string {
   return join(getAgentDir(), "auth.json");
 }
@@ -298,7 +300,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   const updateCosts = setupLiteLLMCostTracking(pi, models);
 
-  let refreshInProgress: Promise<unknown> | null = null;
+  let refreshInProgress: Promise<RefreshResult> | null = null;
 
   function discoveryDisabledReason(): string | null {
     if (isOffline()) return `${ENV_OFFLINE}=1`;
@@ -306,7 +308,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     return null;
   }
 
-  async function refreshModelsAndCosts(): Promise<{ models: ProviderModelConfig[]; source: string }> {
+  async function refreshModelsAndCosts(): Promise<RefreshResult> {
     const fresh = await resolveCredentials();
     const freshFp = fresh.apiKey ? fingerprint(fresh.apiKey) : undefined;
     if (!fresh.baseUrl || !fresh.apiKey || !freshFp) {
@@ -327,6 +329,13 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     return { models: result.models, source: result.source };
   }
 
+  function runRefresh(): Promise<RefreshResult> {
+    refreshInProgress ??= refreshModelsAndCosts().finally(() => {
+      refreshInProgress = null;
+    });
+    return refreshInProgress;
+  }
+
   pi.registerCommand("litellm-refresh", {
     description: "Re-discover models from the LiteLLM proxy.",
     handler: async (_args, ctx) => {
@@ -336,7 +345,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         return;
       }
       try {
-        const result = await refreshModelsAndCosts();
+        const result = await runRefresh();
         ctx.ui.notify(`LiteLLM: ${result.models.length} models refreshed (source: ${result.source})`, "info");
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -350,12 +359,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     sessionId = getSessionIdFromFile(ctx.sessionManager.getSessionFile());
 
     if (discoveryDisabledReason() || !cacheFetchedAt || Date.now() - cacheFetchedAt <= CACHE_STALE_MS) return;
-    if (refreshInProgress) return;
-    refreshInProgress = refreshModelsAndCosts()
-      .catch(() => undefined)
-      .finally(() => {
-        refreshInProgress = null;
-      });
+    void runRefresh().catch(() => undefined);
   });
 
   pi.on("before_provider_request", (event, ctx) => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -526,19 +526,19 @@ describe("feature parity", () => {
     for (const handler of sessionStartHandlers) {
       await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
     }
-    await vi.waitFor(() => expect(callCount).toBe(1));
-
-    // Verify costs updated via message_end
     const endHandler = pi.handlers.get("message_end")?.[0];
-    const result = await endHandler?.({
-      message: {
-        role: "assistant",
-        model: "test-model",
-        usage: { input: 1000, output: 1000 },
-      },
+    await vi.waitFor(async () => {
+      const result = await endHandler?.({
+        message: {
+          role: "assistant",
+          model: "test-model",
+          usage: { input: 1000, output: 1000 },
+        },
+      });
+      // After refresh: input: 0.000006 * 1000 = 0.006, output: 0.000030 * 1000 = 0.030
+      expect(result.message.usage.cost.total).toBeCloseTo(0.036, 6);
     });
-    // After refresh: input: 0.000006 * 1000 = 0.006, output: 0.000030 * 1000 = 0.030
-    expect(result.message.usage.cost.total).toBeCloseTo(0.036, 6);
+    expect(callCount).toBe(1);
   });
 
   it("handles stale refresh failure silently on session_start", async () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, readFile } from "node:fs/promises";
+import { scryptSync } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -398,5 +399,204 @@ describe("feature parity", () => {
         },
       },
     });
+  });
+
+  it("updates costs after litellm-refresh", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        callCount++;
+        // First call: original costs; second call (refresh): doubled costs
+        const inputCost = callCount === 1 ? 0.000003 : 0.000006;
+        const outputCost = callCount === 1 ? 0.000015 : 0.00003;
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "test-model",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: inputCost,
+                output_cost_per_token: outputCost,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    // Fire session_start handlers (no cache file exists → staleness check skipped)
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+
+    // Get initial cost from model-based calculation
+    const endHandler = pi.handlers.get("message_end")?.[0];
+    const initialResult = await endHandler?.({
+      message: {
+        role: "assistant",
+        model: "test-model",
+        usage: { input: 1000, output: 1000 },
+      },
+    });
+    // input: 0.000003 * 1000 = 0.003, output: 0.000015 * 1000 = 0.015
+    expect(initialResult.message.usage.cost.total).toBeCloseTo(0.018, 6);
+
+    // Run /litellm-refresh to update models and costs
+    const refreshCmd = pi.commands.get("litellm-refresh");
+    const notifications: Array<{ message: string; type: string }> = [];
+    await refreshCmd!.handler([], {
+      ui: {
+        notify: (message: string, type: string) => {
+          notifications.push({ message, type });
+        },
+      },
+    });
+    expect(notifications[0].type).toBe("info");
+
+    // Now get cost after refresh (costs doubled)
+    const refreshedResult = await endHandler?.({
+      message: {
+        role: "assistant",
+        model: "test-model",
+        usage: { input: 1000, output: 1000 },
+      },
+    });
+    // input: 0.000006 * 1000 = 0.006, output: 0.000030 * 1000 = 0.030
+    expect(refreshedResult.message.usage.cost.total).toBeCloseTo(0.036, 6);
+  });
+
+  it("auto-refreshes stale cache on session_start", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    const fp = scryptSync("sk-test", "pi-provider-litellm-cache-fingerprint-v1", 32).toString("hex");
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fp,
+        fetchedAt: Date.now() - 25 * 60 * 60 * 1000,
+        source: "model_info",
+        models: [{ id: "test-model", name: "test-model", cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 } }],
+      }),
+    );
+
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        callCount++;
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "test-model",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000006,
+                output_cost_per_token: 0.00003,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    // Extension used stale cache, no fetch during init
+    expect(callCount).toBe(0);
+
+    // Fire session_start to trigger stale auto-refresh (fire-and-forget)
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+    await vi.waitFor(() => expect(callCount).toBe(1));
+
+    // Verify costs updated via message_end
+    const endHandler = pi.handlers.get("message_end")?.[0];
+    const result = await endHandler?.({
+      message: {
+        role: "assistant",
+        model: "test-model",
+        usage: { input: 1000, output: 1000 },
+      },
+    });
+    // After refresh: input: 0.000006 * 1000 = 0.006, output: 0.000030 * 1000 = 0.030
+    expect(result.message.usage.cost.total).toBeCloseTo(0.036, 6);
+  });
+
+  it("handles stale refresh failure silently on session_start", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    const fp = scryptSync("sk-test", "pi-provider-litellm-cache-fingerprint-v1", 32).toString("hex");
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fp,
+        fetchedAt: Date.now() - 25 * 60 * 60 * 1000,
+        source: "model_info",
+        models: [
+          {
+            id: "test-model",
+            name: "test-model",
+            cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+          },
+        ],
+      }),
+    );
+
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        callCount++;
+        throw new Error("network error");
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    // Fire session_start — fire-and-forget refresh kicks off
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+
+    // Wait for background refresh to attempt the fetch (and fail silently)
+    await vi.waitFor(() => expect(callCount).toBe(1));
+
+    // Existing cached costs still work after the refresh failure
+    const endHandler = pi.handlers.get("message_end")?.[0];
+    const result = await endHandler?.({
+      message: {
+        role: "assistant",
+        model: "test-model",
+        usage: { input: 1000, output: 1000 },
+      },
+    });
+    // Original costs: input: 3/1M * 1000 = 0.003, output: 15/1M * 1000 = 0.015
+    expect(result.message.usage.cost.total).toBeCloseTo(0.018, 6);
   });
 });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -476,6 +476,77 @@ describe("feature parity", () => {
     expect(refreshedResult.message.usage.cost.total).toBeCloseTo(0.036, 6);
   });
 
+  it("shares concurrent litellm-refresh requests", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    const fp = scryptSync("sk-test", "pi-provider-litellm-cache-fingerprint-v1", 32).toString("hex");
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fp,
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: [{ id: "test-model", name: "test-model", cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 } }],
+      }),
+    );
+
+    let releaseFetch!: () => void;
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve;
+    });
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        callCount++;
+        if (callCount > 1) throw new Error("overlapping discovery");
+        await fetchGate;
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "test-model",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000006,
+                output_cost_per_token: 0.00003,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const refreshCmd = pi.commands.get("litellm-refresh");
+    const notifications: Array<{ message: string; type: string }> = [];
+    const ctx = {
+      ui: {
+        notify: (message: string, type: string) => {
+          notifications.push({ message, type });
+        },
+      },
+    };
+
+    const firstRefresh = refreshCmd!.handler([], ctx);
+    await vi.waitFor(() => expect(callCount).toBe(1));
+    const secondRefresh = refreshCmd!.handler([], ctx);
+    releaseFetch();
+    await Promise.all([firstRefresh, secondRefresh]);
+
+    expect(callCount).toBe(1);
+    expect(notifications).toEqual([
+      { message: "LiteLLM: 1 models refreshed (source: model_info)", type: "info" },
+      { message: "LiteLLM: 1 models refreshed (source: model_info)", type: "info" },
+    ]);
+  });
+
   it("auto-refreshes stale cache on session_start", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -190,4 +190,47 @@ describe("extension startup", () => {
     expect(cache.models.map((model) => model.id)).toEqual(["vidaimock-openai"]);
     expect(progress).toHaveBeenCalledWith("LiteLLM: 1 models discovered (source: model_info)");
   });
+
+  it("uses the login cache timestamp for later stale auto-refresh", async () => {
+    const agentDir = await makeAgentDir();
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.LITELLM_API_KEY;
+    delete process.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+    const loginTime = new Date("2026-05-01T00:00:00.000Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(loginTime);
+
+    let callCount = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        callCount++;
+        return jsonResponse(200, {
+          data: [{ model_name: `vidaimock-openai-${callCount}`, model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    expect(callCount).toBe(0);
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => (options.placeholder ? " http://127.0.0.1:4000/v1 " : " sk-login "),
+      signal: new AbortController().signal,
+    });
+    expect(callCount).toBe(1);
+    await writeFile(join(agentDir, "auth.json"), JSON.stringify({ litellm: { type: "oauth", ...credential } }), "utf8");
+
+    vi.mocked(Date.now).mockReturnValue(loginTime + 25 * 60 * 60 * 1000);
+    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
+    for (const handler of sessionStartHandlers) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+
+    await vi.waitFor(() => {
+      expect(callCount).toBe(2);
+      expect(pi.providers).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
Currently, cost.ts re-fetches /model/info on every session_start, duplicating the network request already made during model discovery in index.ts. This fetch also lacks timeout handling and fallback logic.

The main problem we're aiming to solve is the redundant per-session network call, but in fixing it we also need to keep cost data fresh — without it, LiteLLM proxy pricing changes would go unnoticed until pi restarts.

To address this, setupLiteLLMCostTracking now receives the already-discovered model list at startup and returns an updateCosts() closure for live updates. On session_start, we check cache age against a 24h threshold and re-discover if stale. /litellm-refresh also calls updateCosts() after re-registration.

The 24h stale refresh runs in the background; session_start does not block on the network call. The cached models remain in use until the refresh succeeds; failures are silent.

Key implementation details:
- Extract refreshModelsAndCosts() and registerProvider() to deduplicate the discover → writeCache → register → updateCosts chain shared between session_start, /litellm-refresh, and initial setup.
- discoveryDisabledReason() centralizes the LITELLM_OFFLINE / timeout=0 precheck used by the slash command and the auto-refresh.
- refreshInProgress promise guard prevents duplicate stale refreshes on concurrent session_start events.
- cacheFetchedAt tracked in memory instead of re-reading cache file on every session_start.
- Cost conversion math unchanged: per-million-token / 1_000_000.

Net result: fewer network requests, fresher cost data, no startup latency for stale refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-blocking background refresh of LiteLLM model/cache when older than 24 hours, triggered at session start.

* **Improvements**
  * Cost tracking now initializes from supplied model configs, derives per-token costs, supports runtime updates, and avoids concurrent refreshes.
  * Manual refresh command consolidated to shared refresh logic; cache staleness gating added.

* **Documentation**
  * README clarified cache freshness, silent-refresh behavior, and manual refresh guidance.

* **Tests**
  * Added tests for refresh behavior, deduplication, auto-refresh on session start, and silent-failure fallback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/balcsida/pi-provider-litellm/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->