### PR TITLE
[codex] fix Anthropic cache compat for routed aliases

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -47,7 +47,7 @@ export function normalizeBaseUrl(input: string): string {
 // `google/claude-sonnet-4-6`, `opus-4.7`, `sonnet-4.6`, `haiku-4.5`). Without
 // the `cacheControlFormat: "anthropic"` flag, pi never relays cache_control
 // markers through the proxy, so prompt caching silently no-ops on Claude models.
-const ANTHROPIC_MODEL_PATTERN = /(?:^|[-_/.:])(anthropic\/|claude|opus|sonnet|haiku)/i;
+const ANTHROPIC_MODEL_PATTERN = /(?:^|[-_/.:])(?:anthropic\/|(?:claude|opus|sonnet|haiku)(?=$|[-_/.:]))/i;
 const MOONSHOT_MODEL_PATTERN = /^(moonshotai\/|moonshot\/|kimi[-/])/i;
 const FORCED_THINKING_MODEL_PATTERN = /(?:^|[-/])thinking(?:[-/]|$)/i;
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -42,12 +42,12 @@ export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
 }
 
-// Matches both the conventional `anthropic/...` prefix and bare aliases that
+// Matches both the conventional `anthropic/...` prefix and aliases that
 // LiteLLM deployments commonly assign to Anthropic-backed routes (e.g.
-// `opus-4.7`, `sonnet-4.6`, `haiku-4.5`, `claude-3-5-sonnet`). Without the
-// `cacheControlFormat: "anthropic"` flag, pi never relays cache_control markers
-// through the proxy, so prompt caching silently no-ops on Claude models.
-const ANTHROPIC_MODEL_PATTERN = /^(anthropic\/|claude|opus|sonnet|haiku)/i;
+// `google/claude-sonnet-4-6`, `opus-4.7`, `sonnet-4.6`, `haiku-4.5`). Without
+// the `cacheControlFormat: "anthropic"` flag, pi never relays cache_control
+// markers through the proxy, so prompt caching silently no-ops on Claude models.
+const ANTHROPIC_MODEL_PATTERN = /(?:^|[-_/.:])(anthropic\/|claude|opus|sonnet|haiku)/i;
 const MOONSHOT_MODEL_PATTERN = /^(moonshotai\/|moonshot\/|kimi[-/])/i;
 const FORCED_THINKING_MODEL_PATTERN = /(?:^|[-/])thinking(?:[-/]|$)/i;
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -84,6 +84,11 @@ describe("buildCompat", () => {
     });
   });
 
+  it("does not match non-Anthropic tokens that start with Anthropic family names", () => {
+    expect(buildCompat("openai/sonnetic-gpt")).toEqual({ supportsStore: false });
+    expect(buildCompat("vendor/opusflow")).toEqual({ supportsStore: false });
+  });
+
   it("matches case-insensitively", () => {
     expect(buildCompat("Opus-4.7")).toEqual({
       supportsStore: false,

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -77,6 +77,13 @@ describe("buildCompat", () => {
     }
   });
 
+  it("adds cacheControlFormat for routed Anthropic aliases", () => {
+    expect(buildCompat("google/claude-sonnet-4-6")).toEqual({
+      supportsStore: false,
+      cacheControlFormat: "anthropic",
+    });
+  });
+
   it("matches case-insensitively", () => {
     expect(buildCompat("Opus-4.7")).toEqual({
       supportsStore: false,


### PR DESCRIPTION
## Summary

Fixes Anthropic prompt-cache compatibility detection for LiteLLM-routed aliases such as `google/claude-sonnet-4-6`.

## Root cause

`ANTHROPIC_MODEL_PATTERN` only matched Anthropic-family names at the beginning of the model id. LiteLLM deployments can expose Anthropic-backed routes under another provider prefix, so those aliases received only `{ supportsStore: false }` and Pi did not forward Anthropic cache-control markers.

## Changes

- Match Anthropic-family tokens after common alias separators as well as at the start of the model id.
- Add a regression test for `google/claude-sonnet-4-6`.

## Validation

- `npm run check`

Fixes #20