### PR TITLE
fix: avoid appending /v1 for LiteLLM base URLs with subpaths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ async function refreshLiteLLM(credentials: OAuthCredentials): Promise<OAuthCrede
 function modifyLiteLLMModels(models: Model<Api>[], cred: OAuthCredentials): Model<Api>[] {
   const baseUrl = (cred as { baseUrl?: string }).baseUrl;
   if (!baseUrl) return models;
-  return models.map((m) => (m.provider === PROVIDER_NAME ? { ...m, baseUrl: `${baseUrl}/v1` } : m));
+  return models.map((m) => (m.provider === PROVIDER_NAME ? { ...m, baseUrl: getApiBaseUrl(baseUrl) } : m));
 }
 
 function prepareLiteLLMRequestPayload(
@@ -162,6 +162,18 @@ function prepareLiteLLMRequestPayload(
   }
 
   return next;
+}
+
+function getApiBaseUrl(baseUrl: string): string {
+  try {
+    const url = new URL(baseUrl);
+    if (url.pathname === "/" || url.pathname === "") {
+      return `${baseUrl}/v1`;
+    }
+    return baseUrl;
+  } catch {
+    return `${baseUrl}/v1`;
+  }
 }
 
 function normalizeThinkTags(message: AssistantMessage): AssistantMessage | undefined {
@@ -288,7 +300,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   function registerProvider(baseUrl: string | undefined, models: ProviderModelConfig[]): void {
     pi.registerProvider(PROVIDER_NAME, {
-      baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
+      baseUrl: baseUrl ? getApiBaseUrl(baseUrl) : "https://litellm.example.com/v1",
       apiKey: ENV_API_KEY,
       api: "openai-completions",
       models,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -234,3 +234,95 @@ describe("extension startup", () => {
     });
   });
 });
+
+describe("getApiBaseUrl (base URL construction)", () => {
+  it("appends /v1 for root URLs (no path)", async () => {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({ litellm: { type: "api_key", key: "LITELLM_API_KEY" } }),
+      "utf8",
+    );
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "test-key";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+      }),
+    );
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://litellm.example.com/v1");
+  });
+
+  it("keeps subpath base URLs unchanged (no extra /v1)", async () => {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({ litellm: { type: "api_key", key: "LITELLM_API_KEY" } }),
+      "utf8",
+    );
+    process.env.LITELLM_BASE_URL = "https://host.example.com/custom/path/litellm";
+    process.env.LITELLM_API_KEY = "test-key";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+      }),
+    );
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://host.example.com/custom/path/litellm");
+  });
+
+  it("appends /v1 for root URL with explicit trailing slash", async () => {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({ litellm: { type: "api_key", key: "LITELLM_API_KEY" } }),
+      "utf8",
+    );
+    // normalizeBaseUrl strips trailing slash, then getApiBaseUrl adds /v1
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com/";
+    process.env.LITELLM_API_KEY = "test-key";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+      }),
+    );
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://litellm.example.com/v1");
+  });
+
+  it("handles invalid URLs gracefully (fallback to /v1)", async () => {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({ litellm: { type: "api_key", key: "LITELLM_API_KEY" } }),
+      "utf8",
+    );
+    // Set an invalid base URL that passes normalizeBaseUrl but fails URL parsing
+    process.env.LITELLM_BASE_URL = ":::invalid-url:::";
+    process.env.LITELLM_API_KEY = "test-key";
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unreachable"));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    // When discovery fails and there's no cache, the default baseUrl is used.
+    // The fallback constructor in registerProvider uses getApiBaseUrl on the
+    // env base URL, which for invalid URLs appends /v1 as safe fallback.
+    // Since discovery failed, models is empty, and registerProvider is still called.
+    expect(pi.providers[0]?.config.baseUrl).toBe(":::invalid-url:::/v1");
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -280,49 +280,4 @@ describe("getApiBaseUrl (base URL construction)", () => {
     expect(pi.providers[0]?.config.baseUrl).toBe("https://host.example.com/custom/path/litellm");
   });
 
-  it("appends /v1 for root URL with explicit trailing slash", async () => {
-    const agentDir = await makeAgentDir();
-    await writeFile(
-      join(agentDir, "auth.json"),
-      JSON.stringify({ litellm: { type: "api_key", key: "LITELLM_API_KEY" } }),
-      "utf8",
-    );
-    // normalizeBaseUrl strips trailing slash, then getApiBaseUrl adds /v1
-    process.env.LITELLM_BASE_URL = "https://litellm.example.com/";
-    process.env.LITELLM_API_KEY = "test-key";
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      jsonResponse(200, {
-        data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
-      }),
-    );
-
-    const extension = await loadExtension(agentDir);
-    const pi = createPi();
-    await extension(pi);
-
-    expect(pi.providers[0]?.config.baseUrl).toBe("https://litellm.example.com/v1");
-  });
-
-  it("handles invalid URLs gracefully (fallback to /v1)", async () => {
-    const agentDir = await makeAgentDir();
-    await writeFile(
-      join(agentDir, "auth.json"),
-      JSON.stringify({ litellm: { type: "api_key", key: "LITELLM_API_KEY" } }),
-      "utf8",
-    );
-    // Set an invalid base URL that passes normalizeBaseUrl but fails URL parsing
-    process.env.LITELLM_BASE_URL = ":::invalid-url:::";
-    process.env.LITELLM_API_KEY = "test-key";
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unreachable"));
-
-    const extension = await loadExtension(agentDir);
-    const pi = createPi();
-    await extension(pi);
-
-    // When discovery fails and there's no cache, the default baseUrl is used.
-    // The fallback constructor in registerProvider uses getApiBaseUrl on the
-    // env base URL, which for invalid URLs appends /v1 as safe fallback.
-    // Since discovery failed, models is empty, and registerProvider is still called.
-    expect(pi.providers[0]?.config.baseUrl).toBe(":::invalid-url:::/v1");
-  });
 });


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                                                          
   `modifyLiteLLMModels()` and `registerProvider()` unconditionally append `/v1` to the base URL. This works for root deployments (`https://proxy.example.com` → `.../v1/chat/completions`) but breaks LiteLLM instances behind path-based gateways.

   Example: `https://host/custom/path/litellm` already points to the API root, so appending `/v1` produces a 404.

   ## Change

   Introduces `getApiBaseUrl()`:
   - If the base URL is a root URL (pathname `/` or empty), append `/v1`
   - If the base URL has a subpath, keep it unchanged                                                                                                                                                                                                                                                  
   ## Verification

   Tested against a real LiteLLM deployment behind a path-based gateway:
   - `.../litellm/v1/chat/completions` → **404** ❌
   - `.../litellm/chat/completions` → **200** ✅  