### PR TITLE
[codex] Route smoke tests through VidaiMock

### DIFF
--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -1,13 +1,7 @@
 name: LiteLLM Smoke
 
 on:
-  workflow_dispatch:
-    inputs:
-      require_vendors:
-        description: Fail unless OpenAI, Anthropic, and Gemini secrets are configured
-        required: false
-        type: boolean
-        default: false
+  workflow_dispatch: {}
   schedule:
     - cron: '23 4 * * 1'
   push:
@@ -22,7 +16,6 @@ on:
 
 permissions:
   contents: read
-  models: read
 
 jobs:
   smoke:
@@ -33,10 +26,9 @@ jobs:
       LITELLM_API_KEY: sk-ci-litellm-smoke
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
       LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
-      GH_MODELS_SMOKE_MODEL: ${{ vars.GH_MODELS_SMOKE_MODEL || 'openai/gpt-4o-mini' }}
-      OPENAI_SMOKE_MODEL: ${{ vars.OPENAI_SMOKE_MODEL || 'gpt-4.1-nano' }}
-      ANTHROPIC_SMOKE_MODEL: ${{ vars.ANTHROPIC_SMOKE_MODEL || 'claude-haiku-4-5-20251001' }}
-      GEMINI_SMOKE_MODEL: ${{ vars.GEMINI_SMOKE_MODEL || 'gemini-2.5-flash-lite' }}
+      LITELLM_SMOKE_MODEL: vidaimock-openai
+      VIDAIMOCK_BASE_URL: http://127.0.0.1:8100
+      VIDAIMOCK_VERSION: v0.2.7
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,105 +41,73 @@ jobs:
       - run: npm ci
       - run: npm run build
 
-      - name: Write LiteLLM smoke config
-        id: config
+      - name: Install VidaiMock
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          REQUIRE_VENDORS: ${{ github.event_name == 'workflow_dispatch' && inputs.require_vendors && '1' || '0' }}
         run: |
           set -euo pipefail
 
