### PR TITLE
[codex] add LiteLLM host configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,19 @@ pi install npm:pi-provider-litellm
 
 Pi fetches the package from npm and registers it. Add `-l` to install into project settings (`.pi/settings.json`) instead of global.
 
-After installing, you can pass the LiteLLM host when starting pi:
+Pi's package installer currently only accepts package-manager options such as `-l`; extension-specific install flags are rejected before this package is loaded. To persist the LiteLLM host in Pi config, use the package object form in `~/.pi/agent/settings.json` or `.pi/settings.json`:
 
-```bash
-pi --litellm-host https://litellm.your-domain.com
+```json
+{
+  "packages": [
+    {
+      "source": "npm:pi-provider-litellm",
+      "config": {
+        "litellmHost": "litellm.your-domain.com"
+      }
+    }
+  ]
+}
 ```
 
 To try it without installing (one-off, current run only):
@@ -54,22 +63,41 @@ Inside pi:
 
 You'll be prompted for the base URL and API key. Credentials are persisted to `~/.pi/agent/auth.json`.
 
-### Option B — environment variables
+### Option B — saved package config
+
+Add `config.litellmHost` to this package entry in `~/.pi/agent/settings.json` or `.pi/settings.json`:
+
+```json
+{
+  "packages": [
+    {
+      "source": "npm:pi-provider-litellm",
+      "config": {
+        "litellmHost": "litellm.your-domain.com"
+      }
+    }
+  ]
+}
+```
+
+`litellmHost` accepts URLs with or without a scheme and with or without a trailing `/v1`. Bare hosts default to `https://`. `litellmBaseUrl` is also supported as an alias.
+
+### Option C — environment variables
 
 ```bash
 export LITELLM_BASE_URL="https://litellm.your-domain.com"
 export LITELLM_API_KEY="sk-..."
 ```
 
-Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the environment key is used when no saved credential exists. `LITELLM_BASE_URL` is used when no saved login base URL exists.
+Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the environment key is used when no saved credential exists. `LITELLM_BASE_URL` is used when no CLI host, saved package host, or saved login base URL exists.
 
-### Option C — CLI host parameter
+### Option D — runtime CLI host parameter
 
 ```bash
 pi --litellm-host https://litellm.your-domain.com
 ```
 
-`--litellm-host` supplies the LiteLLM base URL for the current pi run and accepts URLs with or without a trailing `/v1`. `--litellm-base-url` is also supported as an alias. The CLI host parameter takes precedence over saved login base URLs and `LITELLM_BASE_URL`; API keys still come from `/login litellm` or `LITELLM_API_KEY`.
+`--litellm-host` supplies the LiteLLM base URL for the current pi run. `--litellm-base-url` is also supported as an alias. The CLI host parameter takes precedence over saved package host config, saved login base URLs, and `LITELLM_BASE_URL`; API keys still come from `/login litellm` or `LITELLM_API_KEY`.
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,22 @@ pi install npm:pi-provider-litellm
 
 Pi fetches the package from npm and registers it. Add `-l` to install into project settings (`.pi/settings.json`) instead of global.
 
+After installing, you can pass the LiteLLM host when starting pi:
+
+```bash
+pi --litellm-host https://litellm.your-domain.com
+```
+
 To try it without installing (one-off, current run only):
 
 ```bash
 pi -e npm:pi-provider-litellm
+```
+
+With a one-off extension run, pass the host after the extension source:
+
+```bash
+pi -e npm:pi-provider-litellm --litellm-host https://litellm.your-domain.com
 ```
 
 <details>
