### PR TITLE
fix: support /login litellm on clean Pi configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Inside pi:
 /login litellm
 ```
 
+You can also run `/login`, select `Use a subscription`, then select `LiteLLM`.
+
 You'll be prompted for the base URL and API key. Credentials are persisted to `~/.pi/agent/auth.json`.
 
 ### Option B — environment variables

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
   "linter": {
     "enabled": true,
     "rules": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
@@ -429,6 +429,49 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     });
     return refreshInProgress;
   }
+
+  async function runLoginCommand(ctx: ExtensionCommandContext): Promise<void> {
+    const credential = await loginLiteLLM(
+      {
+        onAuth: () => undefined,
+        onDeviceCode: () => undefined,
+        onPrompt: async ({ message, placeholder }) => {
+          const value = await ctx.ui.input(message, placeholder);
+          if (value === undefined) throw new Error("Login cancelled");
+          return value;
+        },
+        onProgress: (message) => ctx.ui.notify(message, "info"),
+        onSelect: async () => undefined,
+        signal: ctx.signal,
+      },
+      (next) => {
+        cacheFetchedAt = next.fetchedAt;
+        registerProvider(next.baseUrl, next.models);
+        updateCosts(next.models);
+      },
+    );
+
+    ctx.modelRegistry.authStorage.set(PROVIDER_NAME, { type: "oauth", ...credential });
+    ctx.modelRegistry.refresh();
+    ctx.ui.notify(`Logged in to LiteLLM. Credentials saved to ${getAuthPath()}`, "info");
+  }
+
+  pi.registerCommand("login", {
+    description: "Configure LiteLLM credentials with /login litellm.",
+    handler: async (args, ctx) => {
+      if (args.trim() !== PROVIDER_NAME) {
+        ctx.ui.notify("Use /login to choose a provider, or /login litellm to configure LiteLLM.", "warning");
+        return;
+      }
+
+      try {
+        await runLoginCommand(ctx);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message !== "Login cancelled") ctx.ui.notify(`LiteLLM login failed: ${message}`, "error");
+      }
+    },
+  });
 
   pi.registerCommand("litellm-refresh", {
     description: "Re-discover models from the LiteLLM proxy.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { execSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
-import type { ExtensionAPI, ExtensionCommandContext, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
@@ -430,7 +430,9 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     return refreshInProgress;
   }
 
-  async function runLoginCommand(ctx: ExtensionCommandContext): Promise<void> {
+  type LoginContext = Pick<ExtensionContext, "modelRegistry" | "signal" | "ui">;
+
+  async function runLogin(ctx: LoginContext): Promise<void> {
     const credential = await loginLiteLLM(
       {
         onAuth: () => undefined,
@@ -456,21 +458,18 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     ctx.ui.notify(`Logged in to LiteLLM. Credentials saved to ${getAuthPath()}`, "info");
   }
 
-  pi.registerCommand("login", {
-    description: "Configure LiteLLM credentials with /login litellm.",
-    handler: async (args, ctx) => {
-      if (args.trim() !== PROVIDER_NAME) {
-        ctx.ui.notify("Use /login to choose a provider, or /login litellm to configure LiteLLM.", "warning");
-        return;
-      }
+  pi.on("input", async (event, ctx) => {
+    if (event.text.trim() !== `/login ${PROVIDER_NAME}`) return { action: "continue" };
+    if (!ctx.hasUI) return { action: "continue" };
 
-      try {
-        await runLoginCommand(ctx);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (message !== "Login cancelled") ctx.ui.notify(`LiteLLM login failed: ${message}`, "error");
-      }
-    },
+    try {
+      await runLogin(ctx);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message !== "Login cancelled") ctx.ui.notify(`LiteLLM login failed: ${message}`, "error");
+    }
+
+    return { action: "handled" };
   });
 
   pi.registerCommand("litellm-refresh", {

--- a/src/litellm.ts
+++ b/src/litellm.ts
@@ -1,71 +1,3 @@
-import { readFile } from "node:fs/promises";
-import { join } from "node:path";
-import type { OAuthCredentials } from "@earendil-works/pi-ai";
-import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
-import { normalizeBaseUrl } from "./discover.js";
-import type { AuthFileEntry, ResolvedCredentials } from "./types.js";
-
-export const PROVIDER_NAME = "litellm";
-export const ENV_BASE_URL = "LITELLM_BASE_URL";
-export const ENV_API_KEY = "LITELLM_API_KEY";
-export const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
-export const ENV_OFFLINE = "LITELLM_OFFLINE";
-export const DEFAULT_TIMEOUT_MS = 5000;
-export const LOGIN_TIMEOUT_MS = 10_000;
-export const CACHE_FILENAME = "litellm-models.json";
-
-export function getAuthPath(): string {
-  return join(getAgentDir(), "auth.json");
-}
-
-export function getCachePath(): string {
-  return join(getAgentDir(), CACHE_FILENAME);
-}
-
-async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
-  try {
-    const raw = await readFile(getAuthPath(), "utf8");
-    const parsed = JSON.parse(raw) as Record<string, AuthFileEntry>;
-    return parsed?.[PROVIDER_NAME];
-  } catch {
-    return undefined;
-  }
-}
-
-export async function resolveCredentials(): Promise<ResolvedCredentials> {
-  const entry = await readAuthEntry();
-  const envBase = process.env[ENV_BASE_URL]?.trim();
-  const envKey = process.env[ENV_API_KEY]?.trim();
-  const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
-  const authKey =
-    entry?.type === "oauth"
-      ? entry.access?.trim()
-      : entry?.type === "api_key"
-        ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
-        : undefined;
-  const rawBase = authBase || envBase;
-  return {
-    baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
-    apiKey: authKey || envKey || undefined,
-  };
-}
-
-export function getDiscoveryTimeoutMs(): number {
-  const raw = process.env[ENV_TIMEOUT];
-  if (raw === undefined) return DEFAULT_TIMEOUT_MS;
-  const parsed = Number.parseInt(raw, 10);
-  if (Number.isNaN(parsed) || parsed < 0) return DEFAULT_TIMEOUT_MS;
-  return parsed;
-}
-
-export function isOffline(): boolean {
-  return process.env[ENV_OFFLINE] === "1";
-}
-
-export function isListModelsMode(): boolean {
-  return process.argv.includes("--list-models");
-}
-
 export function getSessionIdFromFile(sessionFile?: string): string | undefined {
   if (!sessionFile) return undefined;
   const filename = sessionFile
@@ -76,5 +8,3 @@ export function getSessionIdFromFile(sessionFile?: string): string | undefined {
   const uuidMatch = filename.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
   return uuidMatch?.[1] ?? filename;
 }
-
-export type { OAuthCredentials };

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+vi.unmock("@earendil-works/pi-coding-agent");
+
 type TestProviderConfig = {
   baseUrl?: string;
   apiKey?: string;
@@ -81,7 +83,6 @@ function createPi(): TestPi {
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
-  vi.unmock("@earendil-works/pi-coding-agent");
   delete process.env.LITELLM_BASE_URL;
   delete process.env.LITELLM_API_KEY;
   delete process.env.LITELLM_DISCOVERY_TIMEOUT_MS;

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -82,9 +82,9 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
   vi.unmock("@earendil-works/pi-coding-agent");
-  process.env.LITELLM_BASE_URL = undefined;
-  process.env.LITELLM_API_KEY = undefined;
-  process.env.LITELLM_DISCOVERY_TIMEOUT_MS = undefined;
+  delete process.env.LITELLM_BASE_URL;
+  delete process.env.LITELLM_API_KEY;
+  delete process.env.LITELLM_DISCOVERY_TIMEOUT_MS;
 });
 
 describe("feature parity", () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -16,7 +16,7 @@ type TestProviderConfig = {
 
 type TestCommand = {
   description: string;
-  handler: (args: string[], ctx: { ui: { notify: (message: string, type: string) => void } }) => Promise<void> | void;
+  handler: (args: string, ctx: { ui: { notify: (message: string, type: string) => void } }) => Promise<void> | void;
 };
 
 type TestPi = {
@@ -456,7 +456,7 @@ describe("feature parity", () => {
     // Run /litellm-refresh to update models and costs
     const refreshCmd = pi.commands.get("litellm-refresh");
     const notifications: Array<{ message: string; type: string }> = [];
-    await refreshCmd!.handler([], {
+    await refreshCmd!.handler("", {
       ui: {
         notify: (message: string, type: string) => {
           notifications.push({ message, type });
@@ -535,9 +535,9 @@ describe("feature parity", () => {
       },
     };
 
-    const firstRefresh = refreshCmd!.handler([], ctx);
+    const firstRefresh = refreshCmd!.handler("", ctx);
     await vi.waitFor(() => expect(callCount).toBe(1));
-    const secondRefresh = refreshCmd!.handler([], ctx);
+    const secondRefresh = refreshCmd!.handler("", ctx);
     releaseFetch();
     await Promise.all([firstRefresh, secondRefresh]);
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -14,6 +14,8 @@ const ENV_KEYS = [
 ];
 const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
 
+vi.unmock("@earendil-works/pi-coding-agent");
+
 type TestProviderConfig = {
   baseUrl?: string;
   apiKey?: string;
@@ -164,7 +166,6 @@ afterEach(() => {
   }
   vi.restoreAllMocks();
   vi.resetModules();
-  vi.unmock("@earendil-works/pi-coding-agent");
 });
 
 describe("extension startup", () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -159,7 +159,7 @@ type TestPi = {
 afterEach(() => {
   for (const key of ENV_KEYS) {
     const original = ORIGINAL_ENV.get(key);
-    if (original === undefined) process.env[key] = undefined;
+    if (original === undefined) delete process.env[key];
     else process.env[key] = original;
   }
   vi.restoreAllMocks();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -38,7 +38,20 @@ type TestProviderConfig = {
 
 type TestCommand = {
   description: string;
-  handler: (args: string[], ctx: { ui: { notify: (message: string, type: string) => void } }) => Promise<void> | void;
+  handler: (args: string, ctx: TestCommandContext) => Promise<void> | void;
+};
+
+type TestCommandContext = {
+  ui: {
+    input?: (title: string, placeholder?: string) => Promise<string | undefined>;
+    notify: (message: string, type: string) => void;
+  };
+  modelRegistry?: {
+    authStorage: {
+      set: (provider: string, credential: unknown) => void;
+    };
+    refresh?: () => void;
+  };
 };
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -230,7 +243,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
-    await pi.commands.get("litellm-refresh")?.handler([], { ui: { notify } });
+    await pi.commands.get("litellm-refresh")?.handler("", { ui: { notify } });
 
     expect(fetchMock).not.toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith("LiteLLM refresh disabled (LITELLM_DISCOVERY_TIMEOUT_MS=0)", "warning");
@@ -310,6 +323,59 @@ describe("extension startup", () => {
     expect(pi.providers).toHaveLength(2);
     expect(pi.providers[1]?.config.baseUrl).toBe("http://127.0.0.1:4000/v1");
     expect(registeredModels?.map((model) => model.id)).toEqual(["vidaimock-openai"]);
+  });
+
+  it("supports /login litellm as an extension command", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const savedCredentials: Record<string, unknown> = {};
+    const promptMessages: string[] = [];
+    const notifications: Array<{ message: string; type: string }> = [];
+    await pi.commands.get("login")?.handler("litellm", {
+      ui: {
+        input: async (message, placeholder) => {
+          promptMessages.push(message);
+          return placeholder ? " http://127.0.0.1:4000/v1 " : " sk-login ";
+        },
+        notify: (message, type) => notifications.push({ message, type }),
+      },
+      modelRegistry: {
+        authStorage: {
+          set: (provider, credential) => {
+            savedCredentials[provider] = credential;
+          },
+        },
+        refresh: vi.fn(),
+      },
+    });
+
+    expect(promptMessages).toEqual(["Enter LiteLLM proxy URL (no trailing /v1):", "Enter API key:"]);
+    expect(savedCredentials.litellm).toMatchObject({
+      type: "oauth",
+      access: "sk-login",
+      refresh: "",
+      baseUrl: "http://127.0.0.1:4000",
+    });
+    const registeredModels = pi.providers[1]?.config.models as Array<{ id: string }> | undefined;
+    expect(pi.providers[1]?.config.baseUrl).toBe("http://127.0.0.1:4000/v1");
+    expect(registeredModels?.map((model) => model.id)).toEqual(["vidaimock-openai"]);
+    expect(notifications).toContainEqual({
+      message: "LiteLLM: 1 models discovered (source: model_info)",
+      type: "info",
+    });
   });
 
   it("uses the login cache timestamp for later stale auto-refresh", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -178,6 +178,18 @@ describe("extension startup", () => {
     expect(pi.providers[0]?.config.apiKey).toBe("$LITELLM_API_KEY");
   });
 
+  it('treats literal "undefined" env values as unset', async () => {
+    process.env.LITELLM_BASE_URL = "undefined";
+    process.env.LITELLM_API_KEY = "undefined";
+    const agentDir = await makeAgentDir();
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.baseUrl).toBe("https://litellm.example.com/v1");
+  });
+
   it("discovers with the resolved stored auth key before LITELLM_API_KEY", async () => {
     const agentDir = await makeAgentDir();
     await writeFile(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -325,7 +325,7 @@ describe("extension startup", () => {
     expect(registeredModels?.map((model) => model.id)).toEqual(["vidaimock-openai"]);
   });
 
-  it("supports /login litellm as an extension command", async () => {
+  it("handles /login litellm without registering a conflicting command", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
@@ -341,27 +341,33 @@ describe("extension startup", () => {
     const pi = createPi();
     await extension(pi);
 
+    expect(pi.commands.has("login")).toBe(false);
     const savedCredentials: Record<string, unknown> = {};
     const promptMessages: string[] = [];
     const notifications: Array<{ message: string; type: string }> = [];
-    await pi.commands.get("login")?.handler("litellm", {
-      ui: {
-        input: async (message, placeholder) => {
-          promptMessages.push(message);
-          return placeholder ? " http://127.0.0.1:4000/v1 " : " sk-login ";
-        },
-        notify: (message, type) => notifications.push({ message, type }),
-      },
-      modelRegistry: {
-        authStorage: {
-          set: (provider, credential) => {
-            savedCredentials[provider] = credential;
+    const result = await pi.handlers.get("input")?.[0]?.(
+      { type: "input", text: "/login litellm", source: "interactive" },
+      {
+        hasUI: true,
+        ui: {
+          input: async (message: string, placeholder?: string) => {
+            promptMessages.push(message);
+            return placeholder ? " http://127.0.0.1:4000/v1 " : " sk-login ";
           },
+          notify: (message: string, type: string) => notifications.push({ message, type }),
         },
-        refresh: vi.fn(),
+        modelRegistry: {
+          authStorage: {
+            set: (provider: string, credential: unknown) => {
+              savedCredentials[provider] = credential;
+            },
+          },
+          refresh: vi.fn(),
+        },
       },
-    });
+    );
 
+    expect(result).toEqual({ action: "handled" });
     expect(promptMessages).toEqual(["Enter LiteLLM proxy URL (no trailing /v1):", "Enter API key:"]);
     expect(savedCredentials.litellm).toMatchObject({
       type: "oauth",
@@ -376,6 +382,24 @@ describe("extension startup", () => {
       message: "LiteLLM: 1 models discovered (source: model_info)",
       type: "info",
     });
+  });
+
+  it("continues input handling for non-LiteLLM login arguments", async () => {
+    const agentDir = await makeAgentDir();
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const result = await pi.handlers.get("input")?.[0]?.(
+      { type: "input", text: "/login other", source: "interactive" },
+      {
+        ui: {
+          notify: vi.fn(),
+        },
+      },
+    );
+
+    expect(result).toEqual({ action: "continue" });
   });
 
   it("uses the login cache timestamp for later stale auto-refresh", async () => {

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -36,8 +36,26 @@ describe("dependency security overrides", () => {
       packages?: Record<string, { version?: string }>;
     };
 
-    expect([undefined, "6.0.1"]).toContain(lockfile.packages?.["node_modules/basic-ftp"]?.version);
-    expect(lockfile.packages?.["node_modules/protobufjs"]?.version).toBe("8.2.1");
-    expect(lockfile.packages?.["node_modules/fast-xml-builder"]?.version).toBe("1.2.0");
+    const copiesOf = (name: string): Record<string, string> =>
+      Object.fromEntries(
+        Object.entries(lockfile.packages ?? {})
+          .filter(([path]) => path === `node_modules/${name}` || path.endsWith(`/node_modules/${name}`))
+          .map(([path, pkg]) => [path, pkg.version ?? "missing"]),
+      );
+
+    // basic-ftp left the dependency tree entirely; its override is vestigial.
+    expect(Object.values(copiesOf("basic-ftp")).every((version) => version === "6.0.1")).toBe(true);
+    const fastXmlBuilderCopies = Object.values(copiesOf("fast-xml-builder"));
+    expect(fastXmlBuilderCopies).not.toHaveLength(0);
+    expect(fastXmlBuilderCopies.every((version) => version === "1.2.0")).toBe(true);
+    // pi-coding-agent publishes its own "overrides" field, so npm isolates its
+    // subtree from root overrides (none of plain, @google/genai-scoped, or
+    // pi-coding-agent-scoped overrides reach it; verified with npm 11.16).
+    // Its nested protobufjs copy therefore stays on the latest 7.x until that
+    // is fixed upstream. Any other copy or version drift must fail this test.
+    expect(copiesOf("protobufjs")).toEqual({
+      "node_modules/protobufjs": "8.2.1",
+      "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": "7.5.9",
+    });
   });
 });


### PR DESCRIPTION
Fixes #40.

## Summary
- Support `/login litellm` on clean Pi configs by intercepting Pi's input event path, prompting for LiteLLM URL/API key, persisting credentials, and refreshing registered models/cache.
- Avoid registering a conflicting `/login` extension command, so clean startup no longer emits the built-in-command conflict warning.
- Document the alternate bare `/login` -> `Use a subscription` -> `LiteLLM` flow.
- Retain the earlier review-cleanup commits already on this branch: dependency-override coverage, dead helper cleanup, env restoration hardening, Vitest hoisting cleanup, and the Biome schema migration.

## Verification
- `npm run check`
- `npm run clean && npm run build`
- Clean `--list-models` startup with isolated `PI_CODING_AGENT_DIR`/`HOME` on local Pi `0.78.1` and published Pi `0.79.0`
- Expect-driven TUI `/login litellm` smoke with a mock LiteLLM `/model/info` server on local Pi `0.78.1` and published Pi `0.79.0`; credentials and cache were written, with no `No API key found` error and no `/login` command conflict warning