### PR TITLE
chore: support Pi 0.76 package peers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",
-        "@earendil-works/pi-ai": "^0.75.4",
-        "@earendil-works/pi-coding-agent": "^0.75.4",
+        "@earendil-works/pi-ai": "^0.76.0",
+        "@earendil-works/pi-coding-agent": "^0.76.0",
         "@types/node": "^25.9.1",
         "@typescript/native-preview": "7.0.0-dev.20260519.1",
         "shx": "^0.4.0",
@@ -23,8 +23,8 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "^0.75.4",
-        "@earendil-works/pi-coding-agent": "^0.75.4"
+        "@earendil-works/pi-ai": ">=0.75.4 <0.77.0",
+        "@earendil-works/pi-coding-agent": ">=0.75.4 <0.77.0"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -650,9 +650,9 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.4.tgz",
-      "integrity": "sha512-m/w8Hh3vQ0rAycwJiJWdzkypkn4295f4eq/966lDRy8aX5sk6bgYXH8TQmL16TO7Uwc7MbJG0QoyFHgX8RqXUQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.76.0.tgz",
+      "integrity": "sha512-RO/L80iTxkK/nM2s5IVuirjH04UBsVzFfAT0qVcP/VwtDe9pjpqL+BVqb3XTyfitTD9tBo/hQuKmagN8Ep5qZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -660,6 +660,7 @@
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
@@ -694,17 +695,32 @@
         }
       }
     },
+    "node_modules/@earendil-works/pi-ai/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.4.tgz",
-      "integrity": "sha512-Fb+FRo08b5H9pYKbQJ708/5OKL0+K/yclhfCMEhrBzSPTZZ4c85nY1YsBo4qwL20ohBMlBezHMRuHzcJ1ylEoQ==",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.76.0.tgz",
+      "integrity": "sha512-vTnKbgw1rDQq2MD+vcWgyYvEPMV4mMb07tZZMS7FOvlS5t/jzIX9smC+k97YGpfl8dT+L9Uj+MYyvYSBXVaEHw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.75.4",
-        "@earendil-works/pi-ai": "^0.75.4",
-        "@earendil-works/pi-tui": "^0.75.4",
+        "@earendil-works/pi-agent-core": "^0.76.0",
+        "@earendil-works/pi-ai": "^0.76.0",
+        "@earendil-works/pi-tui": "^0.76.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1193,12 +1209,12 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.4.tgz",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.76.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.4",
+        "@earendil-works/pi-ai": "^0.76.0",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1208,8 +1224,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.4.tgz",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.76.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1217,6 +1233,7 @@
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
         "@mistralai/mistralai": "2.2.1",
+        "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
@@ -1231,8 +1248,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.4.tgz",
+      "version": "0.76.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.76.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1241,9 +1258,6 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "koffi": "2.16.2"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
@@ -2161,18 +2175,6 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "node": ">=22.19.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": "^0.75.4",
-    "@earendil-works/pi-coding-agent": "^0.75.4"
+    "@earendil-works/pi-ai": ">=0.75.4 <0.77.0",
+    "@earendil-works/pi-coding-agent": ">=0.75.4 <0.77.0"
   },
   "overrides": {
     "basic-ftp": "6.0.1",
@@ -64,8 +64,8 @@
     "protobufjs": "8.2.1"
   },
   "devDependencies": {
-    "@earendil-works/pi-ai": "^0.75.4",
-    "@earendil-works/pi-coding-agent": "^0.75.4",
+    "@earendil-works/pi-ai": "^0.76.0",
+    "@earendil-works/pi-coding-agent": "^0.76.0",
     "@biomejs/biome": "^2.4.15",
     "@types/node": "^25.9.1",
     "@typescript/native-preview": "7.0.0-dev.20260519.1",

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -19,6 +19,17 @@ describe("package gallery metadata", () => {
   });
 });
 
+describe("pi package compatibility", () => {
+  it("allows the supported 0.75 and 0.76 pi package lines", async () => {
+    const { default: manifest } = await import("../package.json", {
+      with: { type: "json" },
+    });
+
+    expect(manifest.peerDependencies["@earendil-works/pi-ai"]).toBe(">=0.75.4 <0.77.0");
+    expect(manifest.peerDependencies["@earendil-works/pi-coding-agent"]).toBe(">=0.75.4 <0.77.0");
+  });
+});
+
 describe("dependency security overrides", () => {
   it("keeps vulnerable transitive dependencies above alerted ranges", async () => {
     const lockfile = JSON.parse(await readFile("package-lock.json", "utf8")) as {


### PR DESCRIPTION
## Summary

- widen the Pi peer dependency range to allow the supported 0.75 and 0.76 package lines
- update development Pi package dependencies and the lockfile to 0.76.0
- add a package metadata regression test for the supported Pi peer range

## Why

Pi 0.76.0 is the current released Pi package line. The extension runtime code remains compatible, but the previous `^0.75.4` peer dependency range excluded 0.76.0.

## Validation

- `npm test -- tests/package.test.ts` (red before the manifest change, green after)
- `npm run check`
- `npm run clean && npm run build`
- `npm run supply-chain:guard`
- `npm pack --dry-run`
- Pi 0.76.0 CLI loaded `dist/index.js` and listed a mocked LiteLLM model from `/model/info`