@@ -50,6 +62,14 @@ export LITELLM_API_KEY="sk-..."
 ```
 
 Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the environment key is used when no saved credential exists. `LITELLM_BASE_URL` is used when no saved login base URL exists.
+
+### Option C — CLI host parameter
+
+```bash
+pi --litellm-host https://litellm.your-domain.com
+```
+
+`--litellm-host` supplies the LiteLLM base URL for the current pi run and accepts URLs with or without a trailing `/v1`. `--litellm-base-url` is also supported as an alias. The CLI host parameter takes precedence over saved login base URLs and `LITELLM_BASE_URL`; API keys still come from `/login litellm` or `LITELLM_API_KEY`.
 
 ## Use
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -39,7 +39,9 @@ interface ModelsDevModel {
 type ModelsDevResponse = Record<string, { models?: Record<string, ModelsDevModel> }>;
 
 export function normalizeBaseUrl(input: string): string {
-  return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
+  const trimmed = input.trim();
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  return withScheme.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
 }
 
 // Matches both the conventional `anthropic/...` prefix and aliases that

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
-import { getSessionIdFromFile } from "./litellm.js";
+import { CLI_BASE_URL_FLAG, CLI_HOST_FLAG, getCliBaseUrl, getSessionIdFromFile } from "./litellm.js";
 import type { AuthFileEntry, CacheFile, DiscoveryOptions, DiscoveryResult, ResolvedCredentials } from "./types.js";
 
 const PROVIDER_NAME = "litellm";
@@ -41,6 +41,7 @@ async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
 
 async function resolveCredentials(): Promise<ResolvedCredentials> {
   const entry = await readAuthEntry();
+  const cliBase = getCliBaseUrl();
   const envBase = process.env[ENV_BASE_URL]?.trim();
   const envKey = process.env[ENV_API_KEY]?.trim();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
@@ -50,7 +51,7 @@ async function resolveCredentials(): Promise<ResolvedCredentials> {
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
-  const rawBase = authBase || envBase;
+  const rawBase = cliBase || authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
     apiKey: authKey || envKey || undefined,
@@ -227,6 +228,15 @@ function normalizeThinkTags(message: AssistantMessage): AssistantMessage | undef
 }
 
 export default async function (pi: ExtensionAPI): Promise<void> {
+  pi.registerFlag(CLI_HOST_FLAG, {
+    description: "LiteLLM proxy host URL (alias for --litellm-base-url)",
+    type: "string",
+  });
+  pi.registerFlag(CLI_BASE_URL_FLAG, {
+    description: "LiteLLM proxy base URL",
+    type: "string",
+  });
+
   const creds = await resolveCredentials();
   const cache = await readCache(getCachePath());
   const fp = creds.apiKey ? fingerprint(creds.apiKey) : undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,13 @@ import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
-import { CLI_BASE_URL_FLAG, CLI_HOST_FLAG, getCliBaseUrl, getSessionIdFromFile } from "./litellm.js";
+import {
+  CLI_BASE_URL_FLAG,
+  CLI_HOST_FLAG,
+  getCliBaseUrl,
+  getConfiguredBaseUrl,
+  getSessionIdFromFile,
+} from "./litellm.js";
 import type { AuthFileEntry, CacheFile, DiscoveryOptions, DiscoveryResult, ResolvedCredentials } from "./types.js";
 
 const PROVIDER_NAME = "litellm";
@@ -42,6 +48,7 @@ async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
 async function resolveCredentials(): Promise<ResolvedCredentials> {
   const entry = await readAuthEntry();
   const cliBase = getCliBaseUrl();
+  const configBase = await getConfiguredBaseUrl();
   const envBase = process.env[ENV_BASE_URL]?.trim();
   const envKey = process.env[ENV_API_KEY]?.trim();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
@@ -51,7 +58,7 @@ async function resolveCredentials(): Promise<ResolvedCredentials> {
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
-  const rawBase = cliBase || authBase || envBase;
+  const rawBase = cliBase || configBase || authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
     apiKey: authKey || envKey || undefined,

--- a/src/litellm.ts
+++ b/src/litellm.ts
@@ -10,6 +10,8 @@ export const ENV_BASE_URL = "LITELLM_BASE_URL";
 export const ENV_API_KEY = "LITELLM_API_KEY";
 export const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
 export const ENV_OFFLINE = "LITELLM_OFFLINE";
+export const CLI_HOST_FLAG = "litellm-host";
+export const CLI_BASE_URL_FLAG = "litellm-base-url";
 export const DEFAULT_TIMEOUT_MS = 5000;
 export const LOGIN_TIMEOUT_MS = 10_000;
 export const CACHE_FILENAME = "litellm-models.json";
@@ -32,8 +34,36 @@ async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
   }
 }
 
+export function getCliFlagValue(name: string, argv = process.argv): string | undefined {
+  const flag = `--${name}`;
+  const prefix = `${flag}=`;
+  let value: string | undefined;
+
+  for (let index = 2; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--") break;
+    if (arg.startsWith(prefix)) {
+      value = arg.slice(prefix.length);
+      continue;
+    }
+    if (arg !== flag) continue;
+
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("-")) continue;
+    value = next;
+    index++;
+  }
+
+  return value?.trim() || undefined;
+}
+
+export function getCliBaseUrl(): string | undefined {
+  return getCliFlagValue(CLI_HOST_FLAG) ?? getCliFlagValue(CLI_BASE_URL_FLAG);
+}
+
 export async function resolveCredentials(): Promise<ResolvedCredentials> {
   const entry = await readAuthEntry();
+  const cliBase = getCliBaseUrl();
   const envBase = process.env[ENV_BASE_URL]?.trim();
   const envKey = process.env[ENV_API_KEY]?.trim();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
@@ -43,7 +73,7 @@ export async function resolveCredentials(): Promise<ResolvedCredentials> {
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
-  const rawBase = authBase || envBase;
+  const rawBase = cliBase || authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
     apiKey: authKey || envKey || undefined,

--- a/src/litellm.ts
+++ b/src/litellm.ts
@@ -15,6 +15,17 @@ export const CLI_BASE_URL_FLAG = "litellm-base-url";
 export const DEFAULT_TIMEOUT_MS = 5000;
 export const LOGIN_TIMEOUT_MS = 10_000;
 export const CACHE_FILENAME = "litellm-models.json";
+const PACKAGE_NAME = "pi-provider-litellm";
+const PROJECT_CONFIG_DIR = ".pi";
+
+type PackageSettingsEntry = {
+  source?: unknown;
+  config?: unknown;
+};
+
+type SettingsFile = {
+  packages?: unknown;
+};
 
 export function getAuthPath(): string {
   return join(getAgentDir(), "auth.json");
@@ -22,6 +33,14 @@ export function getAuthPath(): string {
 
 export function getCachePath(): string {
   return join(getAgentDir(), CACHE_FILENAME);
+}
+
+function getGlobalSettingsPath(): string {
+  return join(getAgentDir(), "settings.json");
+}
+
+function getProjectSettingsPath(): string {
+  return join(process.cwd(), PROJECT_CONFIG_DIR, "settings.json");
 }
 
 async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
@@ -61,9 +80,49 @@ export function getCliBaseUrl(): string | undefined {
   return getCliFlagValue(CLI_HOST_FLAG) ?? getCliFlagValue(CLI_BASE_URL_FLAG);
 }
 
+function getNpmPackageName(source: string): string {
+  const spec = source.startsWith("npm:") ? source.slice("npm:".length).trim() : source.trim();
+  const match = spec.match(/^(@?[^@]+(?:\/[^@]+)?)(?:@.+)?$/);
+  return match?.[1] ?? spec;
+}
+
+function isLiteLLMPackageSource(source: unknown): boolean {
+  return typeof source === "string" && getNpmPackageName(source) === PACKAGE_NAME;
+}
+
+function getPackageConfigBaseUrl(entry: PackageSettingsEntry): string | undefined {
+  if (!isLiteLLMPackageSource(entry.source)) return undefined;
+  if (typeof entry.config !== "object" || entry.config === null) return undefined;
+  const config = entry.config as Record<string, unknown>;
+  const raw = config.litellmHost ?? config.litellmBaseUrl;
+  return typeof raw === "string" ? raw.trim() || undefined : undefined;
+}
+
+async function readPackageConfigBaseUrl(path: string): Promise<string | undefined> {
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as SettingsFile;
+    if (!Array.isArray(parsed.packages)) return undefined;
+    for (const pkg of parsed.packages) {
+      if (typeof pkg !== "object" || pkg === null || Array.isArray(pkg)) continue;
+      const baseUrl = getPackageConfigBaseUrl(pkg as PackageSettingsEntry);
+      if (baseUrl) return baseUrl;
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+export async function getConfiguredBaseUrl(): Promise<string | undefined> {
+  return (
+    (await readPackageConfigBaseUrl(getProjectSettingsPath())) ?? readPackageConfigBaseUrl(getGlobalSettingsPath())
+  );
+}
+
 export async function resolveCredentials(): Promise<ResolvedCredentials> {
   const entry = await readAuthEntry();
   const cliBase = getCliBaseUrl();
+  const configBase = await getConfiguredBaseUrl();
   const envBase = process.env[ENV_BASE_URL]?.trim();
   const envKey = process.env[ENV_API_KEY]?.trim();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
@@ -73,7 +132,7 @@ export async function resolveCredentials(): Promise<ResolvedCredentials> {
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
-  const rawBase = cliBase || authBase || envBase;
+  const rawBase = cliBase || configBase || authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
     apiKey: authKey || envKey || undefined,

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -18,6 +18,11 @@ describe("normalizeBaseUrl", () => {
     expect(normalizeBaseUrl("https://x.example.com///")).toBe("https://x.example.com");
   });
 
+  it("defaults bare hosts to https", () => {
+    expect(normalizeBaseUrl("x.example.com")).toBe("https://x.example.com");
+    expect(normalizeBaseUrl("x.example.com/v1")).toBe("https://x.example.com");
+  });
+
   it("strips a single trailing /v1 suffix", () => {
     expect(normalizeBaseUrl("https://x.example.com/v1")).toBe("https://x.example.com");
     expect(normalizeBaseUrl("https://x.example.com/v1/")).toBe("https://x.example.com");

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -17,12 +17,22 @@ type TestCommand = {
   handler: (args: string[], ctx: { ui: { notify: (message: string, type: string) => void } }) => Promise<void> | void;
 };
 
+type TestFlag = {
+  description?: string;
+  type: "boolean" | "string";
+  default?: boolean | string;
+};
+
 type TestPi = {
   providers: Array<{ name: string; config: TestProviderConfig }>;
   commands: Map<string, TestCommand>;
+  flags: Map<string, TestFlag>;
+  flagValues: Map<string, boolean | string>;
   handlers: Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>;
   registerProvider(name: string, config: TestProviderConfig): void;
   registerCommand(name: string, command: TestCommand): void;
+  registerFlag(name: string, flag: TestFlag): void;
+  getFlag(name: string): boolean | string | undefined;
   on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
 };
 
@@ -65,12 +75,21 @@ function createPi(): TestPi {
   return {
     providers: [],
     commands: new Map(),
+    flags: new Map(),
+    flagValues: new Map(),
     handlers: new Map(),
     registerProvider(name: string, config: TestProviderConfig) {
       this.providers.push({ name, config });
     },
     registerCommand(name: string, command: TestCommand) {
       this.commands.set(name, command);
+    },
+    registerFlag(name: string, flag: TestFlag) {
+      this.flags.set(name, flag);
+      if (flag.default !== undefined && !this.flagValues.has(name)) this.flagValues.set(name, flag.default);
+    },
+    getFlag(name: string) {
+      return this.flagValues.get(name);
     },
     on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
       this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const ENV_KEYS = ["LITELLM_BASE_URL", "LITELLM_API_KEY", "LITELLM_DISCOVERY_TIMEOUT_MS", "STORED_LITELLM_KEY"];
 const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+const ORIGINAL_ARGV = [...process.argv];
 
 type TestProviderConfig = {
   baseUrl?: string;
@@ -21,6 +22,12 @@ type TestProviderConfig = {
 type TestCommand = {
   description: string;
   handler: (args: string[], ctx: { ui: { notify: (message: string, type: string) => void } }) => Promise<void> | void;
+};
+
+type TestFlag = {
+  description?: string;
+  type: "boolean" | "string";
+  default?: boolean | string;
 };
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -73,6 +80,15 @@ function createPi(): TestPi {
     registerCommand(name: string, command: TestCommand) {
       this.commands.set(name, command);
     },
+    flags: new Map(),
+    flagValues: new Map(),
+    registerFlag(name: string, flag: TestFlag) {
+      this.flags.set(name, flag);
+      if (flag.default !== undefined && !this.flagValues.has(name)) this.flagValues.set(name, flag.default);
+    },
+    getFlag(name: string) {
+      return this.flagValues.get(name);
+    },
     on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
       this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
     },
@@ -82,9 +98,13 @@ function createPi(): TestPi {
 type TestPi = {
   providers: Array<{ name: string; config: TestProviderConfig }>;
   commands: Map<string, TestCommand>;
+  flags: Map<string, TestFlag>;
+  flagValues: Map<string, boolean | string>;
   handlers: Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>;
   registerProvider(name: string, config: TestProviderConfig): void;
   registerCommand(name: string, command: TestCommand): void;
+  registerFlag(name: string, flag: TestFlag): void;
+  getFlag(name: string): boolean | string | undefined;
   on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
 };
 
@@ -94,6 +114,7 @@ afterEach(() => {
     if (original === undefined) process.env[key] = undefined;
     else process.env[key] = original;
   }
+  process.argv = [...ORIGINAL_ARGV];
   vi.restoreAllMocks();
   vi.resetModules();
   vi.unmock("@earendil-works/pi-coding-agent");
@@ -122,6 +143,27 @@ describe("extension startup", () => {
     await extension(createPi());
 
     expect(seenAuthHeaders).toEqual(["Bearer stored-key"]);
+  });
+
+  it("uses the LiteLLM host CLI parameter before LITELLM_BASE_URL", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://env-litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    process.argv = [...ORIGINAL_ARGV, "--litellm-host", " https://cli-litellm.example.com/v1 "];
+    const seenUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      seenUrls.push(String(input));
+      return jsonResponse(200, {
+        data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+      });
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(seenUrls).toEqual(["https://cli-litellm.example.com/model/info"]);
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://cli-litellm.example.com/v1");
   });
 
   it("does not fetch on refresh when discovery timeout is zero", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -166,6 +166,38 @@ describe("extension startup", () => {
     expect(pi.providers[0]?.config.baseUrl).toBe("https://cli-litellm.example.com/v1");
   });
 
+  it("uses the saved package LiteLLM host before LITELLM_BASE_URL", async () => {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "settings.json"),
+      JSON.stringify({
+        packages: [
+          {
+            source: "npm:pi-provider-litellm",
+            config: { litellmHost: " settings-litellm.example.com/v1 " },
+          },
+        ],
+      }),
+      "utf8",
+    );
+    process.env.LITELLM_BASE_URL = "https://env-litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    const seenUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      seenUrls.push(String(input));
+      return jsonResponse(200, {
+        data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+      });
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(seenUrls).toEqual(["https://settings-litellm.example.com/model/info"]);
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://settings-litellm.example.com/v1");
+  });
+
   it("does not fetch on refresh when discovery timeout is zero", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";


### PR DESCRIPTION
## Summary

- Add runtime `--litellm-host` and `--litellm-base-url` overrides for current-run LiteLLM host selection.
- Add support for persisted package config via `packages[].config.litellmHost` or `litellmBaseUrl`, so a saved Pi settings entry can provide the LiteLLM host without environment variables.
- Normalize bare hosts such as `litellm.example.com` to `https://litellm.example.com` and continue stripping a trailing `/v1`.
- Update docs to show the saved settings object and call out that current Pi package install parsing rejects extension-specific install flags before this package can run.

## Validation

- `npm test -- tests/discover.test.ts`
- `npm test -- tests/index.test.ts`
- `npm run check`
- `npm run clean`
- `npm run build`
- `npm run supply-chain:guard`
- `npm pack --dry-run`