### PR TITLE
[codex] fix LiteLLM API key reference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -379,7 +379,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       // resolveConfigValue). So a short-lived/rotating helper token stays fresh. The OAuth hooks
       // remain registered for `/login litellm` users. See the regression test
       // "re-runs the helper command on every request" in tests/index.test.ts.
-      apiKey: getApiKeyHelperCommand() ?? ENV_API_KEY,
+      apiKey: getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`,
       api: "openai-completions",
       models,
       oauth,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -168,6 +168,16 @@ afterEach(() => {
 });
 
 describe("extension startup", () => {
+  it("registers the API key as an explicit environment reference", async () => {
+    const agentDir = await makeAgentDir();
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.apiKey).toBe("$LITELLM_API_KEY");
+  });
+
   it("discovers with the resolved stored auth key before LITELLM_API_KEY", async () => {
     const agentDir = await makeAgentDir();
     await writeFile(


### PR DESCRIPTION
## Summary

- Pass `"$LITELLM_API_KEY"` to Pi provider registration so the API key is an explicit environment-variable reference.
- Add a startup regression test that verifies the registered provider config uses the new explicit reference.

## Root cause

Pi now warns when `registerProvider("litellm")` receives the bare string `"LITELLM_API_KEY"` because that legacy environment-variable detection is deprecated.

## Validation

- `npm run check` passed: Biome, typecheck, and 66 Vitest tests.
- `npm run build` passed.

Existing Vitest `vi.unmock` hoist warnings are still present and unrelated to this change.

Fixes #30 