### PR TITLE
fix: support dynamic LiteLLM token helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 | Variable | Default | Effect |
 |---|---|---|
-| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. |
+| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. The helper is resolved per request through an internal OAuth credential so rotating/short-lived tokens are always refreshed — it is never registered as a `!command` provider key (those are cached for the process lifetime). |
 | `LITELLM_OFFLINE` | unset | If `1`, skip discovery on this start; use cache only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Discovery fetch timeout in ms; `0` to skip discovery |
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 | Variable | Default | Effect |
 |---|---|---|
+| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. |
 | `LITELLM_OFFLINE` | unset | If `1`, skip discovery on this start; use cache only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Discovery fetch timeout in ms; `0` to skip discovery |
 
@@ -117,6 +118,7 @@ If the cache is older than 24 hours, the extension refreshes it in the backgroun
 | "discovered no models" | Proxy returned an empty list — check pi's startup log for the actual response |
 | `/model/info` returning 401/403/404 | Expected behavior with virtual keys — extension falls back to `/v1/models` |
 | Discovery times out | Increase `LITELLM_DISCOVERY_TIMEOUT_MS` or set `LITELLM_OFFLINE=1` to fall back on cached models |
+| `401 Token expired` | Set `LITELLM_API_KEY_HELPER`. |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 
 | Variable | Default | Effect |
 |---|---|---|
-| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. The helper is resolved per request through an internal OAuth credential so rotating/short-lived tokens are always refreshed — it is never registered as a `!command` provider key (those are cached for the process lifetime). |
+| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. Registered as a `!command` provider key; Pi re-runs it on every request (the per-request auth path is uncached), so rotating/short-lived tokens stay fresh. |
 | `LITELLM_OFFLINE` | unset | If `1`, skip discovery on this start; use cache only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Discovery fetch timeout in ms; `0` to skip discovery |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,8 +23,8 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.75.4 <0.77.0",
