### PR TITLE
feat: add enterprise SSO login with OAuth JWT and virtual key pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ You can also run `/login`, select `Use a subscription`, then select `LiteLLM`.
 
 You'll be prompted for the base URL and API key. Credentials are persisted to `~/.pi/agent/auth.json`.
 
+#### Enterprise SSO login
+
+If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments), you can authenticate via a browser SSO flow and optionally pair the resulting JWT with a stable virtual key:
+
+1. Run `/login litellm` inside pi
+2. Enter the proxy URL
+3. At the login method prompt, enter `2` for SSO / Enterprise JWT
+4. Open the displayed login URL (e.g. `https://litellm.your-domain.com/login`) in your browser and authenticate via SSO
+5. Copy your token from the LiteLLM UI and paste it at the prompt (copying a full `Bearer ...` header value is fine — the prefix is stripped automatically)
+6. When prompted to generate a virtual key, press Enter to accept (recommended) or enter `n` to use the JWT directly
+
+When you generate a virtual key, the resulting `sk-...` key is stored as your credential and used for all API requests. Virtual keys are stable and long-lived — they do not expire unless revoked in LiteLLM.
+
+When using a JWT directly, the extension reads its `exp` claim and Pi will prompt you to re-authenticate when the token nears expiry. Run `/login litellm` again to refresh.
+
 ### Option B — environment variables
 
 ```bash
@@ -153,6 +168,8 @@ If the cache is older than 24 hours, the extension refreshes it in the backgroun
 | Discovery times out | Increase `LITELLM_DISCOVERY_TIMEOUT_MS` or set `LITELLM_OFFLINE=1` to fall back on cached models |
 | `401 Token expired` | Set `LITELLM_API_KEY_HELPER`. |
 | No models with gcloud auth | Verify `gcloud auth application-default login` has been run or set `GOOGLE_APPLICATION_CREDENTIALS` to an `authorized_user` ADC file |
+| Enterprise SSO login shows "virtual key generation failed" | The LiteLLM instance may not be enterprise edition, or your user account lacks key-generation permission; the JWT is used directly as a fallback |
+| Enterprise SSO token prompt fails with "SSO token is required" | The token field was left empty — paste the token copied from the LiteLLM UI |
 | MCP tools not showing | Verify the proxy exposes `/mcp-rest/tools/list` and run `/litellm-refresh` after fixing the proxy |
 | Skills not affecting prompts | Verify the proxy exposes `/v1/skills` and returns enabled skills |
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments)
 1. Run `/login litellm` inside pi
 2. Enter the proxy URL
 3. At the login method prompt, enter `2` for SSO / Enterprise JWT
-4. Open the displayed login URL (e.g. `https://litellm.your-domain.com/login`) in your browser and authenticate via SSO
+4. Your default browser opens the LiteLLM login page (e.g. `https://litellm.your-domain.com/login`) automatically — the URL is also displayed in case it can't be opened. Authenticate via SSO
 5. Copy your token from the LiteLLM UI and paste it at the prompt (copying a full `Bearer ...` header value is fine — the prefix is stripped automatically)
 6. When prompted to generate a virtual key, press Enter to accept (recommended) or enter `n` to use the JWT directly
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If the cache is older than 24 hours, the extension refreshes it in the backgroun
 | Discovery times out | Increase `LITELLM_DISCOVERY_TIMEOUT_MS` or set `LITELLM_OFFLINE=1` to fall back on cached models |
 | `401 Token expired` | Set `LITELLM_API_KEY_HELPER`. |
 | No models with gcloud auth | Verify `gcloud auth application-default login` has been run or set `GOOGLE_APPLICATION_CREDENTIALS` to an `authorized_user` ADC file |
-| Enterprise SSO login shows "virtual key generation failed" | The LiteLLM instance may not be enterprise edition, or your user account lacks key-generation permission; the JWT is used directly as a fallback |
+| Enterprise SSO login shows "virtual key generation failed" | The LiteLLM instance may lack a database (`/key/generate` requires one), your user account may lack key-generation permission, or the request timed out; the JWT is used directly as a fallback |
 | Enterprise SSO token prompt fails with "SSO token is required" | The token field was left empty — paste the token copied from the LiteLLM UI |
 | MCP tools not showing | Verify the proxy exposes `/mcp-rest/tools/list` and run `/litellm-refresh` after fixing the proxy |
 | Skills not affecting prompts | Verify the proxy exposes `/v1/skills` and returns enabled skills |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments)
 1. Run `/login litellm` inside pi
 2. Enter the proxy URL
 3. At the login method prompt, enter `2` for SSO / Enterprise JWT
