### PR TITLE
chore: release v1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump package metadata to 1.2.4

## Verification
- npm run check
- npm run clean
- npm run build
- npm run supply-chain:guard
- npm pack --dry-run