-          if [[ "$REQUIRE_VENDORS" == "1" ]]; then
-            missing=()
-            [[ -n "${OPENAI_API_KEY:-}" ]] || missing+=("OPENAI_API_KEY")
-            [[ -n "${ANTHROPIC_API_KEY:-}" ]] || missing+=("ANTHROPIC_API_KEY")
-            [[ -n "${GEMINI_API_KEY:-}" ]] || missing+=("GEMINI_API_KEY")
-            if (( ${#missing[@]} > 0 )); then
-              printf 'Missing required vendor secrets: %s\n' "${missing[*]}" >&2
-              exit 1
+          mkdir -p .tmp/bin
+          asset="vidaimock-linux-x64.tar.gz"
+          curl -fsSL \
+            "https://github.com/vidaiUK/VidaiMock/releases/download/${VIDAIMOCK_VERSION}/${asset}" \
+            -o ".tmp/${asset}"
+          curl -fsSL \
+            "https://github.com/vidaiUK/VidaiMock/releases/download/${VIDAIMOCK_VERSION}/${asset%.tar.gz}.sha256" \
+            -o ".tmp/${asset%.tar.gz}.sha256"
+          (cd .tmp && sha256sum -c "${asset%.tar.gz}.sha256")
+          tar -xzf ".tmp/${asset}" -C .tmp
+          install -m 0755 .tmp/vidaimock/vidaimock .tmp/bin/vidaimock
+          .tmp/bin/vidaimock --version
+
+      - name: Start VidaiMock
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          .tmp/bin/vidaimock --host 0.0.0.0 --port 8100 > .tmp/vidaimock.log 2>&1 &
+          echo "$!" > .tmp/vidaimock.pid
+
+      - name: Wait for VidaiMock
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for _ in {1..30}; do
+            if curl -fsS "$VIDAIMOCK_BASE_URL/v1/models" >/tmp/vidaimock-models.json; then
+              cat /tmp/vidaimock-models.json
+              exit 0
             fi
-          fi
+            sleep 1
+          done
+          cat .tmp/vidaimock.log >&2 || true
+          exit 1
+
+      - name: Write LiteLLM smoke config
+        shell: bash
+        run: |
+          set -euo pipefail
 
           mkdir -p .tmp
-          smoke_models=("github-models-openai")
-
           cat > .tmp/litellm_config.yaml <<YAML
           model_list:
-            - model_name: github-models-openai
+            - model_name: ${LITELLM_SMOKE_MODEL}
               litellm_params:
-                model: ${GH_MODELS_SMOKE_MODEL}
-                api_base: https://models.github.ai/inference
-                api_key: os.environ/GITHUB_TOKEN
-          YAML
-
-          if [[ -n "${OPENAI_API_KEY:-}" ]]; then
-            smoke_models+=("openai-direct")
-            cat >> .tmp/litellm_config.yaml <<YAML
-            - model_name: openai-direct
-              litellm_params:
-                model: openai/${OPENAI_SMOKE_MODEL}
-                api_key: os.environ/OPENAI_API_KEY
-          YAML
-          else
-            echo "Skipping OpenAI direct smoke: OPENAI_API_KEY is not configured."
-          fi
-
-          if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-            smoke_models+=("anthropic-direct")
-            cat >> .tmp/litellm_config.yaml <<YAML
-            - model_name: anthropic-direct
-              litellm_params:
-                model: anthropic/${ANTHROPIC_SMOKE_MODEL}
-                api_key: os.environ/ANTHROPIC_API_KEY
-          YAML
-          else
-            echo "Skipping Anthropic direct smoke: ANTHROPIC_API_KEY is not configured."
-          fi
-
-          if [[ -n "${GEMINI_API_KEY:-}" ]]; then
-            smoke_models+=("gemini-direct")
-            cat >> .tmp/litellm_config.yaml <<YAML
-            - model_name: gemini-direct
-              litellm_params:
-                model: gemini/${GEMINI_SMOKE_MODEL}
-                api_key: os.environ/GEMINI_API_KEY
-          YAML
-          else
-            echo "Skipping Gemini direct smoke: GEMINI_API_KEY is not configured."
-          fi
-
-          cat >> .tmp/litellm_config.yaml <<YAML
+                model: openai/gpt-4o-mini
+                api_base: http://host.docker.internal:8100/v1
+                api_key: sk-vidaimock
           general_settings:
             master_key: ${LITELLM_MASTER_KEY}
           YAML
 
-          {
-            echo 'models<<EOF'
-            printf '%s\n' "${smoke_models[@]}"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
-
       - name: Start LiteLLM proxy
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: |
           set -euo pipefail
           docker run -d \
             --name litellm-smoke \
+            --add-host=host.docker.internal:host-gateway \
             -p 4000:4000 \
             -v "$PWD/.tmp/litellm_config.yaml:/app/config.yaml:ro" \
-            -e GITHUB_TOKEN \
-            -e OPENAI_API_KEY \
-            -e ANTHROPIC_API_KEY \
-            -e GEMINI_API_KEY \
             -e LITELLM_MASTER_KEY \
             "$LITELLM_IMAGE" \
             --config /app/config.yaml
@@ -170,7 +130,7 @@ jobs:
 
       - name: Run provider smoke
         env:
-          LITELLM_SMOKE_MODELS: ${{ steps.config.outputs.models }}
+          LITELLM_SMOKE_MODELS: ${{ env.LITELLM_SMOKE_MODEL }}
           LITELLM_SMOKE_TIMEOUT_MS: '60000'
         run: npx tsx scripts/smoke.ts
 
@@ -178,6 +138,17 @@ jobs:
         if: failure()
         run: docker logs litellm-smoke || true
 
+      - name: Dump VidaiMock logs
+        if: failure()
+        run: cat .tmp/vidaimock.log || true
+
       - name: Stop LiteLLM proxy
         if: always()
         run: docker rm -f litellm-smoke || true
+
+      - name: Stop VidaiMock
+        if: always()
+        run: |
+          if [[ -f .tmp/vidaimock.pid ]]; then
+            kill "$(cat .tmp/vidaimock.pid)" 2>/dev/null || true
+          fi

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -74,7 +74,7 @@ jobs:
           set -euo pipefail
 
           for _ in {1..30}; do
-            if curl -fsS "$VIDAIMOCK_BASE_URL/v1/models" >/tmp/vidaimock-models.json; then
+            if curl -fsS --connect-timeout 1 --max-time 3 "$VIDAIMOCK_BASE_URL/v1/models" >/tmp/vidaimock-models.json; then
               cat /tmp/vidaimock-models.json
               exit 0
             fi
@@ -123,7 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           for _ in {1..60}; do
-            if curl -fsS \
+            if curl -fsS --connect-timeout 1 --max-time 3 \
               -H "Authorization: Bearer $LITELLM_API_KEY" \
               "$LITELLM_BASE_URL/v1/models" >/tmp/litellm-models.json; then
               cat /tmp/litellm-models.json

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -26,7 +26,8 @@ jobs:
       LITELLM_API_KEY: sk-ci-litellm-smoke
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
       LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
-      LITELLM_SMOKE_MODEL: vidaimock-openai
+      LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
+      LITELLM_CLI_SMOKE_MODEL: vidaimock-openai
       VIDAIMOCK_BASE_URL: http://127.0.0.1:8100
       VIDAIMOCK_VERSION: v0.2.7
 
@@ -90,10 +91,15 @@ jobs:
           mkdir -p .tmp
           cat > .tmp/litellm_config.yaml <<YAML
           model_list:
-            - model_name: ${LITELLM_SMOKE_MODEL}
+            - model_name: vidaimock-openai
               litellm_params:
                 model: openai/gpt-4o-mini
                 api_base: http://host.docker.internal:8100/v1
+                api_key: sk-vidaimock
+            - model_name: anthropic/vidaimock-claude
+              litellm_params:
+                model: anthropic/claude-3-5-sonnet
+                api_base: http://host.docker.internal:8100
                 api_key: sk-vidaimock
           general_settings:
             master_key: ${LITELLM_MASTER_KEY}
@@ -130,9 +136,29 @@ jobs:
 
       - name: Run provider smoke
         env:
-          LITELLM_SMOKE_MODELS: ${{ env.LITELLM_SMOKE_MODEL }}
           LITELLM_SMOKE_TIMEOUT_MS: '60000'
         run: npx tsx scripts/smoke.ts
+
+      - name: Run Pi CLI smoke
+        env:
+          LITELLM_DISCOVERY_TIMEOUT_MS: '60000'
+          PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-cli-smoke
+        run: |
+          set -euo pipefail
+
+          rm -rf "$PI_CODING_AGENT_DIR"
+          ./node_modules/.bin/pi -e ./dist/index.js --list-models litellm 2>&1 | tee /tmp/pi-litellm-models.txt
+          grep -F "vidaimock-openai" /tmp/pi-litellm-models.txt
+          grep -F "anthropic/vidaimock-claude" /tmp/pi-litellm-models.txt
+
+          ./node_modules/.bin/pi \
+            -e ./dist/index.js \
+            --provider litellm \
+            --model "$LITELLM_CLI_SMOKE_MODEL" \
+            --no-tools \
+            --no-session \
+            -p "Reply with one short word." | tee /tmp/pi-litellm-response.txt
+          grep -F "mock response" /tmp/pi-litellm-response.txt
 
       - name: Dump LiteLLM logs
         if: failure()

--- a/README.md
+++ b/README.md
@@ -66,28 +66,11 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` only disables startup and refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
 
-## Real LiteLLM smoke workflow
+## Mocked LiteLLM smoke workflow
 
-The `LiteLLM Smoke` GitHub Actions workflow starts a real LiteLLM proxy on the runner, discovers models through this extension's smoke runner, and sends real `/v1/chat/completions` requests through the proxy.
+The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes one `vidaimock-openai` model whose upstream is VidaiMock's OpenAI-compatible `/v1` API, then this extension's smoke runner discovers that model through LiteLLM and sends a `/v1/chat/completions` request through the proxy.
 
-The required baseline route uses GitHub Models with the workflow `GITHUB_TOKEN` and `models: read` permission, so it can run without adding provider secrets. Direct vendor routes are added only when these repository secrets exist:
-
-| Secret | Default smoke model | Notes |
-|---|---|---|
-| `OPENAI_API_KEY` | `gpt-4.1-nano` | Cheap direct OpenAI/GPT route |
-| `ANTHROPIC_API_KEY` | `claude-haiku-4-5-20251001` | Cheap direct Claude route |
-| `GEMINI_API_KEY` | `gemini-2.5-flash-lite` | Cheap/free-tier-friendly Gemini route |
-
-Optional repository variables override model choices without editing the workflow. `GH_MODELS_SMOKE_MODEL` is a complete LiteLLM model id for the GitHub Models OpenAI-compatible route. The direct vendor variables are bare model names and the workflow adds their provider prefixes.
-
-| Variable | Default |
-|---|---|
-| `GH_MODELS_SMOKE_MODEL` | `openai/gpt-4o-mini` |
-| `OPENAI_SMOKE_MODEL` | `gpt-4.1-nano` |
-| `ANTHROPIC_SMOKE_MODEL` | `claude-haiku-4-5-20251001` |
-| `GEMINI_SMOKE_MODEL` | `gemini-2.5-flash-lite` |
-
-Manual runs include a `require_vendors` input. When enabled, the workflow fails before starting LiteLLM unless all three direct vendor secrets are configured. Scheduled and push runs keep the GitHub Models baseline required and skip missing direct vendors.
+This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required.
 
 ## Slash commands
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 ## Mocked LiteLLM smoke workflow
 
-The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes one `vidaimock-openai` model whose upstream is VidaiMock's OpenAI-compatible `/v1` API, then this extension's smoke runner discovers that model through LiteLLM and sends a `/v1/chat/completions` request through the proxy.
+The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes OpenAI-compatible and Anthropic routes whose upstreams are served by VidaiMock, then this extension's smoke runner discovers those models through LiteLLM and sends `/v1/chat/completions` requests through the proxy.
 
-This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required.
+This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` so extension loading, model discovery, and a real completion path are covered without opening the TUI.
 
 ## Slash commands
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -9,6 +9,13 @@ const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
 type TestProviderConfig = {
   baseUrl?: string;
   models?: unknown[];
+  oauth?: {
+    login: (callbacks: {
+      onPrompt: (options: { message: string; placeholder?: string }) => Promise<string>;
+      onProgress?: (message: string) => void;
+      signal?: AbortSignal;
+    }) => Promise<{ access: string; refresh: string; expires: number; baseUrl?: string }>;
+  };
 };
 
 type TestCommand = {
@@ -136,5 +143,51 @@ describe("extension startup", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith("LiteLLM refresh disabled (LITELLM_DISCOVERY_TIMEOUT_MS=0)", "warning");
+  });
+
+  it("prompts during login and caches discovered models", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const seenRequests: Array<{ url: string; authorization: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      seenRequests.push({
+        url,
+        authorization: new Headers(init?.headers).get("authorization") ?? "",
+      });
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const promptMessages: string[] = [];
+    const progress = vi.fn();
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        promptMessages.push(options.message);
+        return promptMessages.length === 1 ? " http://127.0.0.1:4000/v1 " : " sk-login ";
+      },
+      onProgress: progress,
+      signal: new AbortController().signal,
+    });
+
+    expect(promptMessages).toEqual(["Enter LiteLLM proxy URL (no trailing /v1):", "Enter API key:"]);
+    expect(seenRequests).toEqual([{ url: "http://127.0.0.1:4000/model/info", authorization: "Bearer sk-login" }]);
+    expect(credential).toMatchObject({
+      access: "sk-login",
+      refresh: "",
+      baseUrl: "http://127.0.0.1:4000",
+    });
+    const cache = JSON.parse(await readFile(join(agentDir, "litellm-models.json"), "utf8")) as {
+      models: Array<{ id: string }>;
+    };
+    expect(cache.models.map((model) => model.id)).toEqual(["vidaimock-openai"]);
+    expect(progress).toHaveBeenCalledWith("LiteLLM: 1 models discovered (source: model_info)");
   });
 });

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -9,16 +9,44 @@ function readWorkflow(): string {
   return readFileSync(resolve(repoRoot, ".github/workflows/litellm-smoke.yml"), "utf8");
 }
 
