### PR TITLE
test: improve mocked smoke test coverage

### DIFF
--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -17,7 +17,6 @@ describe("LiteLLM smoke workflow", () => {
   it("routes smoke completions through VidaiMock instead of real LLM APIs", () => {
     const workflow = readWorkflow();
 
-    expect(workflow).toContain("VIDAIMOCK_VERSION: v0.2.7");
     expect(workflow).toContain("Start VidaiMock");
     expect(workflow).toContain("Wait for VidaiMock");
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
@@ -43,6 +42,14 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).not.toContain("GEMINI_API_KEY");
     expect(workflow).not.toContain("require_vendors");
     expect(workflow).not.toContain("model_name: kimi-vidaimock");
+  });
+
+  it("uses minimal permissions and a pinned, checksum-verified VidaiMock build", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toMatch(/permissions:\n {2}contents: read/);
+    expect(workflow).toMatch(/VIDAIMOCK_VERSION: v\d+\.\d+\.\d+$/m);
+    expect(workflow).toMatch(/sha256sum -c "\$\{asset%\.tar\.gz\}\.sha256"/);
   });
 
   it("documents the mocked smoke workflow without provider secrets", () => {

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -10,6 +10,7 @@ function jsonResponse(status: number, body: unknown): Response {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 describe("parseSmokeModels", () => {
@@ -20,16 +21,22 @@ describe("parseSmokeModels", () => {
       "anthropic-claude-haiku",
     ]);
   });
+
+  it("returns an empty list for undefined or separator-only input", () => {
+    expect(parseSmokeModels(undefined)).toEqual([]);
+    expect(parseSmokeModels(" \n ,, \t ")).toEqual([]);
+  });
 });
 
 describe("runSmoke", () => {
   it("discovers models and sends a chat completion request to each requested model", async () => {
-    const requests: Array<{ url: string; body?: unknown }> = [];
+    const requests: Array<{ url: string; body?: unknown; headers?: Record<string, string> }> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
       requests.push({
         url,
         body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        headers: init?.headers as Record<string, string>,
       });
       if (url.endsWith("/model/info")) {
         return jsonResponse(200, {
@@ -71,6 +78,7 @@ describe("runSmoke", () => {
           max_tokens: 16,
           temperature: 0,
         },
+        headers: { Authorization: "Bearer sk-smoke" },
       },
       {
         url: "http://127.0.0.1:4000/v1/chat/completions",
@@ -85,8 +93,10 @@ describe("runSmoke", () => {
   });
 
   it("fails before completion calls when a requested model is not discovered", async () => {
+    const requestedUrls: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
+      requestedUrls.push(url);
       if (url.endsWith("/model/info")) {
         return jsonResponse(200, {
           data: [{ model_name: "github-gpt-4.1-mini", model_info: { mode: "chat" } }],
@@ -103,6 +113,95 @@ describe("runSmoke", () => {
         timeoutMs: 1000,
       }),
     ).rejects.toThrow(/Requested smoke models were not discovered: anthropic-claude-haiku/);
+    expect(requestedUrls).toEqual(["http://127.0.0.1:4000/model/info"]);
+  });
+
+  it("fails without any network calls when no smoke models are configured", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected fetch"));
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: [],
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/At least one smoke model must be configured in LITELLM_SMOKE_MODELS/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fails when a completion returns no assistant text", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, { choices: [{ message: { content: "   " } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["github-models-openai"],
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/\/v1\/chat\/completions for github-models-openai returned no assistant text/);
+  });
+
+  it("aborts a completion that exceeds the configured timeout", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return Promise.resolve(
+          jsonResponse(200, {
+            data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+          }),
+        );
+      }
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["github-models-openai"],
+        timeoutMs: 25,
+      }),
+    ).rejects.toThrow(/Timed out after 25ms/);
+  });
+
+  it("truncates oversized provider error bodies in failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return new Response("x".repeat(600), { status: 500 });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["github-models-openai"],
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(/returned 500: x{500}$/);
   });
 
   it("includes provider response bodies in chat completion failures", async () => {
@@ -170,5 +269,38 @@ describe("runSmokeFromEnv", () => {
     await expect(runSmokeFromEnv({ LITELLM_BASE_URL: "http://127.0.0.1:4000" })).rejects.toThrow(
       /LITELLM_BASE_URL and LITELLM_API_KEY must be set/,
     );
+  });
+
+  it("requires at least one model in LITELLM_SMOKE_MODELS", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected fetch"));
+
+    await expect(
+      runSmokeFromEnv({
+        LITELLM_BASE_URL: "http://127.0.0.1:4000",
+        LITELLM_API_KEY: "sk-env",
+      }),
+    ).rejects.toThrow(/At least one smoke model must be configured in LITELLM_SMOKE_MODELS/);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the default timeout when LITELLM_SMOKE_TIMEOUT_MS is invalid", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          const signal = init?.signal;
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+        }),
+    );
+
+    const smoke = runSmokeFromEnv({
+      LITELLM_BASE_URL: "http://127.0.0.1:4000",
+      LITELLM_API_KEY: "sk-env",
+      LITELLM_SMOKE_MODELS: "github-models-openai",
+      LITELLM_SMOKE_TIMEOUT_MS: "not-a-number",
+    });
+    const rejection = expect(smoke).rejects.toThrow(/Timed out after 30000ms/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejection;
   });
 });


### PR DESCRIPTION
## Summary

- `tests/smoke-runner.test.ts`: cover previously untested failure paths in `scripts/smoke-runner.ts`
  - timeout abort of a hung completion (`Timed out after 25ms`)
  - fallback to the 30s default when `LITELLM_SMOKE_TIMEOUT_MS` is invalid (fake timers)
  - empty model list rejects before any network call (`runSmoke` and `runSmokeFromEnv`)
  - 200 response with whitespace-only assistant text fails the smoke
  - provider error bodies are truncated to 500 chars
  - `parseSmokeModels` handles undefined/separator-only input
  - strengthened existing tests: the not-discovered failure asserts only `/model/info` was called; the happy path asserts the `Authorization` header on completion requests
- `tests/litellm-smoke-workflow.test.ts`: harden workflow assertions
  - new test for minimal `permissions: contents: read` and `sha256sum -c` verification of the VidaiMock download
  - exact `VIDAIMOCK_VERSION: v0.2.7` pin relaxed to a pinned-semver regex so version bumps don't require test edits while the pinning invariant stays guarded

Discovery-fallback paths (`/v1/models`, models.dev) are intentionally not duplicated here; `tests/discover.test.ts` already covers them.

## Test plan

- [x] `npm run check` (Biome, typecheck, full Vitest suite — 86 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)