### PR TITLE
fix: register LiteLLM models after login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,11 +358,15 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     }
   }
 
+  let updateCosts: (models: ProviderModelConfig[]) => void = () => undefined;
+
   const oauth = {
     name: "LiteLLM",
     login: (callbacks: OAuthLoginCallbacks) =>
       loginLiteLLM(callbacks, (next) => {
         cacheFetchedAt = next.fetchedAt;
+        registerProvider(next.baseUrl, next.models);
+        updateCosts(next.models);
       }),
     refreshToken: refreshLiteLLM,
     getApiKey: getLiteLLMApiKey,
@@ -388,7 +392,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   registerProvider(creds.baseUrl, models);
 
-  const updateCosts = setupLiteLLMCostTracking(pi, models);
+  updateCosts = setupLiteLLMCostTracking(pi, models);
 
   let refreshInProgress: Promise<RefreshResult> | null = null;
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -269,6 +269,36 @@ describe("extension startup", () => {
     expect(progress).toHaveBeenCalledWith("LiteLLM: 1 models discovered (source: model_info)");
   });
 
+  it("re-registers models discovered during login", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers).toHaveLength(1);
+    expect(pi.providers[0]?.config.models).toEqual([]);
+
+    await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => (options.placeholder ? " http://127.0.0.1:4000/v1 " : " sk-login "),
+      signal: new AbortController().signal,
+    });
+
+    const registeredModels = pi.providers[1]?.config.models as Array<{ id: string }> | undefined;
+    expect(pi.providers).toHaveLength(2);
+    expect(pi.providers[1]?.config.baseUrl).toBe("http://127.0.0.1:4000/v1");
+    expect(registeredModels?.map((model) => model.id)).toEqual(["vidaimock-openai"]);
+  });
+
   it("uses the login cache timestamp for later stale auto-refresh", async () => {
     const agentDir = await makeAgentDir();
     delete process.env.LITELLM_BASE_URL;
@@ -308,7 +338,10 @@ describe("extension startup", () => {
 
     await vi.waitFor(() => {
       expect(callCount).toBe(2);
-      expect(pi.providers).toHaveLength(2);
+      expect(pi.providers).toHaveLength(3);
+      expect((pi.providers.at(-1)?.config.models as Array<{ id: string }> | undefined)?.[0]?.id).toBe(
+        "vidaimock-openai-2",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- Register LiteLLM models immediately after `/login litellm` discovery completes
- Refresh LiteLLM cost metadata from the login-discovered model list
- Bump package version to 1.2.5 for release

## Test Plan
- npm test -- tests/index.test.ts
- LITELLM_BASE_URL=... LITELLM_API_KEY=... LITELLM_SMOKE_MODELS=haiku-4.5 LITELLM_SMOKE_TIMEOUT_MS=30000 ./node_modules/.bin/tsx scripts/smoke.ts
- npm run check
- npm run clean && npm run build
- npm run supply-chain:guard
- npm pack --dry-run