-describe("LiteLLM smoke workflow", () => {
-  it("uses the GitHub Models smoke model as a complete LiteLLM model id", () => {
-    const workflow = readWorkflow();
-    const defaultModelExpression =
-      "GH_MODELS_SMOKE_MODEL: $" + "{{ vars.GH_MODELS_SMOKE_MODEL || 'openai/gpt-4o-mini' }}";
-    const smokeModelExpansion = "model: $" + "{GH_MODELS_SMOKE_MODEL}";
-    const prefixedSmokeModelExpansion = "model: openai/$" + "{GH_MODELS_SMOKE_MODEL}";
+function readReadme(): string {
+  return readFileSync(resolve(repoRoot, "README.md"), "utf8");
+}
 
-    expect(workflow).toContain(defaultModelExpression);
-    expect(workflow).toContain(smokeModelExpansion);
-    expect(workflow).not.toContain(prefixedSmokeModelExpansion);
+describe("LiteLLM smoke workflow", () => {
+  it("routes smoke completions through VidaiMock instead of real LLM APIs", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("VIDAIMOCK_VERSION: v0.2.7");
+    expect(workflow).toContain("Start VidaiMock");
+    expect(workflow).toContain("Wait for VidaiMock");
+    expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
+    expect(workflow).toContain("LITELLM_SMOKE_MODEL: vidaimock-openai");
+    expect(workflow).toContain("model: openai/gpt-4o-mini");
+    expect(workflow).toContain("api_base: http://host.docker.internal:8100/v1");
+    expect(workflow).toContain("--add-host=host.docker.internal:host-gateway");
+    expect(workflow).toContain("LITELLM_SMOKE_MODELS: $" + "{{ env.LITELLM_SMOKE_MODEL }}");
+
+    expect(workflow).not.toContain("models: read");
+    expect(workflow).not.toContain("GH_MODELS_SMOKE_MODEL");
+    expect(workflow).not.toContain("OPENAI_API_KEY");
+    expect(workflow).not.toContain("ANTHROPIC_API_KEY");
+    expect(workflow).not.toContain("GEMINI_API_KEY");
+    expect(workflow).not.toContain("require_vendors");
+  });
+
+  it("documents the mocked smoke workflow without provider secrets", () => {
+    const readme = readReadme();
+
+    expect(readme).toContain("## Mocked LiteLLM smoke workflow");
+    expect(readme).toContain("VidaiMock");
+    expect(readme).toContain("does not call real LLM APIs");
+    expect(readme).toContain("No provider API keys or GitHub Models permission are required");
+
+    expect(readme).not.toContain("## Real LiteLLM smoke workflow");
+    expect(readme).not.toContain("OPENAI_API_KEY");
+    expect(readme).not.toContain("ANTHROPIC_API_KEY");
+    expect(readme).not.toContain("GEMINI_API_KEY");
+    expect(readme).not.toContain("require_vendors");
   });
 });

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -30,6 +30,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("api_base: http://host.docker.internal:8100/v1");
     expect(workflow).toContain("api_base: http://host.docker.internal:8100");
     expect(workflow).toContain("--add-host=host.docker.internal:host-gateway");
+    expect(workflow.match(/curl -fsS --connect-timeout 1 --max-time 3/g)).toHaveLength(2);
     expect(workflow).toContain("Run Pi CLI smoke");
     expect(workflow).toContain("./node_modules/.bin/pi -e ./dist/index.js --list-models litellm");
     expect(workflow).toContain("--provider litellm");

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -21,11 +21,19 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("Start VidaiMock");
     expect(workflow).toContain("Wait for VidaiMock");
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
-    expect(workflow).toContain("LITELLM_SMOKE_MODEL: vidaimock-openai");
+    expect(workflow).toContain("LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude");
+    expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL: vidaimock-openai");
+    expect(workflow).toContain("model_name: vidaimock-openai");
+    expect(workflow).toContain("model_name: anthropic/vidaimock-claude");
     expect(workflow).toContain("model: openai/gpt-4o-mini");
+    expect(workflow).toContain("model: anthropic/claude-3-5-sonnet");
     expect(workflow).toContain("api_base: http://host.docker.internal:8100/v1");
+    expect(workflow).toContain("api_base: http://host.docker.internal:8100");
     expect(workflow).toContain("--add-host=host.docker.internal:host-gateway");
-    expect(workflow).toContain("LITELLM_SMOKE_MODELS: $" + "{{ env.LITELLM_SMOKE_MODEL }}");
+    expect(workflow).toContain("Run Pi CLI smoke");
+    expect(workflow).toContain("./node_modules/.bin/pi -e ./dist/index.js --list-models litellm");
+    expect(workflow).toContain("--provider litellm");
+    expect(workflow).toContain('--model "$LITELLM_CLI_SMOKE_MODEL"');
 
     expect(workflow).not.toContain("models: read");
     expect(workflow).not.toContain("GH_MODELS_SMOKE_MODEL");
@@ -33,6 +41,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).not.toContain("ANTHROPIC_API_KEY");
     expect(workflow).not.toContain("GEMINI_API_KEY");
     expect(workflow).not.toContain("require_vendors");
+    expect(workflow).not.toContain("model_name: kimi-vidaimock");
   });
 
   it("documents the mocked smoke workflow without provider secrets", () => {
@@ -42,6 +51,9 @@ describe("LiteLLM smoke workflow", () => {
     expect(readme).toContain("VidaiMock");
     expect(readme).toContain("does not call real LLM APIs");
     expect(readme).toContain("No provider API keys or GitHub Models permission are required");
+    expect(readme).toContain("OpenAI-compatible and Anthropic routes");
+    expect(readme).toContain("non-interactive Pi CLI smoke");
+    expect(readme).not.toContain("Kimi-shaped routes");
 
     expect(readme).not.toContain("## Real LiteLLM smoke workflow");
     expect(readme).not.toContain("OPENAI_API_KEY");


### PR DESCRIPTION
## Summary

- Replace real LLM smoke routes with local VidaiMock upstreams behind LiteLLM.
- Cover two executable mocked upstream protocols: OpenAI-compatible chat completions and Anthropic messages through LiteLLM.
- Add a non-interactive Pi CLI smoke for extension loading, model listing, and a real `-p` completion without opening the TUI.
- Add callback-level `/login litellm` test coverage for prompts, discovery, cache writes, and progress output.
- Update README documentation and workflow regression coverage for the mocked smoke path.

## Notes

Kimi/Moonshot remains covered at the unit compat layer. It is not included in the end-to-end VidaiMock workflow because mapping a Kimi-shaped model to VidaiMock through LiteLLM is not a faithful provider mock: LiteLLM rejects Pi's Kimi compatibility payload unless `drop_params` is enabled.

## Validation

- `npm run check`
- `actionlint .github/workflows/litellm-smoke.yml`
- Local end-to-end smoke through a real LiteLLM Docker container with VidaiMock upstreams: `Source: model_info`, `Discovered 2 models`, `Smoke OK: vidaimock-openai`, `Smoke OK: anthropic/vidaimock-claude`.
- Local non-interactive Pi CLI smoke: `--list-models litellm` showed both VidaiMock-backed models, and `-p` through `vidaimock-openai` returned `This is a mock response from VidaiMock. Model: openai`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated smoke testing workflow documentation to clarify it uses mocked LLM services and no longer requires provider API keys or GitHub Models permissions.

* **Chores**
  * Refactored smoke testing infrastructure to use mock services instead of real LLM APIs.
  * Updated tests to validate the new mocked workflow behavior and OAuth login flow with model discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/balcsida/pi-provider-litellm/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->