### PR TITLE
feat: port OpenCode LiteLLM integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 LiteLLM proxy provider extension for [Pi](https://pi.dev).
 
-Discovers models from a self-hosted LiteLLM proxy and registers them under the `litellm` provider. Supports `/login litellm` and `/litellm-refresh`. Tries `/model/info` first (admin endpoint with rich metadata), falls back to `/v1/models` (OpenAI-compatible) on 401/403/404.
+Discovers models from a self-hosted LiteLLM proxy and registers them under the `litellm` provider. Supports `/login litellm`, `/litellm-refresh`, LiteLLM MCP tools, LiteLLM Skills Gateway prompt injection, and Google ADC token auth. Tries `/model/info` first (admin endpoint with rich metadata), falls back to `/v1/models` (OpenAI-compatible) on 401/403/404, then tries `/health` plus per-endpoint `/model/info` for older LiteLLM proxies.
 
 ## Install
 
@@ -64,10 +64,41 @@ Stored pi credentials for `litellm` take precedence over `LITELLM_API_KEY`; the 
 | Variable | Default | Effect |
 |---|---|---|
 | `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. Registered as a `!command` provider key; Pi re-runs it on every request (the per-request auth path is uncached), so rotating/short-lived tokens stay fresh. |
+| `LITELLM_GCLOUD_TOKEN_AUTH` | unset | If set to a non-empty value other than `0`, use Google Application Default Credentials as the LiteLLM bearer token source. This takes precedence over `LITELLM_API_KEY_HELPER` and `LITELLM_API_KEY` when no stored `/login litellm` credential exists. |
+| `GOOGLE_APPLICATION_CREDENTIALS` | Google default ADC path | Optional path to an ADC JSON file used by `LITELLM_GCLOUD_TOKEN_AUTH`. If unset, the extension checks the default gcloud ADC locations. |
 | `LITELLM_OFFLINE` | unset | If `1`, skip discovery on this start; use cache only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Discovery fetch timeout in ms; `0` to skip discovery |
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` only disables startup and refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
+
+### Google ADC token auth
+
+When your LiteLLM proxy accepts Google OAuth access tokens, you can let the extension refresh tokens from Application Default Credentials:
+
+```bash
+gcloud auth application-default login
+export LITELLM_BASE_URL="https://litellm.your-domain.com"
+export LITELLM_GCLOUD_TOKEN_AUTH=1
+```
+
+Only `authorized_user` ADC files are supported. Service account JSON files are rejected with a warning. Tokens are cached in memory for 50 minutes and the registered provider key is a Pi `!command`, so request-time auth resolves a fresh token when Pi sends model requests.
+
+## LiteLLM MCP tools
+
+If your LiteLLM proxy exposes MCP REST endpoints, this extension discovers tools from:
+
+- `GET /mcp-rest/tools/list`
+- `POST /mcp-rest/tools/call`
+
+Each discovered tool is registered as a native Pi tool named `mcp_<server>_<tool>`, with simple JSON Schema parameters mapped to Pi/TypeBox parameters. Complex schemas fall back to a single `args` object. MCP discovery runs after successful live model discovery, `/login litellm`, or `/litellm-refresh`; it does not force network or helper-token access when a fresh model cache is used.
+
+## LiteLLM Skills Gateway
+
+If your LiteLLM proxy exposes `/v1/skills`, enabled skills are fetched before each agent turn and appended to the system prompt as a `litellm_skills` section. The extension also registers Pi tools for basic Skills Gateway management:
+
+- `litellm_skill_list`
+- `litellm_skill_create`
+- `litellm_skill_delete`
 
 ## Mocked LiteLLM smoke workflow
 
@@ -117,10 +148,13 @@ If the cache is older than 24 hours, the extension refreshes it in the backgroun
 | Symptom | Likely cause |
 |---|---|
 | "no credentials" warning at startup | Env vars not set and no OAuth credential — run `/login litellm` |
-| "discovered no models" | Proxy returned an empty list — check pi's startup log for the actual response |
+| "discovered no models" | Proxy returned an empty list — check pi's startup log and verify `/model/info`, `/v1/models`, or `/health` responds |
 | `/model/info` returning 401/403/404 | Expected behavior with virtual keys — extension falls back to `/v1/models` |
 | Discovery times out | Increase `LITELLM_DISCOVERY_TIMEOUT_MS` or set `LITELLM_OFFLINE=1` to fall back on cached models |
 | `401 Token expired` | Set `LITELLM_API_KEY_HELPER`. |
+| No models with gcloud auth | Verify `gcloud auth application-default login` has been run or set `GOOGLE_APPLICATION_CREDENTIALS` to an `authorized_user` ADC file |
+| MCP tools not showing | Verify the proxy exposes `/mcp-rest/tools/list` and run `/litellm-refresh` after fixing the proxy |
+| Skills not affecting prompts | Verify the proxy exposes `/v1/skills` and returns enabled skills |
 
 ## License
 

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -1,4 +1,5 @@
 import { discoverModels, normalizeBaseUrl } from "../src/discover.js";
+import type { DiscoverySource } from "../src/types.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const SMOKE_PROMPT = "Reply with one short word.";
@@ -9,7 +10,7 @@ export type SmokeCompletion = {
 };
 
 export type SmokeResult = {
-  source: "model_info" | "models_list";
+  source: DiscoverySource;
   discoveredCount: number;
   completions: SmokeCompletion[];
 };

--- a/scripts/supply-chain-guard.ts
+++ b/scripts/supply-chain-guard.ts
@@ -44,7 +44,7 @@ const allowedPackageFiles = [
   /^package\.json$/,
   /^README\.md$/,
   /^LICENSE$/,
-  /^dist\/(?:cache|cost|discover|index|litellm|types)\.(?:js|d\.ts)$/,
+  /^dist\/(?:cache|cost|discover|gcloud-token|gcloud-token-cli|index|litellm|mcp-tools|skills|types)\.(?:js|d\.ts)$/,
 ];
 
 export interface SupplyChainGuardOptions {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -38,7 +38,7 @@ function isCacheFileShape(value: unknown): value is CacheFile {
     typeof v.baseUrl === "string" &&
     typeof v.apiKeyFingerprint === "string" &&
     typeof v.fetchedAt === "number" &&
-    (v.source === "model_info" || v.source === "models_list") &&
+    (v.source === "model_info" || v.source === "models_list" || v.source === "health") &&
     Array.isArray(v.models)
   );
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -252,6 +252,23 @@ function mapFromHealthModelInfo(
   };
 }
 
+function mapFromHealthEndpoint(entry: { model?: string }): ProviderModelConfig | undefined {
+  const id = entry.model;
+  if (!id) return undefined;
+  const catalogModel = findCatalogModel(id);
+  return {
+    id,
+    name: catalogModel?.name ?? id,
+    reasoning: catalogModel?.reasoning ?? false,
+    thinkingLevelMap: catalogModel?.thinkingLevelMap,
+    input: catalogModel?.input ?? ["text"],
+    cost: catalogModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
+    compat: buildCompat(id),
+  };
+}
+
 function mapFromModelsList(
   entry: ModelsListEntry,
   modelsDev: ModelsDevResponse | undefined,
@@ -280,19 +297,18 @@ async function discoverFromHealth(
 ): Promise<ProviderModelConfig[]> {
   const healthResult = await fetchJson<HealthResponse>(`${base}/health`, apiKey, options);
   if (!healthResult.ok) return [];
-  const endpoints = (healthResult.data.healthy_endpoints ?? []).filter(
-    (entry) => typeof entry.model_id === "string" && entry.model_id,
-  );
+  const endpoints = (healthResult.data.healthy_endpoints ?? []).filter((entry) => entry.model || entry.model_id);
   const models = await Promise.all(
     endpoints.map(async (endpoint) => {
+      if (!endpoint.model_id) return mapFromHealthEndpoint(endpoint);
       const infoResult = await fetchJson<ModelInfoResponse>(
-        `${base}/model/info?litellm_model_id=${encodeURIComponent(endpoint.model_id!)}`,
+        `${base}/model/info?litellm_model_id=${encodeURIComponent(endpoint.model_id)}`,
         apiKey,
         options,
       );
-      if (!infoResult.ok) return undefined;
+      if (!infoResult.ok) return mapFromHealthEndpoint(endpoint);
       const entry = infoResult.data.data?.[0];
-      return entry ? mapFromHealthModelInfo(entry, endpoint.model) : undefined;
+      return entry ? mapFromHealthModelInfo(entry, endpoint.model) : mapFromHealthEndpoint(endpoint);
     }),
   );
   return models.filter((model): model is ProviderModelConfig => model !== undefined);

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -4,6 +4,7 @@ import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type {
   DiscoveryOptions,
   DiscoveryResult,
+  HealthResponse,
   ModelInfoEntry,
   ModelInfoResponse,
   ModelsListEntry,
@@ -227,6 +228,30 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   };
 }
 
+function mapFromHealthModelInfo(
+  entry: ModelInfoEntry,
+  fallbackId: string | undefined,
+): ProviderModelConfig | undefined {
+  const model = mapFromModelInfo(entry);
+  if (model || !fallbackId) return model;
+  if (entry.model_info?.mode && entry.model_info.mode !== "chat") return undefined;
+  return {
+    id: fallbackId,
+    name: fallbackId,
+    reasoning: entry.model_info?.supports_reasoning ?? false,
+    input: entry.model_info?.supports_vision ? ["text", "image"] : ["text"],
+    cost: {
+      input: (entry.model_info?.input_cost_per_token ?? 0) * 1_000_000,
+      output: (entry.model_info?.output_cost_per_token ?? 0) * 1_000_000,
+      cacheRead: (entry.model_info?.cache_read_input_token_cost ?? 0) * 1_000_000,
+      cacheWrite: (entry.model_info?.cache_creation_input_token_cost ?? 0) * 1_000_000,
+    },
+    contextWindow: entry.model_info?.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: entry.model_info?.max_output_tokens ?? DEFAULT_MAX_TOKENS,
+    compat: buildCompat(fallbackId),
+  };
+}
+
 function mapFromModelsList(
   entry: ModelsListEntry,
   modelsDev: ModelsDevResponse | undefined,
@@ -248,6 +273,31 @@ function mapFromModelsList(
   };
 }
 
+async function discoverFromHealth(
+  base: string,
+  apiKey: string,
+  options: DiscoveryOptions,
+): Promise<ProviderModelConfig[]> {
+  const healthResult = await fetchJson<HealthResponse>(`${base}/health`, apiKey, options);
+  if (!healthResult.ok) return [];
+  const endpoints = (healthResult.data.healthy_endpoints ?? []).filter(
+    (entry) => typeof entry.model_id === "string" && entry.model_id,
+  );
+  const models = await Promise.all(
+    endpoints.map(async (endpoint) => {
+      const infoResult = await fetchJson<ModelInfoResponse>(
+        `${base}/model/info?litellm_model_id=${encodeURIComponent(endpoint.model_id!)}`,
+        apiKey,
+        options,
+      );
+      if (!infoResult.ok) return undefined;
+      const entry = infoResult.data.data?.[0];
+      return entry ? mapFromHealthModelInfo(entry, endpoint.model) : undefined;
+    }),
+  );
+  return models.filter((model): model is ProviderModelConfig => model !== undefined);
+}
+
 export async function discoverModels(
   baseUrl: string,
   apiKey: string,
@@ -266,6 +316,10 @@ export async function discoverModels(
   }
   const listResult = await fetchJson<ModelsListResponse>(`${base}/v1/models`, apiKey, options);
   if (!listResult.ok) {
+    if ([401, 403, 404].includes(listResult.status)) {
+      const models = await discoverFromHealth(base, apiKey, options);
+      if (models.length > 0) return { source: "health", models };
+    }
     throw new Error(`/v1/models returned ${listResult.status}`);
   }
   const modelsDev = await getModelsDevCatalog(options);

--- a/src/gcloud-token-cli.ts
+++ b/src/gcloud-token-cli.ts
@@ -1,0 +1,8 @@
+import { getGcloudToken } from "./gcloud-token.js";
+
+const token = await getGcloudToken();
+if (token) {
+  process.stdout.write(token);
+} else {
+  process.exitCode = 1;
+}

--- a/src/gcloud-token.ts
+++ b/src/gcloud-token.ts
@@ -11,6 +11,7 @@ const ADC_FILENAME = "application_default_credentials.json";
 
 let cachedToken: string | null = null;
 let cachedAt = 0;
+let cachedTokenKey: string | null = null;
 
 interface AuthorizedUserCredentials {
   type: "authorized_user";
@@ -58,12 +59,46 @@ function getAdcPath(): string | null {
   return candidates.find((path) => existsSync(path)) ?? null;
 }
 
+function getCredentialsCacheKey(credentials: GoogleCredentials): string | null {
+  if (isAuthorizedUserCredentials(credentials)) {
+    return `${GCLOUD_TOKEN_CACHE_KEY}:authorized_user:${credentials.client_id}:${credentials.refresh_token}`;
+  }
+  return null;
+}
+
 async function readCredentials(path: string): Promise<GoogleCredentials | null> {
   try {
     return JSON.parse(await readFile(path, "utf8")) as GoogleCredentials;
   } catch {
     return null;
   }
+}
+
+export async function getGcloudTokenCacheKey(): Promise<string | null> {
+  const adcPath = getAdcPath();
+  if (!adcPath) {
+    console.warn(
+      "LiteLLM gcloud auth: No Google ADC file found. Set GOOGLE_APPLICATION_CREDENTIALS or run `gcloud auth application-default login`.",
+    );
+    return null;
+  }
+
+  const credentials = await readCredentials(adcPath);
+  if (!credentials) {
+    console.warn(`LiteLLM gcloud auth: Failed to read ADC file: ${adcPath}`);
+    return null;
+  }
+
+  const cacheKey = getCredentialsCacheKey(credentials);
+  if (cacheKey) return cacheKey;
+
+  if (credentials.type === "service_account") {
+    console.warn("LiteLLM gcloud auth: Service account credentials are not supported; use authorized_user ADC.");
+    return null;
+  }
+
+  console.warn(`LiteLLM gcloud auth: Unknown credential type: ${credentials.type ?? "missing"}`);
+  return null;
 }
 
 async function exchangeRefreshToken(credentials: AuthorizedUserCredentials): Promise<string | null> {
@@ -98,8 +133,6 @@ async function exchangeRefreshToken(credentials: AuthorizedUserCredentials): Pro
 }
 
 export async function getGcloudToken(): Promise<string | null> {
-  if (cachedToken && Date.now() - cachedAt < CACHE_TTL_MS) return cachedToken;
-
   const adcPath = getAdcPath();
   if (!adcPath) {
     console.warn(
@@ -114,10 +147,15 @@ export async function getGcloudToken(): Promise<string | null> {
     return null;
   }
 
+  const cacheKey = getCredentialsCacheKey(credentials);
+  if (cacheKey && cachedToken && cachedTokenKey === cacheKey && Date.now() - cachedAt < CACHE_TTL_MS)
+    return cachedToken;
+
   if (isAuthorizedUserCredentials(credentials)) {
     const token = await exchangeRefreshToken(credentials);
     if (token) {
       cachedToken = token;
+      cachedTokenKey = cacheKey;
       cachedAt = Date.now();
     }
     return token;
@@ -134,5 +172,6 @@ export async function getGcloudToken(): Promise<string | null> {
 
 export function resetGcloudTokenCache(): void {
   cachedToken = null;
+  cachedTokenKey = null;
   cachedAt = 0;
 }

--- a/src/gcloud-token.ts
+++ b/src/gcloud-token.ts
@@ -1,0 +1,138 @@
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const CACHE_TTL_MS = 50 * 60 * 1000;
+export const GCLOUD_TOKEN_CACHE_KEY = "gcloud-adc";
+
+const ADC_FILENAME = "application_default_credentials.json";
+
+let cachedToken: string | null = null;
+let cachedAt = 0;
+
+interface AuthorizedUserCredentials {
+  type: "authorized_user";
+  client_id: string;
+  client_secret: string;
+  refresh_token: string;
+}
+
+interface ServiceAccountCredentials {
+  type: "service_account";
+}
+
+type GoogleCredentials = AuthorizedUserCredentials | ServiceAccountCredentials | { type?: string };
+
+function isAuthorizedUserCredentials(credentials: GoogleCredentials): credentials is AuthorizedUserCredentials {
+  return (
+    credentials.type === "authorized_user" &&
+    typeof (credentials as Partial<AuthorizedUserCredentials>).client_id === "string" &&
+    typeof (credentials as Partial<AuthorizedUserCredentials>).client_secret === "string" &&
+    typeof (credentials as Partial<AuthorizedUserCredentials>).refresh_token === "string"
+  );
+}
+
+export function isGcloudTokenAuthEnabled(): boolean {
+  const raw = process.env.LITELLM_GCLOUD_TOKEN_AUTH;
+  return raw !== undefined && raw !== "" && raw !== "0";
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+export function getGcloudTokenCommand(): string {
+  const cliPath = fileURLToPath(new URL("./gcloud-token-cli.js", import.meta.url));
+  return `!${shellQuote(process.execPath)} ${shellQuote(cliPath)}`;
+}
+
+function getAdcPath(): string | null {
+  const envPath = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+  if (envPath) return envPath;
+
+  const candidates = [join(homedir(), ".config", "gcloud", ADC_FILENAME)];
+  if (process.env.APPDATA) candidates.push(join(process.env.APPDATA, "gcloud", ADC_FILENAME));
+
+  return candidates.find((path) => existsSync(path)) ?? null;
+}
+
+async function readCredentials(path: string): Promise<GoogleCredentials | null> {
+  try {
+    return JSON.parse(await readFile(path, "utf8")) as GoogleCredentials;
+  } catch {
+    return null;
+  }
+}
+
+async function exchangeRefreshToken(credentials: AuthorizedUserCredentials): Promise<string | null> {
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    client_id: credentials.client_id,
+    client_secret: credentials.client_secret,
+    refresh_token: credentials.refresh_token,
+  }).toString();
+
+  try {
+    const response = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!response.ok) {
+      console.warn(`LiteLLM gcloud auth: Token exchange failed (${response.status}): ${await response.text()}`);
+      return null;
+    }
+
+    const data = (await response.json()) as { access_token?: unknown };
+    return typeof data.access_token === "string" && data.access_token ? data.access_token : null;
+  } catch (error) {
+    console.warn(
+      `LiteLLM gcloud auth: Token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return null;
+  }
+}
+
+export async function getGcloudToken(): Promise<string | null> {
+  if (cachedToken && Date.now() - cachedAt < CACHE_TTL_MS) return cachedToken;
+
+  const adcPath = getAdcPath();
+  if (!adcPath) {
+    console.warn(
+      "LiteLLM gcloud auth: No Google ADC file found. Set GOOGLE_APPLICATION_CREDENTIALS or run `gcloud auth application-default login`.",
+    );
+    return null;
+  }
+
+  const credentials = await readCredentials(adcPath);
+  if (!credentials) {
+    console.warn(`LiteLLM gcloud auth: Failed to read ADC file: ${adcPath}`);
+    return null;
+  }
+
+  if (isAuthorizedUserCredentials(credentials)) {
+    const token = await exchangeRefreshToken(credentials);
+    if (token) {
+      cachedToken = token;
+      cachedAt = Date.now();
+    }
+    return token;
+  }
+
+  if (credentials.type === "service_account") {
+    console.warn("LiteLLM gcloud auth: Service account credentials are not supported; use authorized_user ADC.");
+    return null;
+  }
+
+  console.warn(`LiteLLM gcloud auth: Unknown credential type: ${credentials.type ?? "missing"}`);
+  return null;
+}
+
+export function resetGcloudTokenCache(): void {
+  cachedToken = null;
+  cachedAt = 0;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
 import {
-  GCLOUD_TOKEN_CACHE_KEY,
   getGcloudToken,
+  getGcloudTokenCacheKey,
   getGcloudTokenCommand,
   isGcloudTokenAuthEnabled,
 } from "./gcloud-token.js";
@@ -104,35 +104,46 @@ async function resolveCredentials({ executeHelpers = true } = {}): Promise<Resol
   const envHelperCommand = getApiKeyHelperCommand();
   const useGcloudToken = isGcloudTokenAuthEnabled();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
+  const gcloudCacheKey = useGcloudToken && !entry ? ((await getGcloudTokenCacheKey()) ?? undefined) : undefined;
   const authKey =
     entry?.type === "oauth"
       ? (executeHelpers ? resolveOAuthApiKey(entry) : entry.access).trim()
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
-  const gcloudKey = executeHelpers && useGcloudToken ? (await getGcloudToken())?.trim() : undefined;
-  const apiKey =
-    authKey ||
-    gcloudKey ||
-    (executeHelpers && envHelperCommand ? executeApiKeyCommand(envHelperCommand) : undefined) ||
-    envKey;
-  const apiKeyFingerprint =
-    entry?.type === "oauth" && entry.refresh.startsWith("!")
-      ? fingerprint(entry.refresh)
-      : authKey
-        ? fingerprint(authKey)
-        : useGcloudToken
-          ? fingerprint(GCLOUD_TOKEN_CACHE_KEY)
-          : envHelperCommand
-            ? fingerprint(envHelperCommand)
-            : envKey
-              ? fingerprint(envKey)
-              : undefined;
+  const gcloudKey = executeHelpers && gcloudCacheKey ? (await getGcloudToken())?.trim() : undefined;
+  const helperKey =
+    !authKey && !gcloudKey && executeHelpers && envHelperCommand ? executeApiKeyCommand(envHelperCommand) : undefined;
+  const apiKey = authKey || gcloudKey || helperKey || envKey;
+
+  let apiKeyFingerprint: string | undefined;
+  let apiKeyConfig: string | undefined;
+  if (entry?.type === "oauth" && entry.refresh.startsWith("!")) {
+    apiKeyFingerprint = fingerprint(entry.refresh);
+  } else if (authKey) {
+    apiKeyFingerprint = fingerprint(authKey);
+  } else if (gcloudKey) {
+    apiKeyFingerprint = fingerprint(gcloudCacheKey ?? gcloudKey);
+    apiKeyConfig = getGcloudTokenCommand();
+  } else if (!executeHelpers && gcloudCacheKey) {
+    apiKeyFingerprint = fingerprint(gcloudCacheKey);
+    apiKeyConfig = getGcloudTokenCommand();
+  } else if (helperKey && envHelperCommand) {
+    apiKeyFingerprint = fingerprint(envHelperCommand);
+    apiKeyConfig = envHelperCommand;
+  } else if (!executeHelpers && envHelperCommand) {
+    apiKeyFingerprint = fingerprint(envHelperCommand);
+    apiKeyConfig = envHelperCommand;
+  } else if (envKey) {
+    apiKeyFingerprint = fingerprint(envKey);
+    apiKeyConfig = `$${ENV_API_KEY}`;
+  }
   const rawBase = authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
     apiKey: apiKey || undefined,
     apiKeyFingerprint,
+    apiKeyConfig,
   };
 }
 
@@ -150,11 +161,6 @@ function isOffline(): boolean {
 
 function isListModelsMode(): boolean {
   return process.argv.includes("--list-models");
-}
-
-function getProviderApiKeyConfig(): string {
-  if (isGcloudTokenAuthEnabled()) return getGcloudTokenCommand();
-  return getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`;
 }
 
 async function discoverWithFallback(
@@ -395,7 +401,11 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     modifyModels: modifyLiteLLMModels,
   };
 
-  function registerProvider(baseUrl: string | undefined, models: ProviderModelConfig[]): void {
+  function registerProvider(
+    baseUrl: string | undefined,
+    models: ProviderModelConfig[],
+    apiKeyConfig = creds.apiKeyConfig ?? getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`,
+  ): void {
     pi.registerProvider(PROVIDER_NAME, {
       baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
       // When LITELLM_API_KEY_HELPER is set we register the helper as a `!command` provider key.
@@ -405,7 +415,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       // resolveConfigValue). So a short-lived/rotating helper token stays fresh. The OAuth hooks
       // remain registered for `/login litellm` users. See the regression test
       // "re-runs the helper command on every request" in tests/index.test.ts.
-      apiKey: getProviderApiKeyConfig(),
+      apiKey: apiKeyConfig,
       api: "openai-completions",
       models,
       oauth,
@@ -481,7 +491,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       source: result.source,
       models: result.models,
     });
-    registerProvider(fresh.baseUrl, result.models);
+    registerProvider(fresh.baseUrl, result.models, fresh.apiKeyConfig);
     updateCosts(result.models);
     cacheFetchedAt = now;
     await registerMcpTools(fresh.baseUrl, fresh.apiKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,15 @@ import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
+import {
+  GCLOUD_TOKEN_CACHE_KEY,
+  getGcloudToken,
+  getGcloudTokenCommand,
+  isGcloudTokenAuthEnabled,
+} from "./gcloud-token.js";
 import { getSessionIdFromFile } from "./litellm.js";
+import { createMcpToolDefinitions } from "./mcp-tools.js";
+import { createSkillsPromptSection, createSkillToolDefinitions, listSkills } from "./skills.js";
 import type { AuthFileEntry, CacheFile, DiscoveryOptions, DiscoveryResult, ResolvedCredentials } from "./types.js";
 
 const PROVIDER_NAME = "litellm";
@@ -94,6 +102,7 @@ async function resolveCredentials({ executeHelpers = true } = {}): Promise<Resol
   const envBase = cleanConfig(process.env[ENV_BASE_URL]);
   const envKey = cleanConfig(process.env[ENV_API_KEY]);
   const envHelperCommand = getApiKeyHelperCommand();
+  const useGcloudToken = isGcloudTokenAuthEnabled();
   const authBase = entry?.type === "oauth" ? entry.baseUrl?.trim() : undefined;
   const authKey =
     entry?.type === "oauth"
@@ -101,18 +110,24 @@ async function resolveCredentials({ executeHelpers = true } = {}): Promise<Resol
       : entry?.type === "api_key"
         ? (await AuthStorage.create(getAuthPath()).getApiKey(PROVIDER_NAME, { includeFallback: false }))?.trim()
         : undefined;
+  const gcloudKey = executeHelpers && useGcloudToken ? (await getGcloudToken())?.trim() : undefined;
   const apiKey =
-    authKey || (executeHelpers && envHelperCommand ? executeApiKeyCommand(envHelperCommand) : undefined) || envKey;
+    authKey ||
+    gcloudKey ||
+    (executeHelpers && envHelperCommand ? executeApiKeyCommand(envHelperCommand) : undefined) ||
+    envKey;
   const apiKeyFingerprint =
     entry?.type === "oauth" && entry.refresh.startsWith("!")
       ? fingerprint(entry.refresh)
       : authKey
         ? fingerprint(authKey)
-        : envHelperCommand
-          ? fingerprint(envHelperCommand)
-          : envKey
-            ? fingerprint(envKey)
-            : undefined;
+        : useGcloudToken
+          ? fingerprint(GCLOUD_TOKEN_CACHE_KEY)
+          : envHelperCommand
+            ? fingerprint(envHelperCommand)
+            : envKey
+              ? fingerprint(envKey)
+              : undefined;
   const rawBase = authBase || envBase;
   return {
     baseUrl: rawBase ? normalizeBaseUrl(rawBase) : undefined,
@@ -135,6 +150,11 @@ function isOffline(): boolean {
 
 function isListModelsMode(): boolean {
   return process.argv.includes("--list-models");
+}
+
+function getProviderApiKeyConfig(): string {
+  if (isGcloudTokenAuthEnabled()) return getGcloudTokenCommand();
+  return getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`;
 }
 
 async function discoverWithFallback(
@@ -316,6 +336,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     (!cacheValid || isListModelsMode());
 
   let credentialWarning: string | undefined;
+  let liveDiscoveryApiKey: string | undefined;
   if (shouldFetch) {
     try {
       creds = await resolveCredentials();
@@ -343,6 +364,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       }
     } else {
       models = result.models;
+      liveDiscoveryApiKey = creds.apiKey;
       const next: CacheFile = {
         baseUrl: creds.baseUrl,
         apiKeyFingerprint: fp,
@@ -383,7 +405,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       // resolveConfigValue). So a short-lived/rotating helper token stays fresh. The OAuth hooks
       // remain registered for `/login litellm` users. See the regression test
       // "re-runs the helper command on every request" in tests/index.test.ts.
-      apiKey: getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`,
+      apiKey: getProviderApiKeyConfig(),
       api: "openai-completions",
       models,
       oauth,
@@ -401,6 +423,48 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     if (getDiscoveryTimeoutMs() === 0) return `${ENV_TIMEOUT}=0`;
     return null;
   }
+
+  async function resolveRuntimeApiKey(): Promise<string> {
+    const fresh = await resolveCredentials();
+    if (!fresh.apiKey) throw new Error("no credentials. Run /login litellm or set env vars.");
+    return fresh.apiKey;
+  }
+
+  function registerSkillTools(baseUrl: string | undefined): void {
+    if (!baseUrl) return;
+    for (const tool of createSkillToolDefinitions(baseUrl, resolveRuntimeApiKey)) {
+      pi.registerTool(tool);
+    }
+  }
+
+  function seededRuntimeApiKey(seed: string): () => Promise<string> {
+    let first: string | undefined = seed;
+    return async () => {
+      if (first) {
+        const value = first;
+        first = undefined;
+        return value;
+      }
+      return resolveRuntimeApiKey();
+    };
+  }
+
+  async function registerMcpTools(baseUrl: string | undefined, discoveryApiKey: string | undefined): Promise<void> {
+    if (!baseUrl || !discoveryApiKey || discoveryDisabledReason()) return;
+    try {
+      const tools = await createMcpToolDefinitions(baseUrl, seededRuntimeApiKey(discoveryApiKey));
+      for (const tool of tools) {
+        pi.registerTool(tool);
+      }
+    } catch (error) {
+      process.stderr.write(
+        `LiteLLM: MCP tool discovery failed (${error instanceof Error ? error.message : String(error)}).\n`,
+      );
+    }
+  }
+
+  registerSkillTools(creds.baseUrl);
+  await registerMcpTools(creds.baseUrl, liveDiscoveryApiKey);
 
   async function refreshModelsAndCosts(): Promise<RefreshResult> {
     const fresh = await resolveCredentials();
@@ -420,6 +484,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     registerProvider(fresh.baseUrl, result.models);
     updateCosts(result.models);
     cacheFetchedAt = now;
+    await registerMcpTools(fresh.baseUrl, fresh.apiKey);
     return { models: result.models, source: result.source };
   }
 
@@ -455,6 +520,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
     ctx.modelRegistry.authStorage.set(PROVIDER_NAME, { type: "oauth", ...credential });
     ctx.modelRegistry.refresh();
+    const credentialBaseUrl = (credential as { baseUrl?: string }).baseUrl;
+    const credentialAccess = typeof credential.access === "string" ? credential.access : undefined;
+    registerSkillTools(credentialBaseUrl);
+    await registerMcpTools(credentialBaseUrl, credentialAccess);
     ctx.ui.notify(`Logged in to LiteLLM. Credentials saved to ${getAuthPath()}`, "info");
   }
 
@@ -502,6 +571,16 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     if (ctx.model?.provider !== PROVIDER_NAME) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
     return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model?.id, sessionId);
+  });
+
+  pi.on("before_agent_start", async (event) => {
+    if (discoveryDisabledReason()) return;
+    const fresh = await resolveCredentials();
+    if (!fresh.baseUrl || !fresh.apiKey) return;
+    const skills = await listSkills(fresh.baseUrl, fresh.apiKey);
+    const section = createSkillsPromptSection(skills);
+    if (!section) return;
+    return { systemPrompt: `${event.systemPrompt}\n\n${section}` };
   });
 
   pi.on("message_end", (event) => {

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -7,12 +7,53 @@ import type { LiteLLMMcpTool } from "./types.js";
 const LIST_TIMEOUT_MS = 10_000;
 const CALL_TIMEOUT_MS = 30_000;
 
+interface RawLiteLLMMcpTool {
+  name?: unknown;
+  description?: unknown;
+  inputSchema?: unknown;
+  input_schema?: unknown;
+  server_id?: unknown;
+  server_name?: unknown;
+  mcp_info?: {
+    server_id?: unknown;
+    server_name?: unknown;
+  };
+}
+
 function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
   return {
     signal: controller.signal,
     cancel: () => clearTimeout(timer),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function normalizeMcpTool(value: unknown): LiteLLMMcpTool | undefined {
+  const raw = asRecord(value) as RawLiteLLMMcpTool | undefined;
+  if (!raw) return undefined;
+  const name = stringValue(raw.name);
+  const serverName =
+    stringValue(raw.mcp_info?.server_name) ??
+    stringValue(raw.server_name) ??
+    stringValue(raw.mcp_info?.server_id) ??
+    stringValue(raw.server_id);
+  if (!name || !serverName) return undefined;
+  const inputSchema = asRecord(raw.inputSchema) ?? asRecord(raw.input_schema) ?? { type: "object", properties: {} };
+  return {
+    name,
+    server_name: serverName,
+    server_id: stringValue(raw.mcp_info?.server_id) ?? stringValue(raw.server_id) ?? serverName,
+    description: stringValue(raw.description) ?? name,
+    input_schema: inputSchema,
   };
 }
 
@@ -28,7 +69,9 @@ export async function discoverMcpTools(baseUrl: string, apiKey: string): Promise
     });
     if (!response.ok) return [];
     const body = (await response.json()) as unknown;
-    return Array.isArray(body) ? (body as LiteLLMMcpTool[]) : [];
+    const bodyRecord = asRecord(body);
+    const rawTools = Array.isArray(body) ? body : Array.isArray(bodyRecord?.tools) ? bodyRecord.tools : [];
+    return rawTools.map(normalizeMcpTool).filter((tool): tool is LiteLLMMcpTool => tool !== undefined);
   } catch {
     return [];
   } finally {
@@ -39,7 +82,7 @@ export async function discoverMcpTools(baseUrl: string, apiKey: string): Promise
 export async function executeMcpTool(
   baseUrl: string,
   apiKey: string,
-  server: string,
+  serverId: string,
   toolName: string,
   args: Record<string, unknown>,
 ): Promise<string> {
@@ -51,14 +94,14 @@ export async function executeMcpTool(
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({ server, tool: toolName, args }),
+      body: JSON.stringify({ server_id: serverId, name: toolName, arguments: args }),
       signal,
     });
-    if (!response.ok) return `Error calling ${toolName} on ${server}: HTTP ${response.status}`;
+    if (!response.ok) return `Error calling ${toolName} on ${serverId}: HTTP ${response.status}`;
     const body = (await response.json()) as Record<string, unknown>;
     return JSON.stringify("result" in body ? body.result : body, null, 2);
   } catch (error) {
-    return `Error calling ${toolName} on ${server}: ${error instanceof Error ? error.message : String(error)}`;
+    return `Error calling ${toolName} on ${serverId}: ${error instanceof Error ? error.message : String(error)}`;
   } finally {
     cancel();
   }
@@ -152,10 +195,16 @@ export async function createMcpToolDefinitions(
           Object.keys(rawParams).length === 1 && rawParams.args && typeof rawParams.args === "object"
             ? (rawParams.args as Record<string, unknown>)
             : rawParams;
-        const text = await executeMcpTool(baseUrl, apiKey, mcpTool.server_name, mcpTool.name, args);
+        const text = await executeMcpTool(
+          baseUrl,
+          apiKey,
+          mcpTool.server_id ?? mcpTool.server_name,
+          mcpTool.name,
+          args,
+        );
         return {
           content: [{ type: "text", text }],
-          details: { server: mcpTool.server_name, tool: mcpTool.name },
+          details: { server: mcpTool.server_name, serverId: mcpTool.server_id, tool: mcpTool.name },
         };
       },
     });

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -1,0 +1,163 @@
+import type { Static, TSchema } from "@earendil-works/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { normalizeBaseUrl } from "./discover.js";
+import type { LiteLLMMcpTool } from "./types.js";
+
+const LIST_TIMEOUT_MS = 10_000;
+const CALL_TIMEOUT_MS = 30_000;
+
+function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timer),
+  };
+}
+
+export async function discoverMcpTools(baseUrl: string, apiKey: string): Promise<LiteLLMMcpTool[]> {
+  const { signal, cancel } = withTimeout(LIST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/list`, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      signal,
+    });
+    if (!response.ok) return [];
+    const body = (await response.json()) as unknown;
+    return Array.isArray(body) ? (body as LiteLLMMcpTool[]) : [];
+  } catch {
+    return [];
+  } finally {
+    cancel();
+  }
+}
+
+export async function executeMcpTool(
+  baseUrl: string,
+  apiKey: string,
+  server: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const { signal, cancel } = withTimeout(CALL_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/call`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ server, tool: toolName, args }),
+      signal,
+    });
+    if (!response.ok) return `Error calling ${toolName} on ${server}: HTTP ${response.status}`;
+    const body = (await response.json()) as Record<string, unknown>;
+    return JSON.stringify("result" in body ? body.result : body, null, 2);
+  } catch (error) {
+    return `Error calling ${toolName} on ${server}: ${error instanceof Error ? error.message : String(error)}`;
+  } finally {
+    cancel();
+  }
+}
+
+function sanitizeName(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  return sanitized || "tool";
+}
+
+function isMappableSchema(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object") return false;
+  const schema = value as Record<string, unknown>;
+  if ("$ref" in schema || "anyOf" in schema || "oneOf" in schema || "allOf" in schema) return false;
+  if (["string", "number", "integer", "boolean"].includes(String(schema.type))) return true;
+  if (schema.type === "array") {
+    const items = schema.items as Record<string, unknown> | undefined;
+    return items?.type === "string";
+  }
+  return false;
+}
+
+function mapPropertySchema(name: string, schema: Record<string, unknown>): TSchema {
+  const description = typeof schema.description === "string" ? schema.description : name;
+  switch (schema.type) {
+    case "string":
+      return Type.String({ description });
+    case "number":
+      return Type.Number({ description });
+    case "integer":
+      return Type.Integer({ description });
+    case "boolean":
+      return Type.Boolean({ description });
+    case "array":
+      return Type.Array(Type.String(), { description });
+    default:
+      return Type.Unknown({ description });
+  }
+}
+
+function buildParameters(inputSchema: Record<string, unknown>): TSchema {
+  const properties = inputSchema.properties as Record<string, unknown> | undefined;
+  if (!properties || typeof properties !== "object") {
+    return Type.Object({
+      args: Type.Record(Type.String(), Type.Unknown(), { description: "Tool arguments as key-value pairs" }),
+    });
+  }
+
+  const required = Array.isArray(inputSchema.required)
+    ? inputSchema.required.filter((key) => typeof key === "string")
+    : [];
+  const mapped: Record<string, TSchema> = {};
+  for (const [key, property] of Object.entries(properties)) {
+    if (!isMappableSchema(property)) {
+      return Type.Object({
+        args: Type.Record(Type.String(), Type.Unknown(), { description: "Tool arguments as key-value pairs" }),
+      });
+    }
+    const field = mapPropertySchema(key, property);
+    mapped[key] = required.includes(key) ? field : Type.Optional(field);
+  }
+
+  return Type.Object(mapped);
+}
+
+export async function createMcpToolDefinitions(
+  baseUrl: string,
+  getApiKey: () => Promise<string>,
+): Promise<ToolDefinition[]> {
+  const discoveryApiKey = await getApiKey();
+  const tools = await discoverMcpTools(baseUrl, discoveryApiKey);
+
+  return tools.map((mcpTool) => {
+    const safeServer = sanitizeName(mcpTool.server_name);
+    const safeTool = sanitizeName(mcpTool.name);
+    const parameters = buildParameters(mcpTool.input_schema);
+
+    return defineTool({
+      name: `mcp_${safeServer}_${safeTool}`,
+      label: `${mcpTool.server_name}: ${mcpTool.name}`,
+      description: `${mcpTool.description} (via ${mcpTool.server_name} MCP server)`,
+      promptSnippet: `${mcpTool.description} via ${mcpTool.server_name} MCP server`,
+      parameters,
+      async execute(_toolCallId, params: Static<typeof parameters>) {
+        const apiKey = await getApiKey();
+        const rawParams = params as Record<string, unknown>;
+        const args =
+          Object.keys(rawParams).length === 1 && rawParams.args && typeof rawParams.args === "object"
+            ? (rawParams.args as Record<string, unknown>)
+            : rawParams;
+        const text = await executeMcpTool(baseUrl, apiKey, mcpTool.server_name, mcpTool.name, args);
+        return {
+          content: [{ type: "text", text }],
+          details: { server: mcpTool.server_name, tool: mcpTool.name },
+        };
+      },
+    });
+  });
+}

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -1,0 +1,166 @@
+import type { Static } from "@earendil-works/pi-ai";
+import { Type } from "@earendil-works/pi-ai";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { normalizeBaseUrl } from "./discover.js";
+import type { LiteLLMSkill } from "./types.js";
+
+const SKILLS_CACHE_TTL_MS = 60_000;
+
+let skillsCache:
+  | {
+      baseUrl: string;
+      apiKey: string;
+      fetchedAt: number;
+      skills: LiteLLMSkill[];
+    }
+  | undefined;
+
+function getSkillsFromBody(body: unknown): LiteLLMSkill[] {
+  if (Array.isArray(body)) return body as LiteLLMSkill[];
+  if (body && typeof body === "object") {
+    const record = body as { data?: unknown; skills?: unknown };
+    if (Array.isArray(record.data)) return record.data as LiteLLMSkill[];
+    if (Array.isArray(record.skills)) return record.skills as LiteLLMSkill[];
+  }
+  return [];
+}
+
+export async function listSkills(baseUrl: string, apiKey: string): Promise<LiteLLMSkill[]> {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  if (
+    skillsCache &&
+    skillsCache.baseUrl === normalizedBaseUrl &&
+    skillsCache.apiKey === apiKey &&
+    Date.now() - skillsCache.fetchedAt < SKILLS_CACHE_TTL_MS
+  ) {
+    return skillsCache.skills;
+  }
+
+  try {
+    const response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
+      headers: { Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) return [];
+    const skills = getSkillsFromBody(await response.json());
+    skillsCache = { baseUrl: normalizedBaseUrl, apiKey, fetchedAt: Date.now(), skills };
+    return skills;
+  } catch {
+    return [];
+  }
+}
+
+export async function createSkill(
+  baseUrl: string,
+  apiKey: string,
+  input: { name: string; description: string; code: string; inputSchema?: Record<string, unknown> },
+): Promise<unknown> {
+  const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/skills`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: input.name,
+      description: input.description,
+      code: input.code,
+      input_schema: input.inputSchema ?? { type: "object", properties: {} },
+    }),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) throw new Error(`LiteLLM skill create failed: HTTP ${response.status}`);
+  skillsCache = undefined;
+  return response.json().catch(() => ({}));
+}
+
+export async function deleteSkill(baseUrl: string, apiKey: string, skillId: string): Promise<void> {
+  const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/skills/${encodeURIComponent(skillId)}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok && response.status !== 404) throw new Error(`LiteLLM skill delete failed: HTTP ${response.status}`);
+  skillsCache = undefined;
+}
+
+function escapeXml(value: string): string {
+  return value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;");
+}
+
+export function createSkillsPromptSection(skills: LiteLLMSkill[]): string | undefined {
+  const enabled = skills.filter((skill) => skill.enabled !== false && skill.name);
+  if (enabled.length === 0) return undefined;
+
+  const body = enabled
+    .map((skill) => {
+      const description = skill.description?.trim() || "No description provided.";
+      return `<skill name="${escapeXml(skill.name)}">\n${escapeXml(description)}\n</skill>`;
+    })
+    .join("\n");
+  return `LiteLLM Skills Gateway provided these active skills. Use them as additional guidance when relevant.\n<litellm_skills>\n${body}\n</litellm_skills>`;
+}
+
+function formatSkills(skills: LiteLLMSkill[]): string {
+  if (skills.length === 0) return "No LiteLLM skills are registered.";
+  return skills
+    .map((skill) => `- ${skill.name}${skill.enabled === false ? " (disabled)" : ""}: ${skill.description ?? ""}`)
+    .join("\n");
+}
+
+const CreateSkillParams = Type.Object({
+  name: Type.String({ description: "Skill name" }),
+  description: Type.String({ description: "Skill description" }),
+  code: Type.String({ description: "Skill implementation or prompt code" }),
+  inputSchemaJson: Type.Optional(Type.String({ description: "Optional JSON Schema string for skill inputs" })),
+});
+
+const DeleteSkillParams = Type.Object({
+  skillId: Type.String({ description: "LiteLLM skill id" }),
+});
+
+export function createSkillToolDefinitions(baseUrl: string, getApiKey: () => Promise<string>): ToolDefinition[] {
+  return [
+    defineTool({
+      name: "litellm_skill_list",
+      label: "LiteLLM Skills",
+      description: "List skills registered on the LiteLLM proxy Skills Gateway.",
+      promptSnippet: "List LiteLLM Skills Gateway skills",
+      parameters: Type.Object({}),
+      async execute() {
+        const apiKey = await getApiKey();
+        const skills = await listSkills(baseUrl, apiKey);
+        return { content: [{ type: "text", text: formatSkills(skills) }], details: { count: skills.length } };
+      },
+    }),
+    defineTool({
+      name: "litellm_skill_create",
+      label: "Create LiteLLM Skill",
+      description: "Create a skill on the LiteLLM proxy Skills Gateway.",
+      parameters: CreateSkillParams,
+      async execute(_toolCallId, params: Static<typeof CreateSkillParams>) {
+        const apiKey = await getApiKey();
+        const inputSchema = params.inputSchemaJson
+          ? (JSON.parse(params.inputSchemaJson) as Record<string, unknown>)
+          : undefined;
+        const result = await createSkill(baseUrl, apiKey, { ...params, inputSchema });
+        return { content: [{ type: "text", text: "LiteLLM skill created." }], details: { result } };
+      },
+    }),
+    defineTool({
+      name: "litellm_skill_delete",
+      label: "Delete LiteLLM Skill",
+      description: "Delete a skill from the LiteLLM proxy Skills Gateway.",
+      parameters: DeleteSkillParams,
+      async execute(_toolCallId, params: Static<typeof DeleteSkillParams>) {
+        const apiKey = await getApiKey();
+        await deleteSkill(baseUrl, apiKey, params.skillId);
+        return { content: [{ type: "text", text: `LiteLLM skill deleted: ${params.skillId}` }], details: {} };
+      },
+    }),
+  ];
+}
+
+export function resetSkillsCache(): void {
+  skillsCache = undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface ModelInfoResponse {
 export interface HealthModelEntry {
   model?: string;
   model_id?: string;
+  api_base?: string;
 }
 
 export interface HealthResponse {
@@ -65,11 +66,13 @@ export interface ResolvedCredentials {
   baseUrl?: string;
   apiKey?: string;
   apiKeyFingerprint?: string;
+  apiKeyConfig?: string;
 }
 
 export interface LiteLLMMcpTool {
   name: string;
   server_name: string;
+  server_id?: string;
   description: string;
   input_schema: Record<string, unknown>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
-export type DiscoverySource = "model_info" | "models_list";
+export type DiscoverySource = "model_info" | "models_list" | "health";
 
 export interface CacheFile {
   baseUrl: string;
@@ -39,6 +39,15 @@ export interface ModelInfoResponse {
   data?: ModelInfoEntry[];
 }
 
+export interface HealthModelEntry {
+  model?: string;
+  model_id?: string;
+}
+
+export interface HealthResponse {
+  healthy_endpoints?: HealthModelEntry[];
+}
+
 export interface ModelsListEntry {
   id?: string;
   owned_by?: string;
@@ -56,4 +65,20 @@ export interface ResolvedCredentials {
   baseUrl?: string;
   apiKey?: string;
   apiKeyFingerprint?: string;
+}
+
+export interface LiteLLMMcpTool {
+  name: string;
+  server_name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+export interface LiteLLMSkill {
+  id?: string;
+  name: string;
+  description?: string;
+  enabled?: boolean;
+  input_schema?: Record<string, unknown>;
+  code?: string;
 }

--- a/tests/cache.test.ts
+++ b/tests/cache.test.ts
@@ -83,6 +83,20 @@ describe("readCache", () => {
     await writeFile(path, JSON.stringify(cache), "utf8");
     expect(await readCache(path)).toEqual(cache);
   });
+
+  it("accepts cache files populated from the health discovery fallback", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-"));
+    const path = join(dir, "health.json");
+    const cache = {
+      baseUrl: "https://x.example.com",
+      apiKeyFingerprint: fingerprint("k"),
+      fetchedAt: 12345,
+      source: "health" as const,
+      models: [],
+    };
+    await writeFile(path, JSON.stringify(cache), "utf8");
+    expect(await readCache(path)).toEqual(cache);
+  });
 });
 
 describe("writeCache", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -324,6 +324,41 @@ describe("discoverModels fallback to /health", () => {
       compat: { supportsStore: false, cacheControlFormat: "anthropic" },
     });
   });
+
+  it("uses healthy endpoint model names when /health entries do not include model ids", async () => {
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 404 });
+      if (url.endsWith("/v1/models")) return new Response(null, { status: 404 });
+      if (url.endsWith("/health")) {
+        return jsonResponse(200, {
+          healthy_endpoints: [
+            { model: "azure/gpt-35-turbo", api_base: "https://azure.example.com" },
+            { model: "anthropic/claude-3-5-sonnet", api_base: "https://anthropic.example.com" },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(urls).toEqual([
+      "https://litellm.example.com/model/info",
+      "https://litellm.example.com/v1/models",
+      "https://litellm.example.com/health",
+    ]);
+    expect(result.source).toBe("health");
+    expect(result.models.map((model) => model.id)).toEqual(["azure/gpt-35-turbo", "anthropic/claude-3-5-sonnet"]);
+    expect(result.models[1]).toMatchObject({
+      name: "anthropic/claude-3-5-sonnet",
+      contextWindow: 128000,
+      maxTokens: 16384,
+      compat: { supportsStore: false, cacheControlFormat: "anthropic" },
+    });
+  });
 });
 
 describe("discoverModels timeout", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -258,6 +258,74 @@ describe("discoverModels fallback to /v1/models", () => {
   });
 });
 
+describe("discoverModels fallback to /health", () => {
+  it("uses /health and per-endpoint /model/info when OpenAI model listing is unavailable", async () => {
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 404 });
+      if (url.endsWith("/v1/models")) return new Response(null, { status: 404 });
+      if (url.endsWith("/health")) {
+        return jsonResponse(200, {
+          healthy_endpoints: [
+            { model: "vertex/claude-sonnet", model_id: "uuid-1" },
+            { model: "openai/gpt-4o-mini", model_id: "uuid-2" },
+          ],
+        });
+      }
+      if (url.endsWith("/model/info?litellm_model_id=uuid-1")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "vertex/claude-sonnet",
+              model_info: {
+                mode: "chat",
+                max_input_tokens: 200000,
+                supports_vision: true,
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+              },
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/model/info?litellm_model_id=uuid-2")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "openai/gpt-4o-mini",
+              model_info: {
+                mode: "chat",
+                max_input_tokens: 128000,
+                max_output_tokens: 16384,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(urls).toEqual([
+      "https://litellm.example.com/model/info",
+      "https://litellm.example.com/v1/models",
+      "https://litellm.example.com/health",
+      "https://litellm.example.com/model/info?litellm_model_id=uuid-1",
+      "https://litellm.example.com/model/info?litellm_model_id=uuid-2",
+    ]);
+    expect(result.source).toBe("health");
+    expect(result.models.map((model) => model.id)).toEqual(["vertex/claude-sonnet", "openai/gpt-4o-mini"]);
+    expect(result.models[0]).toMatchObject({
+      input: ["text", "image"],
+      contextWindow: 200000,
+      compat: { supportsStore: false, cacheControlFormat: "anthropic" },
+    });
+  });
+});
+
 describe("discoverModels timeout", () => {
   it("aborts the fetch after timeoutMs", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation((_input, init) => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -99,8 +99,20 @@ afterEach(() => {
 describe("feature parity", () => {
   it("registers a command-backed gcloud token provider key when ADC auth is enabled", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    const adcPath = join(agentDir, "adc.json");
+    await writeFile(
+      adcPath,
+      JSON.stringify({
+        type: "authorized_user",
+        client_id: "client-id",
+        client_secret: "client-secret",
+        refresh_token: "refresh-token",
+      }),
+      "utf8",
+    );
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_GCLOUD_TOKEN_AUTH = "1";
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = adcPath;
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
 
     const extension = await loadExtension(agentDir);
@@ -119,18 +131,20 @@ describe("feature parity", () => {
       const url = String(input);
       if (url.endsWith("/model/info")) return jsonResponse(200, { data: [] });
       if (url.endsWith("/mcp-rest/tools/list")) {
-        return jsonResponse(200, [
-          {
-            name: "search",
-            server_name: "brave",
-            description: "Search the web",
-            input_schema: {
-              type: "object",
-              properties: { query: { type: "string" } },
-              required: ["query"],
+        return jsonResponse(200, {
+          tools: [
+            {
+              name: "search",
+              description: "Search the web",
+              inputSchema: {
+                type: "object",
+                properties: { query: { type: "string" } },
+                required: ["query"],
+              },
+              mcp_info: { server_name: "brave", server_id: "brave-api" },
             },
-          },
-        ]);
+          ],
+        });
       }
       throw new Error(`unexpected URL: ${url}`);
     });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -23,8 +23,10 @@ type TestPi = {
   providers: Array<{ name: string; config: TestProviderConfig }>;
   commands: Map<string, TestCommand>;
   handlers: Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>;
+  tools: Array<{ name: string; description: string; execute?: (...args: any[]) => Promise<any> | any }>;
   registerProvider(name: string, config: TestProviderConfig): void;
   registerCommand(name: string, command: TestCommand): void;
+  registerTool(tool: { name: string; description: string; execute?: (...args: any[]) => Promise<any> | any }): void;
   on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
 };
 
@@ -57,7 +59,7 @@ async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<
       }
     }
 
-    return { AuthStorage: TestAuthStorage, getAgentDir: () => agentDir };
+    return { AuthStorage: TestAuthStorage, defineTool: (tool: unknown) => tool, getAgentDir: () => agentDir };
   });
   const mod = await import("../src/index.js");
   return mod.default as unknown as (pi: TestPi) => Promise<void>;
@@ -68,11 +70,15 @@ function createPi(): TestPi {
     providers: [],
     commands: new Map(),
     handlers: new Map(),
+    tools: [],
     registerProvider(name: string, config: TestProviderConfig) {
       this.providers.push({ name, config });
     },
     registerCommand(name: string, command: TestCommand) {
       this.commands.set(name, command);
+    },
+    registerTool(tool: { name: string; description: string; execute?: (...args: any[]) => Promise<any> | any }) {
+      this.tools.push(tool);
     },
     on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
       this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
@@ -86,9 +92,85 @@ afterEach(() => {
   delete process.env.LITELLM_BASE_URL;
   delete process.env.LITELLM_API_KEY;
   delete process.env.LITELLM_DISCOVERY_TIMEOUT_MS;
+  delete process.env.LITELLM_GCLOUD_TOKEN_AUTH;
+  delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
 });
 
 describe("feature parity", () => {
+  it("registers a command-backed gcloud token provider key when ADC auth is enabled", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_GCLOUD_TOKEN_AUTH = "1";
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.apiKey).toMatch(/^!.*gcloud-token-cli\.js/);
+  });
+
+  it("registers discovered LiteLLM MCP tools as Pi tools", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return jsonResponse(200, { data: [] });
+      if (url.endsWith("/mcp-rest/tools/list")) {
+        return jsonResponse(200, [
+          {
+            name: "search",
+            server_name: "brave",
+            description: "Search the web",
+            input_schema: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          },
+        ]);
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
+  });
+
+  it("injects enabled LiteLLM skills into the system prompt", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return jsonResponse(200, { data: [] });
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, []);
+      if (url.endsWith("/v1/skills")) {
+        return jsonResponse(200, {
+          data: [{ id: "skill-1", name: "terraform", description: "Terraform conventions", enabled: true }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeAgentStart = pi.handlers.get("before_agent_start")?.[0];
+    const result = await beforeAgentStart?.({ systemPrompt: "Base prompt" }, {});
+
+    expect(result.systemPrompt).toContain("Base prompt");
+    expect(result.systemPrompt).toContain("<litellm_skills>");
+    expect(result.systemPrompt).toContain("Terraform conventions");
+  });
+
   it("registers cost tracking and session grouping handlers", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/gcloud-token.test.ts
+++ b/tests/gcloud-token.test.ts
@@ -80,6 +80,33 @@ describe("getGcloudToken", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("does not reuse a cached token after the ADC identity changes", async () => {
+    const firstPath = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "first-client",
+      client_secret: "first-secret",
+      refresh_token: "first-refresh",
+    });
+    const secondPath = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "second-client",
+      client_secret: "second-secret",
+      refresh_token: "second-refresh",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "first-token" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "second-token" }));
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-06-10T12:00:00.000Z").getTime());
+
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = firstPath;
+    await expect(getGcloudToken()).resolves.toBe("first-token");
+
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = secondPath;
+    await expect(getGcloudToken()).resolves.toBe("second-token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("returns null and warns when no ADC file exists", async () => {
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
     delete process.env.HOME;

--- a/tests/gcloud-token.test.ts
+++ b/tests/gcloud-token.test.ts
@@ -1,0 +1,117 @@
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CACHE_TTL_MS, getGcloudToken, resetGcloudTokenCache } from "../src/gcloud-token.js";
+
+const ORIGINAL_ENV = {
+  APPDATA: process.env.APPDATA,
+  GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
+  HOME: process.env.HOME,
+};
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+async function writeAdcFile(body: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-gcloud-"));
+  const path = join(dir, "adc.json");
+  await writeFile(path, JSON.stringify(body), "utf8");
+  return path;
+}
+
+afterEach(() => {
+  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  resetGcloudTokenCache();
+  vi.restoreAllMocks();
+});
+
+describe("getGcloudToken", () => {
+  it("exchanges authorized_user ADC credentials for an access token", async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      refresh_token: "refresh-token",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { access_token: "ya29.token" }));
+
+    await expect(getGcloudToken()).resolves.toBe("ya29.token");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://oauth2.googleapis.com/token",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: expect.stringContaining("grant_type=refresh_token"),
+      }),
+    );
+  });
+
+  it("uses the cached token until the TTL expires", async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      refresh_token: "refresh-token",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "first-token" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "second-token" }));
+
+    const now = new Date("2026-06-10T12:00:00.000Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    await expect(getGcloudToken()).resolves.toBe("first-token");
+    await expect(getGcloudToken()).resolves.toBe("first-token");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.mocked(Date.now).mockReturnValue(now + CACHE_TTL_MS + 1);
+    await expect(getGcloudToken()).resolves.toBe("second-token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null and warns when no ADC file exists", async () => {
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+    delete process.env.HOME;
+    delete process.env.APPDATA;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(getGcloudToken()).resolves.toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("No Google ADC file found"));
+  });
+
+  it("returns null and warns for service account credentials", async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({ type: "service_account" });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(getGcloudToken()).resolves.toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Service account credentials are not supported"));
+  });
+
+  it("returns null when the token exchange fails", async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      refresh_token: "refresh-token",
+    });
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("invalid_grant", { status: 400 }));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(getGcloudToken()).resolves.toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Token exchange failed"));
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -95,6 +95,21 @@ async function writeFailingHelper(agentDir: string): Promise<string> {
   return helperPath;
 }
 
+async function writeAdcFile(agentDir: string, name: string, refreshToken: string): Promise<string> {
+  const adcPath = join(agentDir, `${name}.json`);
+  await writeFile(
+    adcPath,
+    JSON.stringify({
+      type: "authorized_user",
+      client_id: `${name}-client`,
+      client_secret: `${name}-secret`,
+      refresh_token: refreshToken,
+    }),
+    "utf8",
+  );
+  return adcPath;
+}
+
 async function readHelperCount(agentDir: string): Promise<number> {
   try {
     return Number(await readFile(join(agentDir, "helper-count"), "utf8"));
@@ -198,6 +213,85 @@ describe("extension startup", () => {
     await extension(pi);
 
     expect(pi.providers[0]?.config.apiKey).toBe("$LITELLM_API_KEY");
+  });
+
+  it("registers the env key when gcloud ADC auth falls back during discovery", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    process.env.LITELLM_GCLOUD_TOKEN_AUTH = "1";
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = join(agentDir, "missing-adc.json");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const seenAuthHeaders: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        seenAuthHeaders.push(new Headers(init?.headers).get("authorization") ?? "");
+        return jsonResponse(200, {
+          data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to read ADC file"));
+    expect(seenAuthHeaders).toEqual(["Bearer env-key"]);
+    expect(pi.providers[0]?.config.apiKey).toBe("$LITELLM_API_KEY");
+    const cache = JSON.parse(await readFile(join(agentDir, "litellm-models.json"), "utf8")) as {
+      apiKeyFingerprint: string;
+    };
+    expect(cache.apiKeyFingerprint).toBe(fingerprint("env-key"));
+  });
+
+  it("refreshes the model cache when the gcloud ADC identity changes", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_GCLOUD_TOKEN_AUTH = "1";
+    const seenModelAuthHeaders: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === "https://oauth2.googleapis.com/token") {
+        const body = String(init?.body ?? "");
+        return jsonResponse(200, {
+          access_token: body.includes("refresh_token=second-refresh") ? "second-token" : "first-token",
+        });
+      }
+      if (url.endsWith("/model/info")) {
+        const authorization = new Headers(init?.headers).get("authorization") ?? "";
+        seenModelAuthHeaders.push(authorization);
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: authorization === "Bearer second-token" ? "second-model" : "first-model",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile(agentDir, "first-adc", "first-refresh");
+    let extension = await loadExtension(agentDir);
+    let pi = createPi();
+    await extension(pi);
+    expect((pi.providers[0]?.config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["first-model"]);
+
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile(agentDir, "second-adc", "second-refresh");
+    extension = await loadExtension(agentDir);
+    pi = createPi();
+    await extension(pi);
+
+    expect(seenModelAuthHeaders).toEqual(["Bearer first-token", "Bearer second-token"]);
+    expect((pi.providers[0]?.config.models as Array<{ id: string }>).map((model) => model.id)).toEqual([
+      "second-model",
+    ]);
   });
 
   it('treats literal "undefined" env values as unset', async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -10,6 +10,8 @@ const ENV_KEYS = [
   "LITELLM_API_KEY",
   "LITELLM_API_KEY_HELPER",
   "LITELLM_DISCOVERY_TIMEOUT_MS",
+  "LITELLM_GCLOUD_TOKEN_AUTH",
+  "GOOGLE_APPLICATION_CREDENTIALS",
   "STORED_LITELLM_KEY",
 ];
 const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
@@ -139,7 +141,7 @@ async function loadExtension(agentDir: string): Promise<(pi: TestPi) => Promise<
       }
     }
 
-    return { AuthStorage: TestAuthStorage, getAgentDir: () => agentDir };
+    return { AuthStorage: TestAuthStorage, defineTool: (tool: unknown) => tool, getAgentDir: () => agentDir };
   });
   const mod = await import("../src/index.js");
   return mod.default as unknown as (pi: TestPi) => Promise<void>;
@@ -150,11 +152,15 @@ function createPi(): TestPi {
     providers: [],
     commands: new Map(),
     handlers: new Map(),
+    tools: [],
     registerProvider(name: string, config: TestProviderConfig) {
       this.providers.push({ name, config });
     },
     registerCommand(name: string, command: TestCommand) {
       this.commands.set(name, command);
+    },
+    registerTool(tool: { name: string; description: string; execute?: (...args: any[]) => Promise<any> | any }) {
+      this.tools.push(tool);
     },
     on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any) {
       this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
@@ -166,8 +172,10 @@ type TestPi = {
   providers: Array<{ name: string; config: TestProviderConfig }>;
   commands: Map<string, TestCommand>;
   handlers: Map<string, Array<(event: any, ctx?: any) => Promise<any> | any>>;
+  tools: Array<{ name: string; description: string; execute?: (...args: any[]) => Promise<any> | any }>;
   registerProvider(name: string, config: TestProviderConfig): void;
   registerCommand(name: string, command: TestCommand): void;
+  registerTool(tool: { name: string; description: string; execute?: (...args: any[]) => Promise<any> | any }): void;
   on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
 };
 
@@ -225,7 +233,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     await extension(createPi());
 
-    expect(seenAuthHeaders).toEqual(["Bearer stored-key"]);
+    expect(seenAuthHeaders).toEqual(["Bearer stored-key", "Bearer stored-key"]);
   });
 
   it("does not fetch on refresh when discovery timeout is zero", async () => {
@@ -467,8 +475,8 @@ describe("extension startup", () => {
     const pi = createPi();
     await extension(pi);
 
-    // Startup discovery uses a fresh helper token (one helper invocation).
-    expect(seenAuthHeaders).toEqual([`Bearer ${first}`]);
+    // Startup model and MCP discovery use the same fresh helper token (one helper invocation).
+    expect(seenAuthHeaders).toEqual([`Bearer ${first}`, `Bearer ${first}`]);
     expect(await readHelperCount(agentDir)).toBe(1);
 
     // The provider key is the `!helper` command. Pi's per-request auth path
@@ -616,6 +624,6 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     await extension(createPi());
 
-    expect(seenAuthHeaders).toEqual([`Bearer ${fresh}`]);
+    expect(seenAuthHeaders).toEqual([`Bearer ${fresh}`, `Bearer ${fresh}`]);
   });
 });

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -16,10 +16,49 @@ afterEach(() => {
 
 describe("discoverMcpTools", () => {
   it("returns tools from LiteLLM MCP REST discovery", async () => {
+    const inputSchema = {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        tools: [
+          {
+            name: "web-search",
+            description: "Search the web",
+            inputSchema,
+            mcp_info: { server_name: "Brave API", server_id: "brave-api" },
+          },
+        ],
+      }),
+    );
+
+    await expect(discoverMcpTools("https://litellm.example.com", "sk-test")).resolves.toEqual([
+      {
+        name: "web-search",
+        server_name: "Brave API",
+        server_id: "brave-api",
+        description: "Search the web",
+        input_schema: inputSchema,
+      },
+    ]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/mcp-rest/tools/list",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("keeps compatibility with older array-shaped discovery responses", async () => {
     const tools: LiteLLMMcpTool[] = [
       {
         name: "web-search",
         server_name: "Brave API",
+        server_id: "Brave API",
         description: "Search the web",
         input_schema: {
           type: "object",
@@ -63,7 +102,7 @@ describe("executeMcpTool", () => {
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
-        body: JSON.stringify({ server: "brave", tool: "search", args: { query: "pi" } }),
+        body: JSON.stringify({ server_id: "brave", name: "search", arguments: { query: "pi" } }),
       }),
     );
   });
@@ -76,6 +115,7 @@ describe("createMcpToolDefinitions", () => {
         {
           name: "web-search",
           server_name: "Brave API",
+          server_id: "brave-api",
           description: "Search the web",
           input_schema: {
             type: "object",
@@ -125,18 +165,20 @@ describe("createMcpToolDefinitions", () => {
   it("uses a fresh token when a generated tool executes", async () => {
     vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
-        jsonResponse(200, [
-          {
-            name: "search",
-            server_name: "brave",
-            description: "Search",
-            input_schema: {
-              type: "object",
-              properties: { query: { type: "string" } },
-              required: ["query"],
+        jsonResponse(200, {
+          tools: [
+            {
+              name: "search",
+              description: "Search",
+              inputSchema: {
+                type: "object",
+                properties: { query: { type: "string" } },
+                required: ["query"],
+              },
+              mcp_info: { server_name: "brave", server_id: "brave-api" },
             },
-          },
-        ] satisfies LiteLLMMcpTool[]),
+          ],
+        }),
       )
       .mockResolvedValueOnce(jsonResponse(200, { result: "ok" }));
     const getApiKey = vi.fn().mockResolvedValueOnce("discovery-token").mockResolvedValueOnce("execution-token");
@@ -155,6 +197,7 @@ describe("createMcpToolDefinitions", () => {
     expect(getApiKey).toHaveBeenCalledTimes(2);
     expect(vi.mocked(globalThis.fetch).mock.calls[1]?.[1]).toMatchObject({
       headers: expect.objectContaining({ Authorization: "Bearer execution-token" }),
+      body: JSON.stringify({ server_id: "brave-api", name: "search", arguments: { query: "pi" } }),
     });
   });
 });

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -1,0 +1,160 @@
+import type { Static, TSchema } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMcpToolDefinitions, discoverMcpTools, executeMcpTool } from "../src/mcp-tools.js";
+import type { LiteLLMMcpTool } from "../src/types.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("discoverMcpTools", () => {
+  it("returns tools from LiteLLM MCP REST discovery", async () => {
+    const tools: LiteLLMMcpTool[] = [
+      {
+        name: "web-search",
+        server_name: "Brave API",
+        description: "Search the web",
+        input_schema: {
+          type: "object",
+          properties: { query: { type: "string" } },
+          required: ["query"],
+        },
+      },
+    ];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, tools));
+
+    await expect(discoverMcpTools("https://litellm.example.com", "sk-test")).resolves.toEqual(tools);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/mcp-rest/tools/list",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("returns an empty list when discovery fails", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    await expect(discoverMcpTools("https://litellm.example.com", "sk-test")).resolves.toEqual([]);
+  });
+});
+
+describe("executeMcpTool", () => {
+  it("calls LiteLLM MCP REST execution and formats the result", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse(200, { result: { content: [{ type: "text", text: "found" }] } }));
+
+    await expect(
+      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }),
+    ).resolves.toBe(JSON.stringify({ content: [{ type: "text", text: "found" }] }, null, 2));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/mcp-rest/tools/call",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
+        body: JSON.stringify({ server: "brave", tool: "search", args: { query: "pi" } }),
+      }),
+    );
+  });
+});
+
+describe("createMcpToolDefinitions", () => {
+  it("creates sanitized Pi tool definitions with mapped parameter schemas", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, [
+        {
+          name: "web-search",
+          server_name: "Brave API",
+          description: "Search the web",
+          input_schema: {
+            type: "object",
+            properties: {
+              query: { type: "string" },
+              limit: { type: "integer" },
+              safe: { type: "boolean" },
+              tags: { type: "array", items: { type: "string" } },
+            },
+            required: ["query"],
+          },
+        },
+      ] satisfies LiteLLMMcpTool[]),
+    );
+
+    const definitions = await createMcpToolDefinitions("https://litellm.example.com", async () => "sk-test");
+
+    expect(definitions.map((tool) => tool.name)).toEqual(["mcp_brave_api_web_search"]);
+    expect(definitions[0]?.description).toBe("Search the web (via Brave API MCP server)");
+    const parameters = definitions[0]?.parameters as { required?: string[]; properties?: Record<string, unknown> };
+    expect(parameters.required).toEqual(["query"]);
+    expect(Object.keys(parameters.properties ?? {})).toEqual(["query", "limit", "safe", "tags"]);
+  });
+
+  it("falls back to a single args object for complex schemas", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, [
+        {
+          name: "complex",
+          server_name: "Schema",
+          description: "Complex input",
+          input_schema: {
+            type: "object",
+            properties: { nested: { type: "object", properties: { value: { type: "string" } } } },
+            required: ["nested"],
+          },
+        },
+      ] satisfies LiteLLMMcpTool[]),
+    );
+
+    const definitions = await createMcpToolDefinitions("https://litellm.example.com", async () => "sk-test");
+
+    const parameters = definitions[0]?.parameters as { properties?: Record<string, unknown> };
+    expect(Object.keys(parameters.properties ?? {})).toEqual(["args"]);
+  });
+
+  it("uses a fresh token when a generated tool executes", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse(200, [
+          {
+            name: "search",
+            server_name: "brave",
+            description: "Search",
+            input_schema: {
+              type: "object",
+              properties: { query: { type: "string" } },
+              required: ["query"],
+            },
+          },
+        ] satisfies LiteLLMMcpTool[]),
+      )
+      .mockResolvedValueOnce(jsonResponse(200, { result: "ok" }));
+    const getApiKey = vi.fn().mockResolvedValueOnce("discovery-token").mockResolvedValueOnce("execution-token");
+
+    const definitions = await createMcpToolDefinitions("https://litellm.example.com", getApiKey);
+    type Params = Static<TSchema>;
+    const result = await definitions[0]?.execute(
+      "call-1",
+      { query: "pi" } as Params,
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(result?.content).toEqual([{ type: "text", text: JSON.stringify("ok", null, 2) }]);
+    expect(getApiKey).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(globalThis.fetch).mock.calls[1]?.[1]).toMatchObject({
+      headers: expect.objectContaining({ Authorization: "Bearer execution-token" }),
+    });
+  });
+});

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -1,0 +1,94 @@
+import type { Static, TSchema } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createSkillsPromptSection,
+  createSkillToolDefinitions,
+  deleteSkill,
+  listSkills,
+  resetSkillsCache,
+} from "../src/skills.js";
+import type { LiteLLMSkill } from "../src/types.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  resetSkillsCache();
+  vi.restoreAllMocks();
+});
+
+describe("listSkills", () => {
+  it("returns skills from the LiteLLM Skills Gateway", async () => {
+    const skills: LiteLLMSkill[] = [
+      { id: "skill-1", name: "terraform", description: "Terraform conventions", enabled: true },
+    ];
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: skills }));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
+  });
+
+  it("uses a short in-memory cache for repeated reads", async () => {
+    const skills: LiteLLMSkill[] = [{ id: "skill-1", name: "terraform", description: "Terraform conventions" }];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, skills));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("skill helpers", () => {
+  it("deletes skills by id", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+    await expect(deleteSkill("https://litellm.example.com", "sk-test", "skill-1")).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/v1/skills/skill-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("formats enabled skills as a system-prompt section", () => {
+    const section = createSkillsPromptSection([
+      { id: "enabled", name: "terraform", description: "Terraform conventions", enabled: true },
+      { id: "disabled", name: "legacy", description: "Old guidance", enabled: false },
+    ]);
+
+    expect(section).toContain("<litellm_skills>");
+    expect(section).toContain('<skill name="terraform">');
+    expect(section).toContain("Terraform conventions");
+    expect(section).not.toContain("Old guidance");
+  });
+});
+
+describe("createSkillToolDefinitions", () => {
+  it("creates Pi tools for listing, creating, and deleting LiteLLM skills", async () => {
+    const definitions = createSkillToolDefinitions("https://litellm.example.com", async () => "sk-test");
+
+    expect(definitions.map((definition) => definition.name)).toEqual([
+      "litellm_skill_list",
+      "litellm_skill_create",
+      "litellm_skill_delete",
+    ]);
+  });
+
+  it("executes the list tool with a fresh token", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, [{ id: "skill-1", name: "terraform", description: "Terraform conventions" }]),
+    );
+    const getApiKey = vi.fn().mockResolvedValue("fresh-token");
+    const [listTool] = createSkillToolDefinitions("https://litellm.example.com", getApiKey);
+    type Params = Static<TSchema>;
+
+    const result = await listTool?.execute("call-1", {} as Params, undefined, undefined, {} as never);
+
+    expect(result?.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("terraform") });
+    expect(getApiKey).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/supply-chain-guard.test.ts
+++ b/tests/supply-chain-guard.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -72,5 +72,58 @@ describe("supply-chain guard", () => {
 
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);
+  });
+
+  it("accepts the intentional runtime dist files in the package", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-allowed-"));
+
+    try {
+      await mkdir(join(fixture, "dist"), { recursive: true });
+      await writeFile(
+        join(fixture, "package.json"),
+        JSON.stringify(
+          {
+            name: "allowed-fixture",
+            version: "1.0.0",
+            files: ["dist", "README.md", "LICENSE"],
+          },
+          null,
+          2,
+        ),
+      );
+      await writeFile(
+        join(fixture, "package-lock.json"),
+        JSON.stringify({
+          name: "allowed-fixture",
+          version: "1.0.0",
+          lockfileVersion: 3,
+          packages: { "": { name: "allowed-fixture", version: "1.0.0" } },
+        }),
+      );
+      await writeFile(join(fixture, "README.md"), "# fixture\n");
+      await writeFile(join(fixture, "LICENSE"), "MIT\n");
+      for (const file of [
+        "cache",
+        "cost",
+        "discover",
+        "gcloud-token",
+        "gcloud-token-cli",
+        "index",
+        "litellm",
+        "mcp-tools",
+        "skills",
+        "types",
+      ]) {
+        await writeFile(join(fixture, "dist", `${file}.js`), "export {};\n");
+        await writeFile(join(fixture, "dist", `${file}.d.ts`), "export {};\n");
+      }
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.errors).toEqual([]);
+      expect(result.ok).toBe(true);
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Add Google ADC token auth support for LiteLLM via a Pi command-backed API key helper.
- Add LiteLLM MCP REST tool discovery/execution and Skills Gateway integration where Pi can support them.
- Add `/health` model discovery fallback, README documentation, and package allowlist coverage for the new runtime files.

## Validation

- `rtk npm run check`
- `rtk npm run clean && rtk npm run build`
- `rtk npm run supply-chain:guard`
- `rtk npm pack --dry-run`
- `rtk git diff --check`