-4. Your default browser opens the LiteLLM login page (e.g. `https://litellm.your-domain.com/login`) automatically — the URL is also displayed in case it can't be opened. Authenticate via SSO
+4. Your default browser opens the LiteLLM SSO login URL (e.g. `https://litellm.your-domain.com/sso/key/generate`) automatically — the URL is also displayed in case it can't be opened. Authenticate via SSO
 5. Copy your token from the LiteLLM UI and paste it at the prompt (copying a full `Bearer ...` header value is fine — the prefix is stripped automatically)
 6. When prompted to generate a virtual key, press Enter to accept (recommended) or enter `n` to use the JWT directly
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments)
 5. Copy your token from the LiteLLM UI and paste it at the prompt (copying a full `Bearer ...` header value is fine — the prefix is stripped automatically)
 6. When prompted to generate a virtual key, press Enter to accept (recommended) or enter `n` to use the JWT directly
 
-When you generate a virtual key, the resulting `sk-...` key is stored as your credential and used for all API requests. Virtual keys are stable and long-lived — they do not expire unless revoked in LiteLLM.
+When you generate a virtual key, the resulting `sk-...` key is stored as your credential and used for all API requests. If the proxy's key policy attaches an expiry to the generated key, Pi will prompt you to re-authenticate when it nears expiry; otherwise the key is treated as permanent until revoked in LiteLLM.
 
 When using a JWT directly, the extension reads its `exp` claim and Pi will prompt you to re-authenticate when the token nears expiry. Run `/login litellm` again to refresh.
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -84,23 +84,62 @@ function toKnownProvider(provider: string | undefined): KnownProvider | undefine
 
 function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined {
   const prefixProvider = toKnownProvider(id.split("/")[0]);
-  const candidates = [toKnownProvider(ownedBy), prefixProvider].filter(
+  const lookupIds = catalogLookupIds(id);
+  const candidates = [toKnownProvider(ownedBy), prefixProvider, lookupIds.length > 1 ? "anthropic" : undefined].filter(
     (provider): provider is KnownProvider => provider !== undefined,
   );
 
   for (const provider of candidates) {
-    const exact = getModels(provider).find((model) => model.id === id);
-    if (exact) return exact;
-    const providerQualified = getModels(provider).find((model) => model.id === `${provider}/${id}`);
-    if (providerQualified) return providerQualified;
+    const match = findCatalogModelInProvider(provider, lookupIds);
+    if (match) return match;
   }
 
   for (const provider of getProviders()) {
-    const exact = getModels(provider).find((model) => model.id === id);
-    if (exact) return exact;
+    const match = findCatalogModelInProvider(provider, lookupIds);
+    if (match) return match;
   }
 
   return undefined;
+}
+
+function catalogLookupIds(id: string): string[] {
+  const lookupIds = new Set([id]);
+  const unprefixed = id.includes("/") ? id.slice(id.indexOf("/") + 1) : id;
+  lookupIds.add(unprefixed);
+
+  const anthropicAlias = unprefixed.toLowerCase().replaceAll(".", "-");
+  const match = /^(?:claude-)?(opus|sonnet|haiku)-(\d+)-(\d+)$/.exec(anthropicAlias);
+  if (match) lookupIds.add(`claude-${match[1]}-${match[2]}-${match[3]}`);
+
+  return [...lookupIds];
+}
+
+function findCatalogModelInProvider(provider: KnownProvider, lookupIds: string[]): Model<Api> | undefined {
+  for (const lookupId of lookupIds) {
+    const exact = getModels(provider).find((model) => model.id === lookupId);
+    if (exact) return exact;
+    const providerQualified = getModels(provider).find((model) => model.id === `${provider}/${lookupId}`);
+    if (providerQualified) return providerQualified;
+  }
+  return undefined;
+}
+
+function mapModelInfoCost(
+  info: NonNullable<ModelInfoEntry["model_info"]>,
+  fallback?: ProviderModelConfig["cost"],
+): NonNullable<ProviderModelConfig["cost"]> {
+  return {
+    input: info.input_cost_per_token !== undefined ? info.input_cost_per_token * 1_000_000 : (fallback?.input ?? 0),
+    output: info.output_cost_per_token !== undefined ? info.output_cost_per_token * 1_000_000 : (fallback?.output ?? 0),
+    cacheRead:
+      info.cache_read_input_token_cost !== undefined
+        ? info.cache_read_input_token_cost * 1_000_000
+        : (fallback?.cacheRead ?? 0),
+    cacheWrite:
+      info.cache_creation_input_token_cost !== undefined
+        ? info.cache_creation_input_token_cost * 1_000_000
+        : (fallback?.cacheWrite ?? 0),
+  };
 }
 
 function getFallbackProviderAndModel(id: string, ownedBy?: string): { provider?: string; modelId: string } {
@@ -211,17 +250,13 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   if (!id) return undefined;
   const info = entry.model_info ?? {};
   if (info.mode && info.mode !== "chat") return undefined;
+  const catalogModel = findCatalogModel(id);
   return {
     id,
     name: id,
     reasoning: info.supports_reasoning ?? false,
     input: info.supports_vision ? ["text", "image"] : ["text"],
-    cost: {
-      input: (info.input_cost_per_token ?? 0) * 1_000_000,
-      output: (info.output_cost_per_token ?? 0) * 1_000_000,
-      cacheRead: (info.cache_read_input_token_cost ?? 0) * 1_000_000,
-      cacheWrite: (info.cache_creation_input_token_cost ?? 0) * 1_000_000,
-    },
+    cost: mapModelInfoCost(info, catalogModel?.cost),
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
@@ -235,19 +270,16 @@ function mapFromHealthModelInfo(
   const model = mapFromModelInfo(entry);
   if (model || !fallbackId) return model;
   if (entry.model_info?.mode && entry.model_info.mode !== "chat") return undefined;
+  const info = entry.model_info ?? {};
+  const catalogModel = findCatalogModel(fallbackId);
   return {
     id: fallbackId,
     name: fallbackId,
-    reasoning: entry.model_info?.supports_reasoning ?? false,
-    input: entry.model_info?.supports_vision ? ["text", "image"] : ["text"],
-    cost: {
-      input: (entry.model_info?.input_cost_per_token ?? 0) * 1_000_000,
-      output: (entry.model_info?.output_cost_per_token ?? 0) * 1_000_000,
-      cacheRead: (entry.model_info?.cache_read_input_token_cost ?? 0) * 1_000_000,
-      cacheWrite: (entry.model_info?.cache_creation_input_token_cost ?? 0) * 1_000_000,
-    },
-    contextWindow: entry.model_info?.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
-    maxTokens: entry.model_info?.max_output_tokens ?? DEFAULT_MAX_TOKENS,
+    reasoning: info.supports_reasoning ?? false,
+    input: info.supports_vision ? ["text", "image"] : ["text"],
+    cost: mapModelInfoCost(info, catalogModel?.cost),
+    contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(fallbackId),
   };
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -122,7 +122,7 @@ function findModelsDevModel(
   return catalog?.[provider]?.models?.[modelId];
 }
 
-function withTimeout(timeoutMs: number, signal?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
+export function withTimeout(timeoutMs: number, signal?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
   const controller = new AbortController();
   const onAbort = () => controller.abort(signal?.reason);
   if (signal) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,25 @@ function tokenExpiresAt(apiKey: string, opaqueFallback = PERMANENT_TOKEN_EXPIRES
   }
 }
 
+async function generateVirtualKey(baseUrl: string, userToken: string, signal?: AbortSignal): Promise<string> {
+  const response = await fetch(`${baseUrl}/user/key/generate`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${userToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({}),
+    signal,
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(`Virtual key generation failed (${response.status}): ${text}`);
+  }
+  const data = (await response.json()) as { key?: unknown };
+  if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /user/key/generate");
+  return data.key;
+}
+
 function getLiteLLMApiKey(credentials: OAuthCredentials): string {
   return credentials.access;
 }
@@ -189,12 +208,60 @@ async function loginLiteLLM(
       placeholder: "https://litellm.example.com",
     })
   ).trim();
-  const apiKeyInput = (await callbacks.onPrompt({ message: "Enter API key:" })).trim();
-  if (!rawBaseUrl || !apiKeyInput) throw new Error("Both base URL and API key are required");
+  if (!rawBaseUrl) throw new Error("Base URL is required");
 
   const baseUrl = normalizeBaseUrl(rawBaseUrl);
-  const refresh = apiKeyInput.startsWith("!") ? apiKeyInput : "";
-  const apiKey = refresh ? executeApiKeyCommand(refresh) : apiKeyInput;
+  const method = (
+    await callbacks.onPrompt({
+      message: "Select login method (1 = API key / !command, 2 = SSO / Enterprise JWT):",
+    })
+  ).trim();
+
+  let apiKey: string;
+  let refresh: string;
+  let expires: number;
+
+  if (method === "2") {
+    callbacks.onProgress?.(`Open ${baseUrl}/login in your browser to authenticate via SSO.`);
+    const rawToken = (await callbacks.onPrompt({ message: "Paste your SSO token from the LiteLLM UI:" }))
+      .trim()
+      .replace(/^Bearer\s+/i, "")
+      .trim();
+    if (!rawToken) throw new Error("SSO token is required");
+
+    const wantVirtualKey = (
+      await callbacks.onPrompt({ message: "Generate a LiteLLM virtual key from this token? (y/n):" })
+    )
+      .trim()
+      .toLowerCase();
+
+    if (wantVirtualKey !== "n") {
+      try {
+        callbacks.onProgress?.("Generating virtual key...");
+        apiKey = await generateVirtualKey(baseUrl, rawToken, callbacks.signal);
+        refresh = "";
+        expires = PERMANENT_TOKEN_EXPIRES_AT;
+        callbacks.onProgress?.("Virtual key generated and will be used for API calls.");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        callbacks.onProgress?.(`LiteLLM: virtual key generation failed (${message}); using SSO token directly.`);
+        apiKey = rawToken;
+        refresh = "";
+        expires = tokenExpiresAt(rawToken, PERMANENT_TOKEN_EXPIRES_AT);
+      }
+    } else {
+      apiKey = rawToken;
+      refresh = "";
+      expires = tokenExpiresAt(rawToken, PERMANENT_TOKEN_EXPIRES_AT);
+    }
+  } else {
+    const apiKeyInput = (await callbacks.onPrompt({ message: "Enter API key:" })).trim();
+    if (!apiKeyInput) throw new Error("Both base URL and API key are required");
+    refresh = apiKeyInput.startsWith("!") ? apiKeyInput : "";
+    apiKey = refresh ? executeApiKeyCommand(refresh) : apiKeyInput;
+    expires = tokenExpiresAt(apiKey, refresh ? EXPIRE_TOKEN_IMMEDIATELY : PERMANENT_TOKEN_EXPIRES_AT);
+  }
+
   const { models, source } = await discoverModels(baseUrl, apiKey, {
     timeoutMs: LOGIN_TIMEOUT_MS,
     signal: callbacks.signal,
@@ -214,7 +281,7 @@ async function loginLiteLLM(
   return {
     access: apiKey,
     refresh,
-    expires: tokenExpiresAt(apiKey, refresh ? EXPIRE_TOKEN_IMMEDIATELY : PERMANENT_TOKEN_EXPIRES_AT),
+    expires,
     baseUrl,
   } as OAuthCredentials & { baseUrl: string };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execSync, spawn } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { Api, AssistantMessage, Model, OAuthCredentials, OAuthLoginCallbacks } from "@earendil-works/pi-ai";
@@ -85,6 +85,21 @@ function tokenExpiresAt(apiKey: string, opaqueFallback = PERMANENT_TOKEN_EXPIRES
   } catch {
     return opaqueFallback;
   }
+}
+
+function openInBrowser(url: string): void {
+  // Never invoke a shell here: cmd.exe re-parses metacharacters before `start`
+  // runs, which would make URL contents injectable. Launch is best-effort; the
+  // URL is also shown to the user, so launcher failures must not crash the process.
+  const [cmd, args]: [string, string[]] =
+    process.platform === "darwin"
+      ? ["open", [url]]
+      : process.platform === "win32"
+        ? ["rundll32", ["url.dll,FileProtocolHandler", url]]
+        : ["xdg-open", [url]];
+  spawn(cmd, args, { stdio: "ignore", detached: true })
+    .on("error", () => undefined)
+    .unref();
 }
 
 async function generateVirtualKey(baseUrl: string, userToken: string, signal?: AbortSignal): Promise<string> {
@@ -222,7 +237,10 @@ async function loginLiteLLM(
   let expires: number;
 
   if (method === "2") {
-    callbacks.onProgress?.(`Open ${baseUrl}/login in your browser to authenticate via SSO.`);
+    callbacks.onAuth?.({
+      url: `${baseUrl}/login`,
+      instructions: "Authenticate via SSO, then copy your token from the LiteLLM UI.",
+    });
     const rawToken = (await callbacks.onPrompt({ message: "Paste your SSO token from the LiteLLM UI:" }))
       .trim()
       .replace(/^Bearer\s+/i, "")
@@ -577,7 +595,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   async function runLogin(ctx: LoginContext): Promise<void> {
     const credential = await loginLiteLLM(
       {
-        onAuth: () => undefined,
+        onAuth: ({ url, instructions }) => {
+          openInBrowser(url);
+          ctx.ui.notify(instructions ? `${url} — ${instructions}` : url, "info");
+        },
         onDeviceCode: () => undefined,
         onPrompt: async ({ message, placeholder }) => {
           const value = await ctx.ui.input(message, placeholder);

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ function openInBrowser(url: string): void {
 }
 
 async function generateVirtualKey(baseUrl: string, userToken: string, signal?: AbortSignal): Promise<string> {
-  const response = await fetch(`${baseUrl}/user/key/generate`, {
+  const response = await fetch(`${baseUrl}/key/generate`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${userToken}`,
@@ -117,7 +117,7 @@ async function generateVirtualKey(baseUrl: string, userToken: string, signal?: A
     throw new Error(`Virtual key generation failed (${response.status}): ${text}`);
   }
   const data = (await response.json()) as { key?: unknown };
-  if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /user/key/generate");
+  if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /key/generate");
   return data.key;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { ExtensionAPI, ExtensionContext, ProviderModelConfig } from "@earen
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
-import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
+import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent, withTimeout } from "./discover.js";
 import {
   getGcloudToken,
   getGcloudTokenCacheKey,
@@ -107,23 +107,28 @@ async function generateVirtualKey(
   userToken: string,
   signal?: AbortSignal,
 ): Promise<{ key: string; expiresAt?: number }> {
-  const response = await fetch(`${baseUrl}/key/generate`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${userToken}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({}),
-    signal,
-  });
-  if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`Virtual key generation failed (${response.status}): ${text}`);
+  const { signal: boundedSignal, cancel } = withTimeout(LOGIN_TIMEOUT_MS, signal);
+  try {
+    const response = await fetch(`${baseUrl}/key/generate`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${userToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+      signal: boundedSignal,
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`Virtual key generation failed (${response.status}): ${text}`);
+    }
+    const data = (await response.json()) as { key?: unknown; expires?: unknown };
+    if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /key/generate");
+    const expiresMs = typeof data.expires === "string" ? Date.parse(data.expires) : Number.NaN;
+    return { key: data.key, expiresAt: Number.isNaN(expiresMs) ? undefined : expiresMs };
+  } finally {
+    cancel();
   }
-  const data = (await response.json()) as { key?: unknown; expires?: unknown };
-  if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /key/generate");
-  const expiresMs = typeof data.expires === "string" ? Date.parse(data.expires) : Number.NaN;
-  return { key: data.key, expiresAt: Number.isNaN(expiresMs) ? undefined : expiresMs };
 }
 
 function getLiteLLMApiKey(credentials: OAuthCredentials): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,7 @@ async function loginLiteLLM(
 
   if (method === "2") {
     callbacks.onAuth?.({
-      url: `${baseUrl}/login`,
+      url: `${baseUrl}/sso/key/generate`,
       instructions: "Authenticate via SSO, then copy your token from the LiteLLM UI.",
     });
     const rawToken = (await callbacks.onPrompt({ message: "Paste your SSO token from the LiteLLM UI:" }))

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,11 @@ function openInBrowser(url: string): void {
     .unref();
 }
 
-async function generateVirtualKey(baseUrl: string, userToken: string, signal?: AbortSignal): Promise<string> {
+async function generateVirtualKey(
+  baseUrl: string,
+  userToken: string,
+  signal?: AbortSignal,
+): Promise<{ key: string; expiresAt?: number }> {
   const response = await fetch(`${baseUrl}/key/generate`, {
     method: "POST",
     headers: {
@@ -116,9 +120,10 @@ async function generateVirtualKey(baseUrl: string, userToken: string, signal?: A
     const text = await response.text().catch(() => "");
     throw new Error(`Virtual key generation failed (${response.status}): ${text}`);
   }
-  const data = (await response.json()) as { key?: unknown };
+  const data = (await response.json()) as { key?: unknown; expires?: unknown };
   if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /key/generate");
-  return data.key;
+  const expiresMs = typeof data.expires === "string" ? Date.parse(data.expires) : Number.NaN;
+  return { key: data.key, expiresAt: Number.isNaN(expiresMs) ? undefined : expiresMs };
 }
 
 function getLiteLLMApiKey(credentials: OAuthCredentials): string {
@@ -256,9 +261,13 @@ async function loginLiteLLM(
     if (wantVirtualKey !== "n") {
       try {
         callbacks.onProgress?.("Generating virtual key...");
-        apiKey = await generateVirtualKey(baseUrl, rawToken, callbacks.signal);
+        const generated = await generateVirtualKey(baseUrl, rawToken, callbacks.signal);
+        apiKey = generated.key;
         refresh = "";
-        expires = PERMANENT_TOKEN_EXPIRES_AT;
+        expires =
+          generated.expiresAt === undefined
+            ? PERMANENT_TOKEN_EXPIRES_AT
+            : Math.max(Date.now(), generated.expiresAt - TOKEN_REFRESH_LEAD_MS);
         callbacks.onProgress?.("Virtual key generated and will be used for API calls.");
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,7 +263,7 @@ async function loginLiteLLM(
       .trim()
       .toLowerCase();
 
-    if (wantVirtualKey !== "n") {
+    if (wantVirtualKey !== "n" && wantVirtualKey !== "no") {
       try {
         callbacks.onProgress?.("Generating virtual key...");
         const generated = await generateVirtualKey(baseUrl, rawToken, callbacks.signal);
@@ -319,7 +319,12 @@ async function loginLiteLLM(
 }
 
 async function refreshLiteLLM(credentials: OAuthCredentials): Promise<OAuthCredentials> {
-  if (!credentials.refresh.startsWith("!")) return credentials;
+  if (!credentials.refresh.startsWith("!")) {
+    if (credentials.expires < PERMANENT_TOKEN_EXPIRES_AT) {
+      throw new Error("LiteLLM credential cannot be refreshed; run /login litellm again");
+    }
+    return credentials;
+  }
   const access = executeApiKeyCommand(credentials.refresh);
   return { ...credentials, access, expires: tokenExpiresAt(access, EXPIRE_TOKEN_IMMEDIATELY) };
 }

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -180,6 +180,23 @@ describe("discoverModels via /model/info", () => {
       compat: { supportsStore: false },
     });
   });
+
+  it("uses catalog costs when /model/info omits costs for Anthropic aliases", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "opus-4.8", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("model_info");
+    expect(result.models[0]?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
+  });
 });
 
 describe("discoverModels fallback to /v1/models", () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -377,13 +377,19 @@ describe("extension startup", () => {
     const credential = await pi.providers[0]?.config.oauth?.login({
       onPrompt: async (options) => {
         promptMessages.push(options.message);
-        return promptMessages.length === 1 ? " http://127.0.0.1:4000/v1 " : " sk-login ";
+        if (options.placeholder) return " http://127.0.0.1:4000/v1 ";
+        if (options.message.includes("Select login method")) return "1";
+        return " sk-login ";
       },
       onProgress: progress,
       signal: new AbortController().signal,
     });
 
-    expect(promptMessages).toEqual(["Enter LiteLLM proxy URL (no trailing /v1):", "Enter API key:"]);
+    expect(promptMessages).toEqual([
+      "Enter LiteLLM proxy URL (no trailing /v1):",
+      "Select login method (1 = API key / !command, 2 = SSO / Enterprise JWT):",
+      "Enter API key:",
+    ]);
     expect(seenRequests).toEqual([{ url: "http://127.0.0.1:4000/model/info", authorization: "Bearer sk-login" }]);
     expect(credential).toMatchObject({
       access: "sk-login",
@@ -454,7 +460,9 @@ describe("extension startup", () => {
         ui: {
           input: async (message: string, placeholder?: string) => {
             promptMessages.push(message);
-            return placeholder ? " http://127.0.0.1:4000/v1 " : " sk-login ";
+            if (placeholder) return " http://127.0.0.1:4000/v1 ";
+            if (message.includes("Select login method")) return "1";
+            return " sk-login ";
           },
           notify: (message: string, type: string) => notifications.push({ message, type }),
         },
@@ -470,7 +478,11 @@ describe("extension startup", () => {
     );
 
     expect(result).toEqual({ action: "handled" });
-    expect(promptMessages).toEqual(["Enter LiteLLM proxy URL (no trailing /v1):", "Enter API key:"]);
+    expect(promptMessages).toEqual([
+      "Enter LiteLLM proxy URL (no trailing /v1):",
+      "Select login method (1 = API key / !command, 2 = SSO / Enterprise JWT):",
+      "Enter API key:",
+    ]);
     expect(savedCredentials.litellm).toMatchObject({
       type: "oauth",
       access: "sk-login",
@@ -719,5 +731,169 @@ describe("extension startup", () => {
     await extension(createPi());
 
     expect(seenAuthHeaders).toEqual([`Bearer ${fresh}`, `Bearer ${fresh}`]);
+  });
+
+  it("enterprise SSO login generates a virtual key and uses it as the access token", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const seenRequests: Array<{ url: string; method: string; authorization: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      seenRequests.push({
+        url,
+        method: String(init?.method ?? "GET"),
+        authorization: new Headers(init?.headers).get("authorization") ?? "",
+      });
+      if (url.endsWith("/user/key/generate")) return jsonResponse(200, { key: "sk-virtual-abc" });
+      if (url.endsWith("/model/info"))
+        return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        if (options.placeholder) return "https://litellm.example.com";
+        if (options.message.includes("Select login method")) return "2";
+        if (options.message.includes("SSO token")) return `Bearer ${jwt}`;
+        return "y";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(credential).toMatchObject({
+      access: "sk-virtual-abc",
+      refresh: "",
+      expires: Number.MAX_SAFE_INTEGER,
+      baseUrl: "https://litellm.example.com",
+    });
+    expect(seenRequests).toContainEqual(
+      expect.objectContaining({
+        url: "https://litellm.example.com/user/key/generate",
+        method: "POST",
+        authorization: `Bearer ${jwt}`,
+      }),
+    );
+    expect(seenRequests).toContainEqual(
+      expect.objectContaining({
+        url: "https://litellm.example.com/model/info",
+        authorization: "Bearer sk-virtual-abc",
+      }),
+    );
+  });
+
+  it("enterprise SSO login strips Bearer prefix from pasted SSO token", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const seenAuthorizations: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      seenAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
+      if (url.endsWith("/user/key/generate")) return jsonResponse(200, { key: "sk-stripped" });
+      if (url.endsWith("/model/info"))
+        return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        if (options.placeholder) return "https://litellm.example.com";
+        if (options.message.includes("Select login method")) return "2";
+        if (options.message.includes("SSO token")) return `  Bearer  ${jwt}  `;
+        return "y";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(seenAuthorizations[0]).toBe(`Bearer ${jwt}`);
+  });
+
+  it("enterprise SSO login uses JWT directly when user declines virtual key generation", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const seenRequests: Array<{ url: string; method: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      seenRequests.push({ url, method: String(init?.method ?? "GET") });
+      if (url.endsWith("/model/info"))
+        return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        if (options.placeholder) return "https://litellm.example.com";
+        if (options.message.includes("Select login method")) return "2";
+        if (options.message.includes("SSO token")) return jwt;
+        return "n";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(credential).toMatchObject({ access: jwt, refresh: "" });
+    expect(credential?.expires).toBeLessThan(Number.MAX_SAFE_INTEGER);
+    expect(seenRequests.every(({ url }) => !url.includes("key/generate"))).toBe(true);
+  });
+
+  it("enterprise SSO login falls back to JWT when virtual key generation fails", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const progress = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/user/key/generate")) return jsonResponse(403, { error: "forbidden" });
+      if (url.endsWith("/model/info"))
+        return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        if (options.placeholder) return "https://litellm.example.com";
+        if (options.message.includes("Select login method")) return "2";
+        if (options.message.includes("SSO token")) return jwt;
+        return "y";
+      },
+      onProgress: progress,
+      signal: new AbortController().signal,
+    });
+
+    expect(credential).toMatchObject({ access: jwt, refresh: "" });
+    expect(progress).toHaveBeenCalledWith(expect.stringContaining("virtual key generation failed"));
+  });
+
+  it("enterprise SSO login throws when SSO token is empty", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await expect(
+      pi.providers[0]?.config.oauth?.login({
+        onPrompt: async (options) => {
+          if (options.placeholder) return "https://litellm.example.com";
+          if (options.message.includes("Select login method")) return "2";
+          return "";
+        },
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toThrow("SSO token is required");
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -25,6 +25,7 @@ type TestProviderConfig = {
   oauth?: {
     login: (callbacks: {
       onPrompt: (options: { message: string; placeholder?: string }) => Promise<string>;
+      onAuth?: (info: { url: string; instructions?: string }) => void;
       onProgress?: (message: string) => void;
       signal?: AbortSignal;
     }) => Promise<{ access: string; refresh: string; expires: number; baseUrl?: string }>;
@@ -754,6 +755,7 @@ describe("extension startup", () => {
     const pi = createPi();
     await extension(pi);
 
+    const authInfos: Array<{ url: string; instructions?: string }> = [];
     const credential = await pi.providers[0]?.config.oauth?.login({
       onPrompt: async (options) => {
         if (options.placeholder) return "https://litellm.example.com";
@@ -761,9 +763,16 @@ describe("extension startup", () => {
         if (options.message.includes("SSO token")) return `Bearer ${jwt}`;
         return "y";
       },
+      onAuth: (info) => authInfos.push(info),
       signal: new AbortController().signal,
     });
 
+    expect(authInfos).toEqual([
+      {
+        url: "https://litellm.example.com/login",
+        instructions: "Authenticate via SSO, then copy your token from the LiteLLM UI.",
+      },
+    ]);
     expect(credential).toMatchObject({
       access: "sk-virtual-abc",
       refresh: "",

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -769,7 +769,7 @@ describe("extension startup", () => {
 
     expect(authInfos).toEqual([
       {
-        url: "https://litellm.example.com/login",
+        url: "https://litellm.example.com/sso/key/generate",
         instructions: "Authenticate via SSO, then copy your token from the LiteLLM UI.",
       },
     ]);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -855,6 +855,48 @@ describe("extension startup", () => {
     expect(credential?.expires).toBe(keyExpiresAt.getTime() - 5 * 60 * 1000);
   });
 
+  it("enterprise SSO login falls back to JWT when virtual key generation stalls", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const progress = vi.fn();
+    vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+      const url = String(input);
+      if (url.endsWith("/key/generate"))
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason ?? new Error("aborted")), {
+            once: true,
+          });
+        });
+      if (url.endsWith("/model/info"))
+        return Promise.resolve(jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] }));
+      return Promise.reject(new Error(`unexpected URL: ${url}`));
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    vi.useFakeTimers();
+    try {
+      const loginPromise = pi.providers[0]?.config.oauth?.login({
+        onPrompt: async (options) => {
+          if (options.placeholder) return "https://litellm.example.com";
+          if (options.message.includes("Select login method")) return "2";
+          if (options.message.includes("SSO token")) return jwt;
+          return "y";
+        },
+        onProgress: progress,
+        signal: new AbortController().signal,
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+      const credential = await loginPromise;
+      expect(credential).toMatchObject({ access: jwt, refresh: "" });
+      expect(progress).toHaveBeenCalledWith(expect.stringContaining("virtual key generation failed"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("enterprise SSO login uses JWT directly when user declines virtual key generation", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -746,7 +746,7 @@ describe("extension startup", () => {
         method: String(init?.method ?? "GET"),
         authorization: new Headers(init?.headers).get("authorization") ?? "",
       });
-      if (url.endsWith("/user/key/generate")) return jsonResponse(200, { key: "sk-virtual-abc" });
+      if (url.endsWith("/key/generate")) return jsonResponse(200, { key: "sk-virtual-abc" });
       if (url.endsWith("/model/info"))
         return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
       throw new Error(`unexpected URL: ${url}`);
@@ -781,7 +781,7 @@ describe("extension startup", () => {
     });
     expect(seenRequests).toContainEqual(
       expect.objectContaining({
-        url: "https://litellm.example.com/user/key/generate",
+        url: "https://litellm.example.com/key/generate",
         method: "POST",
         authorization: `Bearer ${jwt}`,
       }),
@@ -802,7 +802,7 @@ describe("extension startup", () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
       seenAuthorizations.push(new Headers(init?.headers).get("authorization") ?? "");
-      if (url.endsWith("/user/key/generate")) return jsonResponse(200, { key: "sk-stripped" });
+      if (url.endsWith("/key/generate")) return jsonResponse(200, { key: "sk-stripped" });
       if (url.endsWith("/model/info"))
         return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
       throw new Error(`unexpected URL: ${url}`);
@@ -862,7 +862,7 @@ describe("extension startup", () => {
     const progress = vi.fn();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/user/key/generate")) return jsonResponse(403, { error: "forbidden" });
+      if (url.endsWith("/key/generate")) return jsonResponse(403, { error: "forbidden" });
       if (url.endsWith("/model/info"))
         return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
       throw new Error(`unexpected URL: ${url}`);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -824,6 +824,37 @@ describe("extension startup", () => {
     expect(seenAuthorizations[0]).toBe(`Bearer ${jwt}`);
   });
 
+  it("enterprise SSO login honors the expiry returned with a generated virtual key", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const keyExpiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/key/generate"))
+        return jsonResponse(200, { key: "sk-expiring", expires: keyExpiresAt.toISOString() });
+      if (url.endsWith("/model/info"))
+        return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        if (options.placeholder) return "https://litellm.example.com";
+        if (options.message.includes("Select login method")) return "2";
+        if (options.message.includes("SSO token")) return jwt;
+        return "y";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(credential).toMatchObject({ access: "sk-expiring", refresh: "" });
+    expect(credential?.expires).toBe(keyExpiresAt.getTime() - 5 * 60 * 1000);
+  });
+
   it("enterprise SSO login uses JWT directly when user declines virtual key generation", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -897,7 +897,7 @@ describe("extension startup", () => {
     }
   });
 
-  it("enterprise SSO login uses JWT directly when user declines virtual key generation", async () => {
+  it("enterprise SSO login uses JWT directly when user answers no to virtual key generation", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
     const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
@@ -918,7 +918,7 @@ describe("extension startup", () => {
         if (options.placeholder) return "https://litellm.example.com";
         if (options.message.includes("Select login method")) return "2";
         if (options.message.includes("SSO token")) return jwt;
-        return "n";
+        return "no";
       },
       signal: new AbortController().signal,
     });
@@ -926,6 +926,38 @@ describe("extension startup", () => {
     expect(credential).toMatchObject({ access: jwt, refresh: "" });
     expect(credential?.expires).toBeLessThan(Number.MAX_SAFE_INTEGER);
     expect(seenRequests.every(({ url }) => !url.includes("key/generate"))).toBe(true);
+  });
+
+  it("enterprise SSO refresh rejects expiring generated virtual keys without a refresh path", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const jwt = makeJwt(Math.floor(Date.now() / 1000) + 3600);
+    const keyExpiresAt = new Date(Date.now() + 60 * 60 * 1000);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/key/generate"))
+        return jsonResponse(200, { key: "sk-expiring", expires: keyExpiresAt.toISOString() });
+      if (url.endsWith("/model/info"))
+        return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => {
+        if (options.placeholder) return "https://litellm.example.com";
+        if (options.message.includes("Select login method")) return "2";
+        if (options.message.includes("SSO token")) return jwt;
+        return "y";
+      },
+      signal: new AbortController().signal,
+    });
+
+    await expect(pi.providers[0]?.config.oauth?.refreshToken(credential!)).rejects.toThrow(
+      "LiteLLM credential cannot be refreshed; run /login litellm again",
+    );
   });
 
   it("enterprise SSO login falls back to JWT when virtual key generation fails", async () => {


### PR DESCRIPTION
Extends `/login litellm` with a new method-selection prompt. Choosing
option 2 guides the user through pasting their SSO JWT (Bearer prefix
stripped automatically) and optionally generating a stable LiteLLM
virtual key via POST /user/key/generate. If key generation fails the
extension falls back to using the JWT directly. JWT expiry is read from
the token's exp claim via the existing tokenExpiresAt helper.

https://claude.ai/code/session_0127AaK3uGvBU4Ra1Kot9dYN