### PR TITLE
Document release workflow and bump v1.2.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,32 +6,54 @@
 - Source is TypeScript ESM under `src/`; tests are Vitest specs under `tests/`.
 - Build output is `dist/`; do not edit generated output by hand.
 - The package entrypoint is `./dist/index.js`, and the Pi extension registration comes from `package.json` `pi.extensions`.
+- Node support starts at `>=22.19.0`; GitHub workflows currently run Node `24.16.0`.
 
 ## Commands
 
+- Use `npm ci` when reinstalling dependencies from the lockfile.
 - Use `npm test` for the full test suite.
 - Use `npm test -- tests/<file>.test.ts` for a focused Vitest run.
 - Use `npm run check` before committing code changes; it runs Biome, typecheck, and tests.
-- Use `npm run build` when changing exported/runtime code.
+- Use `npm run clean && npm run build` when changing exported/runtime code.
+- Use `npm run supply-chain:guard` and `npm pack --dry-run` when package contents, dependency policy, or release packaging change.
 
 ## Discovery And Credentials
 
 - Model discovery lives in `src/discover.ts`.
 - Prefer `/model/info` for rich metadata; fallback to `/v1/models` only on 401, 403, or 404.
+- The `/v1/models` fallback enriches metadata from the Pi catalog and `https://models.dev/api.json`; keep fallback metadata tests current.
 - Keep `LITELLM_OFFLINE` and `LITELLM_DISCOVERY_TIMEOUT_MS` behavior compatible with README docs.
 - Stored Pi `/login litellm` credentials take precedence over `LITELLM_API_KEY`.
+- Cache data is stored as `litellm-models.json` under the Pi agent dir with a keyed API-key fingerprint and a 24-hour stale refresh window.
 
 ## LiteLLM Request Hooks
 
 - `before_provider_request` is a global Pi hook. Only mutate provider payloads when `ctx.model?.provider === "litellm"`.
 - Do not add user-facing flags or environment variables to hide provider-scoping bugs.
 - `litellm_session_id` is optional LiteLLM session grouping metadata. If a LiteLLM server rejects it for LiteLLM-routed requests, keep Pi requests working first and document the admin-facing recommendation separately.
+- Kimi/Moonshot responses may include `<think>` text; Pi-visible normalization happens in the `message_end` hook and should stay covered by feature tests.
 
 ## Compatibility Rules
 
 - Provider-specific request compatibility belongs in discovered model `compat` metadata, not broad runtime mutation.
 - Kimi/Moonshot-style models are handled in `buildCompat()`; keep regression tests with model discovery changes.
 - Anthropic-backed aliases need `cacheControlFormat: "anthropic"` so Pi forwards prompt-cache markers through LiteLLM.
+
+## Smoke And CI
+
+- CI runs `npm ci`, `npm run check`, `npm run clean`, `npm run build`, and `npm pack --dry-run`.
+- `.github/workflows/litellm-smoke.yml` uses VidaiMock plus a real LiteLLM proxy; it should not require real provider API keys.
+- Keep smoke readiness probes bounded with `curl --connect-timeout 1 --max-time 3`.
+- `scripts/smoke.ts` and `scripts/smoke-runner.ts` exercise discovery and `/v1/chat/completions` through the proxy.
+- The non-interactive Pi CLI smoke uses `./dist/index.js`, so runtime changes need a fresh build before running it.
+
+## Release And Packaging
+
+- The release workflow is tag-driven for `v*.*.*`; it publishes with `npm publish --access public --provenance` and creates a GitHub release.
+- Local release prep should keep `package.json` and `package-lock.json` versions in sync, build `dist/`, run package checks, and create only local commits/tags unless the user explicitly overrides the no-push rule.
+- Verify released state with `gh release view <tag>` and `npm view pi-provider-litellm version dist-tags --json` after the user pushes the tag.
+- The npm package should stay limited to `dist`, `README.md`, and `LICENSE`.
+- `scripts/supply-chain-guard.ts` rejects install lifecycle scripts, runtime dependencies, non-registry specs, non-registry lockfile URLs, and unexpected package files; update tests before changing that policy.
 
 ## Package Metadata
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ pi -e npm:pi-provider-litellm
 ```bash
 git clone https://github.com/balcsida/pi-provider-litellm.git ~/.pi/agent/extensions/pi-provider-litellm
 cd ~/.pi/agent/extensions/pi-provider-litellm
-npm install
-npm run build
+npm ci
+npm run clean && npm run build
 ```
 
 </details>
@@ -71,6 +71,33 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes OpenAI-compatible and Anthropic routes whose upstreams are served by VidaiMock, then this extension's smoke runner discovers those models through LiteLLM and sends `/v1/chat/completions` requests through the proxy.
 
 This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` so extension loading, model discovery, and a real completion path are covered without opening the TUI.
+
+## Development
+
+This package requires Node.js `>=22.19.0`. CI currently uses Node `24.16.0`.
+
+```bash
+npm ci
+npm run check
+npm run clean && npm run build
+```
+
+`npm run check` runs Biome, type checking, and the Vitest suite. Runtime changes must be built before local Pi smoke checks because the extension entrypoint is `./dist/index.js`.
+
+Before changing package contents or dependency policy, also run:
+
+```bash
+npm run supply-chain:guard
+npm pack --dry-run
+```
+
+The published npm package should contain only `dist`, `README.md`, and `LICENSE`.
+
+## Release
+
+Releases are driven by semver tags named `v*.*.*`. The GitHub release workflow installs from the lockfile, runs the checks, builds `dist`, verifies the package tarball, publishes to npm with provenance, and creates a GitHub release.
+
+Before tagging a release, keep `package.json` and `package-lock.json` versions in sync and verify the dry-run package contents.
 
 ## Slash commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- update agent notes with current smoke, package, and release guidance
- document development, packaging, and release workflow in the README
- bump package metadata to 1.2.3 for the next patch release

## Validation
- npm run check
- npm run clean && npm run build
- npm run supply-chain:guard
- npm pack --dry-run