-        "@earendil-works/pi-coding-agent": ">=0.75.4 <0.77.0"
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*"
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "node": ">=22.19.0"
   },
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.75.4 <0.77.0",
-    "@earendil-works/pi-coding-agent": ">=0.75.4 <0.77.0"
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*"
   },
   "overrides": {
     "basic-ftp": "6.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, OAuthCredential, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
@@ -40,6 +40,43 @@ async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * When `LITELLM_API_KEY_HELPER` is the only credential source we must not hand the `!helper`
+ * command to Pi's static provider API-key resolver: `!command` keys are documented as "cached for
+ * process lifetime", so a long-running session would keep sending the first helper-issued bearer
+ * token after it expires. Instead, seed a command-backed OAuth credential so every request resolves
+ * through the uncached OAuth `getApiKey`/`refreshToken` hooks, which re-run the helper on demand.
+ *
+ * The seeded credential starts expired (`access: ""`, `expires: 0`) so no helper is executed at
+ * startup (preserving the offline / disabled-discovery path); the first actual request triggers an
+ * OAuth refresh that runs the helper and stores a fresh token.
+ */
+async function seedHelperOAuthCredential(baseUrl: string | undefined): Promise<void> {
+  const helperCommand = getApiKeyHelperCommand();
+  if (!helperCommand) return;
+
+  const existing = await readAuthEntry();
+  if (existing?.type === "oauth" && existing.refresh === helperCommand) {
+    // A command-backed OAuth credential is already in place (seeded earlier or via `/login`); leave
+    // its current token/expiry untouched so we do not discard a freshly refreshed token or rewrite
+    // auth.json on every startup.
+    return;
+  }
+  if (existing) {
+    // Respect an explicit `/login litellm` or stored api_key entry that uses different credentials.
+    return;
+  }
+
+  const credential: OAuthCredential = {
+    type: "oauth",
+    access: "",
+    refresh: helperCommand,
+    expires: 0,
+    ...(baseUrl ? { baseUrl } : {}),
+  };
+  AuthStorage.create(getAuthPath()).set(PROVIDER_NAME, credential);
 }
 
 function cleanConfig(raw: string | undefined): string | undefined {
@@ -359,10 +396,19 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     modifyModels: modifyLiteLLMModels,
   };
 
+  // Route env-helper requests through the uncached OAuth hooks instead of the static `!command`
+  // provider key (which Pi caches for the process lifetime). Seeding is idempotent and starts the
+  // credential expired so the helper is only executed when a request actually needs a token.
+  await seedHelperOAuthCredential(creds.baseUrl);
+
   function registerProvider(baseUrl: string | undefined, models: ProviderModelConfig[]): void {
     pi.registerProvider(PROVIDER_NAME, {
       baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
-      apiKey: getApiKeyHelperCommand() ?? ENV_API_KEY,
+      // The helper command is never handed to Pi's static provider key resolver (it would be
+      // cached for the process lifetime). When a helper is configured it is resolved per request
+      // through the OAuth credential seeded above; otherwise we expose the literal
+      // `LITELLM_API_KEY` env var.
+      apiKey: ENV_API_KEY,
       api: "openai-completions",
       models,
       oauth,

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,12 +315,20 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     getDiscoveryTimeoutMs() > 0 &&
     (!cacheValid || isListModelsMode());
 
+  let credentialWarning: string | undefined;
   if (shouldFetch) {
-    creds = await resolveCredentials();
-    fp = creds.apiKeyFingerprint;
+    try {
+      creds = await resolveCredentials();
+      fp = creds.apiKeyFingerprint;
+    } catch (error) {
+      if (!cacheValid || !cache) throw error;
+      credentialWarning = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`LiteLLM: discovery failed (${credentialWarning}); using cached models.\n`);
+      models = cache.models;
+    }
   }
 
-  if (shouldFetch && creds.baseUrl && creds.apiKey && fp) {
+  if (shouldFetch && !credentialWarning && creds.baseUrl && creds.apiKey && fp) {
     const timeoutMs = getDiscoveryTimeoutMs();
     const { result, warning } = await discoverWithFallback(creds.baseUrl, creds.apiKey, {
       timeoutMs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
@@ -12,12 +13,14 @@ import type { AuthFileEntry, CacheFile, DiscoveryOptions, DiscoveryResult, Resol
 const PROVIDER_NAME = "litellm";
 const ENV_BASE_URL = "LITELLM_BASE_URL";
 const ENV_API_KEY = "LITELLM_API_KEY";
+const ENV_API_KEY_HELPER = "LITELLM_API_KEY_HELPER";
 const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
 const ENV_OFFLINE = "LITELLM_OFFLINE";
 const DEFAULT_TIMEOUT_MS = 5000;
 const LOGIN_TIMEOUT_MS = 10_000;
 const CACHE_FILENAME = "litellm-models.json";
 const CACHE_STALE_MS = 24 * 60 * 60 * 1000;
+const TOKEN_REFRESH_LEAD_MS = 5 * 60 * 1000;
 
 type RefreshResult = { models: ProviderModelConfig[]; source: string };
 
@@ -39,21 +42,80 @@ async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
   }
 }
 
-async function resolveCredentials(): Promise<ResolvedCredentials> {
+function cleanConfig(raw: string | undefined): string | undefined {
+  const trimmed = raw?.trim();
+  return trimmed && trimmed !== "undefined" ? trimmed : undefined;
+}
+
+function normalizeCommand(raw: string | undefined): string | undefined {
+  const trimmed = cleanConfig(raw);
+  if (!trimmed) return undefined;
+  return trimmed.startsWith("!") ? trimmed : `!${trimmed}`;
+}
+
+function getApiKeyHelperCommand(): string | undefined {
+  return normalizeCommand(process.env[ENV_API_KEY_HELPER]);
+}
+
+function executeApiKeyCommand(commandConfig: string): string {
+  const command = commandConfig.startsWith("!") ? commandConfig.slice(1) : commandConfig;
+  const output = execSync(command, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 10_000 }).trim();
+  if (!output) throw new Error(`LiteLLM API key helper produced no output: ${command}`);
+  return output;
+}
+
+function tokenExpiresAt(apiKey: string): number {
+  const [, payload] = apiKey.split(".");
+  if (!payload) return Number.MAX_SAFE_INTEGER;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { exp?: unknown };
+    return typeof claims.exp === "number"
+      ? Math.max(Date.now(), claims.exp * 1000 - TOKEN_REFRESH_LEAD_MS)
+      : Number.MAX_SAFE_INTEGER;
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
+}
+
+function shouldRefreshToken(apiKey: string): boolean {
+  return tokenExpiresAt(apiKey) <= Date.now();
+}
+
+function getLiteLLMApiKey(credentials: OAuthCredentials): string {
+  if (credentials.refresh.startsWith("!")) return executeApiKeyCommand(credentials.refresh);
+  const command = shouldRefreshToken(credentials.access) ? getApiKeyHelperCommand() : undefined;
+  return command ? executeApiKeyCommand(command) : credentials.access;
+}
+
+async function resolveCredentials({ executeHelpers = true } = {}): Promise<ResolvedCredentials> {
   const entry = await readAuthEntry();
-  const envBase = process.env[ENV_BASE_URL]?.trim();
-  const envKey = process.env[ENV_API_KEY]?.trim();
+  const envBase = cleanConfig(process.env[ENV_BASE_URL]);
+  const envKey = cleanConfig(process.env[ENV_API_KEY]);
+  const envHelperCommand = getApiKeyHelperCommand();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
   const authKey =
     entry?.type === "oauth"
-      ? entry.access?.trim()
+      ? (executeHelpers ? getLiteLLMApiKey(entry) : entry.access).trim()
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
+  const apiKey =
+    authKey || (executeHelpers && envHelperCommand ? executeApiKeyCommand(envHelperCommand) : undefined) || envKey;
+  const apiKeyFingerprint =
+    entry?.type === "oauth" && entry.refresh.startsWith("!")
+      ? fingerprint(entry.refresh)
+      : authKey
+        ? fingerprint(authKey)
+        : envHelperCommand
+          ? fingerprint(envHelperCommand)
+          : envKey
+            ? fingerprint(envKey)
+            : undefined;
   const rawBase = authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
-    apiKey: authKey || envKey || undefined,
+    apiKey: apiKey || undefined,
+    apiKeyFingerprint,
   };
 }
 
@@ -99,10 +161,12 @@ async function loginLiteLLM(
       placeholder: "https://litellm.example.com",
     })
   ).trim();
-  const apiKey = (await callbacks.onPrompt({ message: "Enter API key:" })).trim();
-  if (!rawBaseUrl || !apiKey) throw new Error("Both base URL and API key are required");
+  const apiKeyInput = (await callbacks.onPrompt({ message: "Enter API key:" })).trim();
+  if (!rawBaseUrl || !apiKeyInput) throw new Error("Both base URL and API key are required");
 
   const baseUrl = normalizeBaseUrl(rawBaseUrl);
+  const refresh = apiKeyInput.startsWith("!") ? apiKeyInput : "";
+  const apiKey = refresh ? executeApiKeyCommand(refresh) : apiKeyInput;
   const { models, source } = await discoverModels(baseUrl, apiKey, {
     timeoutMs: LOGIN_TIMEOUT_MS,
     signal: callbacks.signal,
@@ -110,7 +174,7 @@ async function loginLiteLLM(
 
   const cache: CacheFile = {
     baseUrl,
-    apiKeyFingerprint: fingerprint(apiKey),
+    apiKeyFingerprint: fingerprint(refresh || apiKey),
     fetchedAt: Date.now(),
     source,
     models,
@@ -121,14 +185,16 @@ async function loginLiteLLM(
 
   return {
     access: apiKey,
-    refresh: "",
-    expires: Number.MAX_SAFE_INTEGER,
+    refresh,
+    expires: tokenExpiresAt(apiKey),
     baseUrl,
   } as OAuthCredentials & { baseUrl: string };
 }
 
 async function refreshLiteLLM(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-  return credentials;
+  if (!credentials.refresh.startsWith("!")) return credentials;
+  const access = executeApiKeyCommand(credentials.refresh);
+  return { ...credentials, access, expires: tokenExpiresAt(access) };
 }
 
 function modifyLiteLLMModels(models: Model<Api>[], cred: OAuthCredentials): Model<Api>[] {
@@ -227,9 +293,9 @@ function normalizeThinkTags(message: AssistantMessage): AssistantMessage | undef
 }
 
 export default async function (pi: ExtensionAPI): Promise<void> {
-  const creds = await resolveCredentials();
+  let creds = await resolveCredentials({ executeHelpers: false });
   const cache = await readCache(getCachePath());
-  const fp = creds.apiKey ? fingerprint(creds.apiKey) : undefined;
+  let fp = creds.apiKeyFingerprint;
   let cacheFetchedAt = cache?.fetchedAt ?? 0;
 
   const cacheValid =
@@ -240,37 +306,44 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     cache.apiKeyFingerprint === fp;
 
   let models: ProviderModelConfig[] = cacheValid && cache ? cache.models : [];
-  const haveCreds = creds.baseUrl !== undefined && creds.apiKey !== undefined && fp !== undefined;
-  const shouldFetch = haveCreds && !isOffline() && (!cacheValid || isListModelsMode());
+  const shouldFetch =
+    creds.baseUrl !== undefined &&
+    fp !== undefined &&
+    !isOffline() &&
+    getDiscoveryTimeoutMs() > 0 &&
+    (!cacheValid || isListModelsMode());
+
+  if (shouldFetch) {
+    creds = await resolveCredentials();
+    fp = creds.apiKeyFingerprint;
+  }
 
   if (shouldFetch && creds.baseUrl && creds.apiKey && fp) {
     const timeoutMs = getDiscoveryTimeoutMs();
-    if (timeoutMs > 0) {
-      const { result, warning } = await discoverWithFallback(creds.baseUrl, creds.apiKey, {
-        timeoutMs,
-      });
-      if (warning) {
-        if (cacheValid && cache) {
-          process.stderr.write(`LiteLLM: discovery failed (${warning}); using cached models.\n`);
-          models = cache.models;
-        } else {
-          process.stderr.write(`LiteLLM: discovery failed (${warning}); registering provider with no models.\n`);
-          models = [];
-        }
+    const { result, warning } = await discoverWithFallback(creds.baseUrl, creds.apiKey, {
+      timeoutMs,
+    });
+    if (warning) {
+      if (cacheValid && cache) {
+        process.stderr.write(`LiteLLM: discovery failed (${warning}); using cached models.\n`);
+        models = cache.models;
       } else {
-        models = result.models;
-        const next: CacheFile = {
-          baseUrl: creds.baseUrl,
-          apiKeyFingerprint: fp,
-          fetchedAt: Date.now(),
-          source: result.source,
-          models: result.models,
-        };
-        await writeCache(getCachePath(), next);
-        cacheFetchedAt = next.fetchedAt;
-        if (isListModelsMode()) {
-          process.stderr.write(`LiteLLM: ${result.models.length} models discovered (source: ${result.source}).\n`);
-        }
+        process.stderr.write(`LiteLLM: discovery failed (${warning}); registering provider with no models.\n`);
+        models = [];
+      }
+    } else {
+      models = result.models;
+      const next: CacheFile = {
+        baseUrl: creds.baseUrl,
+        apiKeyFingerprint: fp,
+        fetchedAt: Date.now(),
+        source: result.source,
+        models: result.models,
+      };
+      await writeCache(getCachePath(), next);
+      cacheFetchedAt = next.fetchedAt;
+      if (isListModelsMode()) {
+        process.stderr.write(`LiteLLM: ${result.models.length} models discovered (source: ${result.source}).\n`);
       }
     }
   }
@@ -282,14 +355,14 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         cacheFetchedAt = next.fetchedAt;
       }),
     refreshToken: refreshLiteLLM,
-    getApiKey: (cred: OAuthCredentials) => cred.access,
+    getApiKey: getLiteLLMApiKey,
     modifyModels: modifyLiteLLMModels,
   };
 
   function registerProvider(baseUrl: string | undefined, models: ProviderModelConfig[]): void {
     pi.registerProvider(PROVIDER_NAME, {
       baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
-      apiKey: ENV_API_KEY,
+      apiKey: getApiKeyHelperCommand() ?? ENV_API_KEY,
       api: "openai-completions",
       models,
       oauth,
@@ -310,7 +383,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   async function refreshModelsAndCosts(): Promise<RefreshResult> {
     const fresh = await resolveCredentials();
-    const freshFp = fresh.apiKey ? fingerprint(fresh.apiKey) : undefined;
+    const freshFp = fresh.apiKeyFingerprint;
     if (!fresh.baseUrl || !fresh.apiKey || !freshFp) {
       throw new Error("no credentials. Run /login litellm or set env vars.");
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, OAuthCredential, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
@@ -40,43 +40,6 @@ async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
   } catch {
     return undefined;
   }
-}
-
-/**
- * When `LITELLM_API_KEY_HELPER` is the only credential source we must not hand the `!helper`
- * command to Pi's static provider API-key resolver: `!command` keys are documented as "cached for
- * process lifetime", so a long-running session would keep sending the first helper-issued bearer
- * token after it expires. Instead, seed a command-backed OAuth credential so every request resolves
- * through the uncached OAuth `getApiKey`/`refreshToken` hooks, which re-run the helper on demand.
- *
- * The seeded credential starts expired (`access: ""`, `expires: 0`) so no helper is executed at
- * startup (preserving the offline / disabled-discovery path); the first actual request triggers an
- * OAuth refresh that runs the helper and stores a fresh token.
- */
-async function seedHelperOAuthCredential(baseUrl: string | undefined): Promise<void> {
-  const helperCommand = getApiKeyHelperCommand();
-  if (!helperCommand) return;
-
-  const existing = await readAuthEntry();
-  if (existing?.type === "oauth" && existing.refresh === helperCommand) {
-    // A command-backed OAuth credential is already in place (seeded earlier or via `/login`); leave
-    // its current token/expiry untouched so we do not discard a freshly refreshed token or rewrite
-    // auth.json on every startup.
-    return;
-  }
-  if (existing) {
-    // Respect an explicit `/login litellm` or stored api_key entry that uses different credentials.
-    return;
-  }
-
-  const credential: OAuthCredential = {
-    type: "oauth",
-    access: "",
-    refresh: helperCommand,
-    expires: 0,
-    ...(baseUrl ? { baseUrl } : {}),
-  };
-  AuthStorage.create(getAuthPath()).set(PROVIDER_NAME, credential);
 }
 
 function cleanConfig(raw: string | undefined): string | undefined {
@@ -396,19 +359,17 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     modifyModels: modifyLiteLLMModels,
   };
 
-  // Route env-helper requests through the uncached OAuth hooks instead of the static `!command`
-  // provider key (which Pi caches for the process lifetime). Seeding is idempotent and starts the
-  // credential expired so the helper is only executed when a request actually needs a token.
-  await seedHelperOAuthCredential(creds.baseUrl);
-
   function registerProvider(baseUrl: string | undefined, models: ProviderModelConfig[]): void {
     pi.registerProvider(PROVIDER_NAME, {
       baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
-      // The helper command is never handed to Pi's static provider key resolver (it would be
-      // cached for the process lifetime). When a helper is configured it is resolved per request
-      // through the OAuth credential seeded above; otherwise we expose the literal
-      // `LITELLM_API_KEY` env var.
-      apiKey: ENV_API_KEY,
+      // When LITELLM_API_KEY_HELPER is set we register the helper as a `!command` provider key.
+      // Pi's per-request auth path (ModelRegistry.getApiKeyAndHeaders) resolves provider keys via
+      // resolveConfigValueOrThrow -> resolveConfigValueUncached, i.e. the command is re-executed on
+      // every request (it does NOT use the process-lifetime command cache, which only applies to
+      // resolveConfigValue). So a short-lived/rotating helper token stays fresh. The OAuth hooks
+      // remain registered for `/login litellm` users. See the regression test
+      // "re-runs the helper command on every request" in tests/index.test.ts.
+      apiKey: getApiKeyHelperCommand() ?? ENV_API_KEY,
       api: "openai-completions",
       models,
       oauth,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ const LOGIN_TIMEOUT_MS = 10_000;
 const CACHE_FILENAME = "litellm-models.json";
 const CACHE_STALE_MS = 24 * 60 * 60 * 1000;
 const TOKEN_REFRESH_LEAD_MS = 5 * 60 * 1000;
+const PERMANENT_TOKEN_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
+const EXPIRE_TOKEN_IMMEDIATELY = 0;
 
 type RefreshResult = { models: ProviderModelConfig[]; source: string };
 
@@ -64,27 +66,27 @@ function executeApiKeyCommand(commandConfig: string): string {
   return output;
 }
 
-function tokenExpiresAt(apiKey: string): number {
+function tokenExpiresAt(apiKey: string, opaqueFallback = PERMANENT_TOKEN_EXPIRES_AT): number {
   const [, payload] = apiKey.split(".");
-  if (!payload) return Number.MAX_SAFE_INTEGER;
+  if (!payload) return opaqueFallback;
   try {
     const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { exp?: unknown };
     return typeof claims.exp === "number"
       ? Math.max(Date.now(), claims.exp * 1000 - TOKEN_REFRESH_LEAD_MS)
-      : Number.MAX_SAFE_INTEGER;
+      : opaqueFallback;
   } catch {
-    return Number.MAX_SAFE_INTEGER;
+    return opaqueFallback;
   }
 }
 
-function shouldRefreshToken(apiKey: string): boolean {
-  return tokenExpiresAt(apiKey) <= Date.now();
+function getLiteLLMApiKey(credentials: OAuthCredentials): string {
+  return credentials.access;
 }
 
-function getLiteLLMApiKey(credentials: OAuthCredentials): string {
-  if (credentials.refresh.startsWith("!")) return executeApiKeyCommand(credentials.refresh);
-  const command = shouldRefreshToken(credentials.access) ? getApiKeyHelperCommand() : undefined;
-  return command ? executeApiKeyCommand(command) : credentials.access;
+function resolveOAuthApiKey(credentials: OAuthCredentials): string {
+  return credentials.refresh.startsWith("!")
+    ? executeApiKeyCommand(credentials.refresh)
+    : getLiteLLMApiKey(credentials);
 }
 
 async function resolveCredentials({ executeHelpers = true } = {}): Promise<ResolvedCredentials> {
@@ -95,7 +97,7 @@ async function resolveCredentials({ executeHelpers = true } = {}): Promise<Resol
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
   const authKey =
     entry?.type === "oauth"
-      ? (executeHelpers ? getLiteLLMApiKey(entry) : entry.access).trim()
+      ? (executeHelpers ? resolveOAuthApiKey(entry) : entry.access).trim()
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
@@ -186,7 +188,7 @@ async function loginLiteLLM(
   return {
     access: apiKey,
     refresh,
-    expires: tokenExpiresAt(apiKey),
+    expires: tokenExpiresAt(apiKey, refresh ? EXPIRE_TOKEN_IMMEDIATELY : PERMANENT_TOKEN_EXPIRES_AT),
     baseUrl,
   } as OAuthCredentials & { baseUrl: string };
 }
@@ -194,7 +196,7 @@ async function loginLiteLLM(
 async function refreshLiteLLM(credentials: OAuthCredentials): Promise<OAuthCredentials> {
   if (!credentials.refresh.startsWith("!")) return credentials;
   const access = executeApiKeyCommand(credentials.refresh);
-  return { ...credentials, access, expires: tokenExpiresAt(access) };
+  return { ...credentials, access, expires: tokenExpiresAt(access, EXPIRE_TOKEN_IMMEDIATELY) };
 }
 
 function modifyLiteLLMModels(models: Model<Api>[], cred: OAuthCredentials): Model<Api>[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,4 +55,5 @@ export type AuthFileEntry =
 export interface ResolvedCredentials {
   baseUrl?: string;
   apiKey?: string;
+  apiKeyFingerprint?: string;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -93,6 +94,10 @@ async function writeModelCache(agentDir: string, helperPath: string): Promise<vo
 async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<void>> {
   vi.resetModules();
   vi.doMock("@earendil-works/pi-coding-agent", () => {
+    type StoredEntry =
+      | { type: "api_key"; key: string }
+      | { type: "oauth"; access: string; expires: number; refresh: string; baseUrl?: string };
+
     class TestAuthStorage {
       constructor(private readonly authPath: string) {}
 
@@ -100,12 +105,22 @@ async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<
         return new TestAuthStorage(authPath);
       }
 
+      private readData(): Record<string, StoredEntry> {
+        try {
+          return JSON.parse(readFileSync(this.authPath, "utf8")) as Record<string, StoredEntry>;
+        } catch {
+          return {};
+        }
+      }
+
+      set(provider: string, credential: StoredEntry): void {
+        const data = this.readData();
+        data[provider] = credential;
+        writeFileSync(this.authPath, JSON.stringify(data), "utf8");
+      }
+
       async getApiKey(provider: string): Promise<string | undefined> {
-        const parsed = JSON.parse(await readFile(this.authPath, "utf8")) as Record<
-          string,
-          { type: "api_key"; key: string } | { type: "oauth"; access: string; expires: number; refresh: string }
-        >;
-        const entry = parsed[provider];
+        const entry = this.readData()[provider];
         if (entry?.type === "api_key") return process.env[entry.key] || entry.key;
         if (entry?.type === "oauth") return entry.access;
         return undefined;
@@ -290,10 +305,11 @@ describe("extension startup", () => {
     });
   });
 
-  it("uses LITELLM_API_KEY_HELPER for startup discovery and per-request provider auth", async () => {
+  it("routes LITELLM_API_KEY_HELPER auth through the uncached OAuth hooks", async () => {
     const agentDir = await makeAgentDir();
-    const token = makeJwt(Math.floor(Date.now() / 1000) + 3600);
-    const helperPath = await writeHelper(agentDir, [token]);
+    const first = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const second = makeJwt(Math.floor(Date.now() / 1000) + 7200);
+    const helperPath = await writeHelper(agentDir, [first, second]);
     process.env.LITELLM_BASE_URL = "https://litellm.example.com/v1";
     process.env.LITELLM_API_KEY = "stale-token";
     process.env.LITELLM_API_KEY_HELPER = helperPath;
@@ -307,11 +323,54 @@ describe("extension startup", () => {
     const pi = createPi();
     await extension(pi);
 
-    expect(seenAuthHeaders).toEqual([`Bearer ${token}`]);
+    // Startup discovery still resolves a fresh helper token (one helper invocation).
+    expect(seenAuthHeaders).toEqual([`Bearer ${first}`]);
+    expect(await readHelperCount(agentDir)).toBe(1);
+
+    // The provider key is never the `!helper` command (Pi caches `!command` keys for the process
+    // lifetime); the literal env var is used as the static fallback instead.
     expect(pi.providers[0]?.config).toMatchObject({
       baseUrl: "https://litellm.example.com/v1",
-      apiKey: `!${helperPath}`,
+      apiKey: "LITELLM_API_KEY",
     });
+
+    // A command-backed OAuth credential is seeded so request-time auth refreshes via the helper.
+    const auth = JSON.parse(await readFile(join(agentDir, "auth.json"), "utf8")) as {
+      litellm: { type: string; access: string; refresh: string; expires: number; baseUrl?: string };
+    };
+    expect(auth.litellm).toMatchObject({ type: "oauth", refresh: `!${helperPath}`, expires: 0 });
+
+    // The OAuth getApiKey hook re-runs the helper for an expired/opaque token (uncached).
+    const refreshed = pi.providers[0]?.config.oauth?.getApiKey({
+      access: "expired-token",
+      refresh: `!${helperPath}`,
+      expires: 0,
+    });
+    expect(refreshed).toBe(second);
+    expect(await readHelperCount(agentDir)).toBe(2);
+  });
+
+  it("does not overwrite an existing /login OAuth credential with the env helper", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, ["helper-token"]);
+    const stored = {
+      type: "oauth",
+      access: "logged-in-token",
+      refresh: "real-refresh-token",
+      expires: Date.now() + 3_600_000,
+      baseUrl: "https://litellm.example.com",
+    };
+    await writeFile(join(agentDir, "auth.json"), JSON.stringify({ litellm: stored }), "utf8");
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+    const extension = await loadExtension(agentDir);
+    await extension(createPi());
+
+    const auth = JSON.parse(await readFile(join(agentDir, "auth.json"), "utf8")) as { litellm: typeof stored };
+    expect(auth.litellm).toEqual(stored);
+    expect(await readHelperCount(agentDir)).toBe(0);
   });
 
   it.each([

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -68,6 +68,16 @@ async function writeHelper(
   return helperPath;
 }
 
+async function writeFailingHelper(agentDir: string): Promise<string> {
+  const helperPath = join(agentDir, "litellm-token-helper.sh");
+  await writeFile(
+    helperPath,
+    `#!/usr/bin/env bash\ncount_file="${join(agentDir, "helper-count")}"\ncount=0\n[ -f "$count_file" ] && count=$(cat "$count_file")\necho $((count + 1)) > "$count_file"\nprintf 'idp offline' >&2\nexit 42\n`,
+    { mode: 0o700 },
+  );
+  return helperPath;
+}
+
 async function readHelperCount(agentDir: string): Promise<number> {
   try {
     return Number(await readFile(join(agentDir, "helper-count"), "utf8"));
@@ -351,6 +361,28 @@ describe("extension startup", () => {
       await extension(pi);
       expect(fetchMock).toHaveBeenCalledTimes(fetches ? 1 : 0);
       expect(await readHelperCount(agentDir)).toBe(helperRuns);
+      expect(pi.providers[0]?.config.models).toEqual(cachedModels);
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it("uses cached helper-backed models when forced discovery cannot execute the helper", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeFailingHelper(agentDir);
+    const originalArgv = process.argv;
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.argv = [...process.argv, "--list-models"];
+    await writeModelCache(agentDir, helperPath);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    try {
+      const extension = await loadExtension(agentDir);
+      const pi = createPi();
+      await extension(pi);
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(await readHelperCount(agentDir)).toBe(1);
       expect(pi.providers[0]?.config.models).toEqual(cachedModels);
     } finally {
       process.argv = originalArgv;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -2,8 +2,15 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { fingerprint } from "../src/cache.js";
 
-const ENV_KEYS = ["LITELLM_BASE_URL", "LITELLM_API_KEY", "LITELLM_DISCOVERY_TIMEOUT_MS", "STORED_LITELLM_KEY"];
+const ENV_KEYS = [
+  "LITELLM_BASE_URL",
+  "LITELLM_API_KEY",
+  "LITELLM_API_KEY_HELPER",
+  "LITELLM_DISCOVERY_TIMEOUT_MS",
+  "STORED_LITELLM_KEY",
+];
 const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
 
 type TestProviderConfig = {
@@ -15,6 +22,13 @@ type TestProviderConfig = {
       onProgress?: (message: string) => void;
       signal?: AbortSignal;
     }) => Promise<{ access: string; refresh: string; expires: number; baseUrl?: string }>;
+    refreshToken: (credential: { access: string; refresh: string; expires: number; baseUrl?: string }) => Promise<{
+      access: string;
+      refresh: string;
+      expires: number;
+      baseUrl?: string;
+    }>;
+    getApiKey: (credential: { access: string; refresh: string; expires: number; baseUrl?: string }) => string;
   };
 };
 
@@ -32,6 +46,48 @@ function jsonResponse(status: number, body: unknown): Response {
 
 async function makeAgentDir(): Promise<string> {
   return mkdtemp(join(tmpdir(), "pi-litellm-index-"));
+}
+
+function makeJwt(expSeconds: number): string {
+  const encode = (value: unknown): string => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "none" })}.${encode({ exp: expSeconds })}.sig`;
+}
+
+async function writeHelper(
+  agentDir: string,
+  tokens: string[],
+  helperPath = join(agentDir, "litellm-token-helper.sh"),
+): Promise<string> {
+  await writeFile(
+    helperPath,
+    `#!/usr/bin/env bash\ncount_file="${join(agentDir, "helper-count")}"\ncount=0\n[ -f "$count_file" ] && count=$(cat "$count_file")\ncase "$count" in\n${tokens.map((token, index) => `  ${index}) printf %s '${token}' ;;`).join("\n")}\n  *) printf %s '${tokens.at(-1)}' ;;\nesac\necho $((count + 1)) > "$count_file"\n`,
+    { mode: 0o700 },
+  );
+  return helperPath;
+}
+
+async function readHelperCount(agentDir: string): Promise<number> {
+  try {
+    return Number(await readFile(join(agentDir, "helper-count"), "utf8"));
+  } catch {
+    return 0;
+  }
+}
+
+const cachedModels = [{ id: "cached-model", name: "cached-model", provider: "litellm" }];
+
+async function writeModelCache(agentDir: string, helperPath: string): Promise<void> {
+  await writeFile(
+    join(agentDir, "litellm-models.json"),
+    JSON.stringify({
+      baseUrl: "https://litellm.example.com",
+      apiKeyFingerprint: fingerprint(`!${helperPath}`),
+      fetchedAt: Date.now(),
+      source: "model_info",
+      models: cachedModels,
+    }),
+    "utf8",
+  );
 }
 
 async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<void>> {
@@ -232,5 +288,117 @@ describe("extension startup", () => {
       expect(callCount).toBe(2);
       expect(pi.providers).toHaveLength(2);
     });
+  });
+
+  it("uses LITELLM_API_KEY_HELPER for startup discovery and per-request provider auth", async () => {
+    const agentDir = await makeAgentDir();
+    const token = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const helperPath = await writeHelper(agentDir, [token]);
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com/v1";
+    process.env.LITELLM_API_KEY = "stale-token";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    const seenAuthHeaders: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      seenAuthHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+      return jsonResponse(200, { data: [{ model_name: "claude-opus-4-8", model_info: { mode: "chat" } }] });
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(seenAuthHeaders).toEqual([`Bearer ${token}`]);
+    expect(pi.providers[0]?.config).toMatchObject({
+      baseUrl: "https://litellm.example.com/v1",
+      apiKey: `!${helperPath}`,
+    });
+  });
+
+  it.each([
+    { name: "discovery is disabled", timeout: "0", fetches: false, helperRuns: 0 },
+    { name: "fresh cache avoids discovery", fetches: false, helperRuns: 0 },
+    { name: "helper output rotates before discovery fails", listModels: true, fetches: true, helperRuns: 1 },
+  ])("uses cached helper-backed models when $name", async ({ timeout, listModels, fetches, helperRuns }) => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, ["rotated-token"]);
+    const originalArgv = process.argv;
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    if (timeout) process.env.LITELLM_DISCOVERY_TIMEOUT_MS = timeout;
+    if (listModels) process.argv = [...process.argv, "--list-models"];
+    await writeModelCache(agentDir, helperPath);
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("temporary outage"));
+
+    try {
+      const extension = await loadExtension(agentDir);
+      const pi = createPi();
+      await extension(pi);
+      expect(fetchMock).toHaveBeenCalledTimes(fetches ? 1 : 0);
+      expect(await readHelperCount(agentDir)).toBe(helperRuns);
+      expect(pi.providers[0]?.config.models).toEqual(cachedModels);
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it("refreshes command-backed login credentials", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const now = new Date("2026-05-29T21:00:00.000Z").getTime();
+    const first = makeJwt(Math.floor(now / 1000) + 60);
+    const second = makeJwt(Math.floor(now / 1000) + 3600);
+    const helperPath = await writeHelper(agentDir, [first, second, "opaque-token"]);
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { data: [{ model_name: "claude-opus-4-8", model_info: { mode: "chat" } }] }),
+    );
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => (options.placeholder ? "https://litellm.example.com" : `!${helperPath}`),
+    });
+    const refreshed = await pi.providers[0]?.config.oauth?.refreshToken(credential!);
+    const opaque = pi.providers[0]?.config.oauth?.getApiKey({ ...credential!, access: "opaque-old" });
+
+    expect(credential?.access).toBe(first);
+    expect(credential?.refresh).toBe(`!${helperPath}`);
+    expect(credential?.expires).toBeLessThan((Math.floor(now / 1000) + 60) * 1000);
+    expect(refreshed?.access).toBe(second);
+    expect(opaque).toBe("opaque-token");
+    expect(await readHelperCount(agentDir)).toBe(3);
+  });
+
+  it("uses a helper when stored OAuth credentials contain an expired token", async () => {
+    const agentDir = await makeAgentDir();
+    const now = new Date("2026-05-29T21:00:00.000Z").getTime();
+    const expired = makeJwt(Math.floor(now / 1000) - 60);
+    const fresh = makeJwt(Math.floor(now / 1000) + 3600);
+    const helperPath = await writeHelper(agentDir, [fresh]);
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({
+        litellm: {
+          type: "oauth",
+          access: expired,
+          refresh: `!${helperPath}`,
+          expires: Number.MAX_SAFE_INTEGER,
+          baseUrl: "https://litellm.example.com",
+        },
+      }),
+      "utf8",
+    );
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const seenAuthHeaders: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      seenAuthHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+      return jsonResponse(200, { data: [{ model_name: "claude-opus-4-8", model_info: { mode: "chat" } }] });
+    });
+
+    const extension = await loadExtension(agentDir);
+    await extension(createPi());
+
+    expect(seenAuthHeaders).toEqual([`Bearer ${fresh}`]);
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,6 +16,7 @@ const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
 
 type TestProviderConfig = {
   baseUrl?: string;
+  apiKey?: string;
   models?: unknown[];
   oauth?: {
     login: (callbacks: {
@@ -94,10 +95,6 @@ async function writeModelCache(agentDir: string, helperPath: string): Promise<vo
 async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<void>> {
   vi.resetModules();
   vi.doMock("@earendil-works/pi-coding-agent", () => {
-    type StoredEntry =
-      | { type: "api_key"; key: string }
-      | { type: "oauth"; access: string; expires: number; refresh: string; baseUrl?: string };
-
     class TestAuthStorage {
       constructor(private readonly authPath: string) {}
 
@@ -105,22 +102,12 @@ async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<
         return new TestAuthStorage(authPath);
       }
 
-      private readData(): Record<string, StoredEntry> {
-        try {
-          return JSON.parse(readFileSync(this.authPath, "utf8")) as Record<string, StoredEntry>;
-        } catch {
-          return {};
-        }
-      }
-
-      set(provider: string, credential: StoredEntry): void {
-        const data = this.readData();
-        data[provider] = credential;
-        writeFileSync(this.authPath, JSON.stringify(data), "utf8");
-      }
-
       async getApiKey(provider: string): Promise<string | undefined> {
-        const entry = this.readData()[provider];
+        const parsed = JSON.parse(await readFile(this.authPath, "utf8")) as Record<
+          string,
+          { type: "api_key"; key: string } | { type: "oauth"; access: string; expires: number; refresh: string }
+        >;
+        const entry = parsed[provider];
         if (entry?.type === "api_key") return process.env[entry.key] || entry.key;
         if (entry?.type === "oauth") return entry.access;
         return undefined;
@@ -305,11 +292,12 @@ describe("extension startup", () => {
     });
   });
 
-  it("routes LITELLM_API_KEY_HELPER auth through the uncached OAuth hooks", async () => {
+  it("registers the helper as a per-request `!command` provider key that re-runs each request", async () => {
     const agentDir = await makeAgentDir();
     const first = makeJwt(Math.floor(Date.now() / 1000) + 3600);
     const second = makeJwt(Math.floor(Date.now() / 1000) + 7200);
-    const helperPath = await writeHelper(agentDir, [first, second]);
+    const third = makeJwt(Math.floor(Date.now() / 1000) + 10800);
+    const helperPath = await writeHelper(agentDir, [first, second, third]);
     process.env.LITELLM_BASE_URL = "https://litellm.example.com/v1";
     process.env.LITELLM_API_KEY = "stale-token";
     process.env.LITELLM_API_KEY_HELPER = helperPath;
@@ -323,54 +311,23 @@ describe("extension startup", () => {
     const pi = createPi();
     await extension(pi);
 
-    // Startup discovery still resolves a fresh helper token (one helper invocation).
+    // Startup discovery uses a fresh helper token (one helper invocation).
     expect(seenAuthHeaders).toEqual([`Bearer ${first}`]);
     expect(await readHelperCount(agentDir)).toBe(1);
 
-    // The provider key is never the `!helper` command (Pi caches `!command` keys for the process
-    // lifetime); the literal env var is used as the static fallback instead.
-    expect(pi.providers[0]?.config).toMatchObject({
-      baseUrl: "https://litellm.example.com/v1",
-      apiKey: "LITELLM_API_KEY",
-    });
+    // The provider key is the `!helper` command. Pi's per-request auth path
+    // (ModelRegistry.getApiKeyAndHeaders) resolves provider keys via resolveConfigValueUncached,
+    // re-executing the command on every request — it does NOT use the process-lifetime command
+    // cache. Simulate that by resolving the registered command twice and asserting fresh tokens.
+    const registeredKey = pi.providers[0]?.config.apiKey;
+    expect(registeredKey).toBe(`!${helperPath}`);
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://litellm.example.com/v1");
 
-    // A command-backed OAuth credential is seeded so request-time auth refreshes via the helper.
-    const auth = JSON.parse(await readFile(join(agentDir, "auth.json"), "utf8")) as {
-      litellm: { type: string; access: string; refresh: string; expires: number; baseUrl?: string };
-    };
-    expect(auth.litellm).toMatchObject({ type: "oauth", refresh: `!${helperPath}`, expires: 0 });
-
-    // The OAuth getApiKey hook re-runs the helper for an expired/opaque token (uncached).
-    const refreshed = pi.providers[0]?.config.oauth?.getApiKey({
-      access: "expired-token",
-      refresh: `!${helperPath}`,
-      expires: 0,
-    });
-    expect(refreshed).toBe(second);
-    expect(await readHelperCount(agentDir)).toBe(2);
-  });
-
-  it("does not overwrite an existing /login OAuth credential with the env helper", async () => {
-    const agentDir = await makeAgentDir();
-    const helperPath = await writeHelper(agentDir, ["helper-token"]);
-    const stored = {
-      type: "oauth",
-      access: "logged-in-token",
-      refresh: "real-refresh-token",
-      expires: Date.now() + 3_600_000,
-      baseUrl: "https://litellm.example.com",
-    };
-    await writeFile(join(agentDir, "auth.json"), JSON.stringify({ litellm: stored }), "utf8");
-    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
-    process.env.LITELLM_API_KEY_HELPER = helperPath;
-    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
-
-    const extension = await loadExtension(agentDir);
-    await extension(createPi());
-
-    const auth = JSON.parse(await readFile(join(agentDir, "auth.json"), "utf8")) as { litellm: typeof stored };
-    expect(auth.litellm).toEqual(stored);
-    expect(await readHelperCount(agentDir)).toBe(0);
+    const command = (registeredKey as string).slice(1);
+    const resolveUncached = () => execSync(command, { encoding: "utf8" }).trim();
+    expect(resolveUncached()).toBe(second);
+    expect(resolveUncached()).toBe(third);
+    expect(await readHelperCount(agentDir)).toBe(3);
   });
 
   it.each([

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -357,13 +357,13 @@ describe("extension startup", () => {
     }
   });
 
-  it("refreshes command-backed login credentials", async () => {
+  it("does not re-run command-backed helpers after refreshing login credentials", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
     const now = new Date("2026-05-29T21:00:00.000Z").getTime();
     const first = makeJwt(Math.floor(now / 1000) + 60);
     const second = makeJwt(Math.floor(now / 1000) + 3600);
-    const helperPath = await writeHelper(agentDir, [first, second, "opaque-token"]);
+    const helperPath = await writeHelper(agentDir, [first, second, "unexpected-third-token"]);
     vi.spyOn(Date, "now").mockReturnValue(now);
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse(200, { data: [{ model_name: "claude-opus-4-8", model_info: { mode: "chat" } }] }),
@@ -376,14 +376,37 @@ describe("extension startup", () => {
       onPrompt: async (options) => (options.placeholder ? "https://litellm.example.com" : `!${helperPath}`),
     });
     const refreshed = await pi.providers[0]?.config.oauth?.refreshToken(credential!);
-    const opaque = pi.providers[0]?.config.oauth?.getApiKey({ ...credential!, access: "opaque-old" });
+    const apiKey = pi.providers[0]?.config.oauth?.getApiKey(refreshed!);
 
     expect(credential?.access).toBe(first);
     expect(credential?.refresh).toBe(`!${helperPath}`);
     expect(credential?.expires).toBeLessThan((Math.floor(now / 1000) + 60) * 1000);
     expect(refreshed?.access).toBe(second);
-    expect(opaque).toBe("opaque-token");
-    expect(await readHelperCount(agentDir)).toBe(3);
+    expect(apiKey).toBe(second);
+    expect(await readHelperCount(agentDir)).toBe(2);
+  });
+
+  it("marks opaque command-backed tokens expired without re-running after refresh", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const helperPath = await writeHelper(agentDir, ["opaque-first", "opaque-second", "unexpected-third"]);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { data: [{ model_name: "claude-opus-4-8", model_info: { mode: "chat" } }] }),
+    );
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => (options.placeholder ? "https://litellm.example.com" : `!${helperPath}`),
+    });
+    const refreshed = await pi.providers[0]?.config.oauth?.refreshToken(credential!);
+    const apiKey = pi.providers[0]?.config.oauth?.getApiKey(refreshed!);
+
+    expect(credential).toMatchObject({ access: "opaque-first", refresh: `!${helperPath}`, expires: 0 });
+    expect(refreshed).toMatchObject({ access: "opaque-second", refresh: `!${helperPath}`, expires: 0 });
+    expect(apiKey).toBe("opaque-second");
+    expect(await readHelperCount(agentDir)).toBe(2);
   });
 
   it("uses a helper when stored OAuth credentials contain an expired token", async () => {

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -20,13 +20,13 @@ describe("package gallery metadata", () => {
 });
 
 describe("pi package compatibility", () => {
-  it("allows the supported 0.75 and 0.76 pi package lines", async () => {
+  it("accepts every pi package version through peer dependencies", async () => {
     const { default: manifest } = await import("../package.json", {
       with: { type: "json" },
     });
 
-    expect(manifest.peerDependencies["@earendil-works/pi-ai"]).toBe(">=0.75.4 <0.77.0");
-    expect(manifest.peerDependencies["@earendil-works/pi-coding-agent"]).toBe(">=0.75.4 <0.77.0");
+    expect(manifest.peerDependencies["@earendil-works/pi-ai"]).toBe("*");
+    expect(manifest.peerDependencies["@earendil-works/pi-coding-agent"]).toBe("*");
   });
 });
 


### PR DESCRIPTION
Hi @balcsida thanks for this extension! I'd love to extend it for dynamic token helpers -- our installation requires a binary to refresh the API tokens periodically. Added this PR, hope you don't mind.

## Summary
- add LITELLM_API_KEY_HELPER for short-lived LiteLLM bearer tokens
- support `!helper-command` via `/login litellm` and OAuth refresh
- derive JWT-backed credential expiry from `exp` instead of treating all keys as permanent
- keep command-backed provider keys uncached so long Pi sessions can resolve fresh tokens per request

## Manual validation
Installed branch and verified:
- `pi --list-models litellm` discovers LiteLLM models with `LITELLM_API_KEY_HELPER`
- `pi -p --provider litellm --model claude-opus-4-8 "Reply exactly: ok"` returns `ok`
