### PR TITLE
Fix /model/info discovery: keep responses-mode models and carry thinkingLevelMap

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -219,10 +219,15 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   if (!id) return undefined;
   const info = entry.model_info ?? {};
   if (!isSelectableMode(info.mode)) return undefined;
+  // Borrow the thinking-level map from the catalog when the model id is known
+  // (e.g. deepseek-v4-pro), so per-model levels like "xhigh" stay available.
+  // The proxy's /model/info does not carry this mapping.
+  const catalogModel = findCatalogModel(id, info.litellm_provider);
   return {
     id,
     name: id,
     reasoning: info.supports_reasoning ?? false,
+    thinkingLevelMap: catalogModel?.thinkingLevelMap,
     input: info.supports_vision ? ["text", "image"] : ["text"],
     cost: {
       input: (info.input_cost_per_token ?? 0) * 1_000_000,

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -14,6 +14,14 @@ import type {
 const DEFAULT_TIMEOUT_MS = 5000;
 const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
+// LiteLLM exposes Responses-API models (e.g. ChatGPT-subscription routes) with
+// mode "responses". They are still callable via /chat/completions through the
+// proxy, so treat them as selectable alongside "chat". Other modes (embedding,
+// image_generation, ...) remain filtered out.
+const SELECTABLE_MODES = new Set(["chat", "responses"]);
+function isSelectableMode(mode: string | undefined): boolean {
+  return !mode || SELECTABLE_MODES.has(mode);
+}
 const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
 const MODELS_DEV_URL = "https://models.dev/api.json";
 let modelsDevCatalog: ModelsDevResponse | undefined;
@@ -210,7 +218,7 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   const id = entry.model_name;
   if (!id) return undefined;
   const info = entry.model_info ?? {};
-  if (info.mode && info.mode !== "chat") return undefined;
+  if (!isSelectableMode(info.mode)) return undefined;
   return {
     id,
     name: id,
@@ -234,7 +242,7 @@ function mapFromHealthModelInfo(
 ): ProviderModelConfig | undefined {
   const model = mapFromModelInfo(entry);
   if (model || !fallbackId) return model;
-  if (entry.model_info?.mode && entry.model_info.mode !== "chat") return undefined;
+  if (!isSelectableMode(entry.model_info?.mode)) return undefined;
   return {
     id: fallbackId,
     name: fallbackId,

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -255,8 +255,8 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
       cacheRead: (info.cache_read_input_token_cost ?? 0) * 1_000_000,
       cacheWrite: (info.cache_creation_input_token_cost ?? 0) * 1_000_000,
     },
-    contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
-    maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
+    contextWindow: info.max_input_tokens ?? catalogModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: info.max_output_tokens ?? catalogModel?.maxTokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
   };
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -120,6 +120,15 @@ function getFallbackProviderAndModel(id: string, ownedBy?: string): { provider?:
   return { provider: toKnownProvider(ownedBy), modelId: id };
 }
 
+// LiteLLM bridge routes prefix the model id with a transport segment (e.g.
+// "responses/gpt-5.5"). Drop a leading known bridge segment so the bare
+// catalog id can match.
+const BRIDGE_SEGMENTS = new Set(["responses"]);
+function stripBridgeSegment(modelId: string): string {
+  const [first, ...rest] = modelId.split("/");
+  return rest.length > 0 && BRIDGE_SEGMENTS.has(first) ? rest.join("/") : modelId;
+}
+
 // Resolve the catalog model for a /model/info entry. With LiteLLM aliases,
 // model_name may be a public alias (e.g. "ds-pro") while the real catalog key
 // is carried in litellm_params.model or model_info.key (e.g.
@@ -135,7 +144,13 @@ function findCatalogModelForInfo(entry: ModelInfoEntry): Model<Api> | undefined 
   const underlyingKey = entry.litellm_params?.model ?? info.key;
   if (underlyingKey && underlyingKey !== id) {
     const { provider, modelId } = getFallbackProviderAndModel(underlyingKey, info.litellm_provider);
-    return findCatalogModel(modelId, provider);
+    const viaKey = findCatalogModel(modelId, provider);
+    if (viaKey) return viaKey;
+    // LiteLLM bridge routes insert a transport segment between provider and
+    // model (e.g. "openai/responses/gpt-5.5" -> modelId "responses/gpt-5.5").
+    // Strip it so the catalog id ("gpt-5.5") matches.
+    const stripped = stripBridgeSegment(modelId);
+    if (stripped !== modelId) return findCatalogModel(stripped, provider);
   }
   return undefined;
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -120,6 +120,26 @@ function getFallbackProviderAndModel(id: string, ownedBy?: string): { provider?:
   return { provider: toKnownProvider(ownedBy), modelId: id };
 }
 
+// Resolve the catalog model for a /model/info entry. With LiteLLM aliases,
+// model_name may be a public alias (e.g. "ds-pro") while the real catalog key
+// is carried in litellm_params.model or model_info.key (e.g.
+// "deepseek/deepseek-v4-pro"). Match the alias first, then fall back to the
+// underlying key so thinkingLevelMap (xhigh etc.) is still carried.
+function findCatalogModelForInfo(entry: ModelInfoEntry): Model<Api> | undefined {
+  const info = entry.model_info ?? {};
+  const id = entry.model_name;
+  if (id) {
+    const direct = findCatalogModel(id, info.litellm_provider);
+    if (direct) return direct;
+  }
+  const underlyingKey = entry.litellm_params?.model ?? info.key;
+  if (underlyingKey && underlyingKey !== id) {
+    const { provider, modelId } = getFallbackProviderAndModel(underlyingKey, info.litellm_provider);
+    return findCatalogModel(modelId, provider);
+  }
+  return undefined;
+}
+
 function findModelsDevModel(
   catalog: ModelsDevResponse | undefined,
   id: string,
@@ -219,10 +239,10 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   if (!id) return undefined;
   const info = entry.model_info ?? {};
   if (!isSelectableMode(info.mode)) return undefined;
-  // Borrow the thinking-level map from the catalog when the model id is known
+  // Borrow the thinking-level map from the catalog when the model is known
   // (e.g. deepseek-v4-pro), so per-model levels like "xhigh" stay available.
   // The proxy's /model/info does not carry this mapping.
-  const catalogModel = findCatalogModel(id, info.litellm_provider);
+  const catalogModel = findCatalogModelForInfo(entry);
   return {
     id,
     name: id,

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,9 @@ export interface DiscoveryOptions {
 
 export interface ModelInfoEntry {
   model_name?: string;
+  litellm_params?: {
+    model?: string;
+  };
   model_info?: {
     mode?: string;
     input_cost_per_token?: number;
@@ -33,6 +36,7 @@ export interface ModelInfoEntry {
     supports_reasoning?: boolean;
     supports_vision?: boolean;
     litellm_provider?: string;
+    key?: string;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export interface ModelInfoEntry {
     max_output_tokens?: number;
     supports_reasoning?: boolean;
     supports_vision?: boolean;
+    litellm_provider?: string;
   };
 }
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -201,6 +201,30 @@ describe("discoverModels via /model/info", () => {
     expect(result.models.map((m) => m.id)).toEqual(["chatgpt-5.5"]);
     expect(result.models[0]).toMatchObject({ id: "chatgpt-5.5", reasoning: true });
   });
+
+  it("borrows thinkingLevelMap from the catalog for known model ids (keeps xhigh etc.)", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "deepseek-v4-pro",
+              model_info: { mode: "chat", supports_reasoning: true, litellm_provider: "deepseek" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("model_info");
+    const model = result.models.find((m) => m.id === "deepseek-v4-pro");
+    // catalog entry for deepseek-v4-pro maps xhigh -> "max"
+    expect(model?.thinkingLevelMap?.xhigh).toBe("max");
+  });
 });
 
 describe("discoverModels fallback to /v1/models", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -180,6 +180,27 @@ describe("discoverModels via /model/info", () => {
       compat: { supportsStore: false },
     });
   });
+
+  it("keeps responses-mode models (e.g. ChatGPT subscription) and drops other non-chat modes", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            { model_name: "chatgpt-5.5", model_info: { mode: "responses", supports_reasoning: true } },
+            { model_name: "openai/text-embedding-3-large", model_info: { mode: "embedding" } },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("model_info");
+    expect(result.models.map((m) => m.id)).toEqual(["chatgpt-5.5"]);
+    expect(result.models[0]).toMatchObject({ id: "chatgpt-5.5", reasoning: true });
+  });
 });
 
 describe("discoverModels fallback to /v1/models", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -224,6 +224,9 @@ describe("discoverModels via /model/info", () => {
     const model = result.models.find((m) => m.id === "deepseek-v4-pro");
     // catalog entry for deepseek-v4-pro maps xhigh -> "max"
     expect(model?.thinkingLevelMap?.xhigh).toBe("max");
+    // context window/max tokens fall back to the catalog when /model/info omits them
+    expect(model?.contextWindow).toBe(1_000_000);
+    expect(model?.maxTokens).toBe(384_000);
   });
 
   it("resolves thinkingLevelMap via the underlying key when model_name is an alias", async () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -262,6 +262,30 @@ describe("discoverModels via /model/info", () => {
     expect(result.models.find((m) => m.id === "ds-pro")?.thinkingLevelMap?.xhigh).toBe("max");
     expect(result.models.find((m) => m.id === "ds-pro-2")?.thinkingLevelMap?.xhigh).toBe("max");
   });
+
+  it("strips the LiteLLM bridge segment (responses/) to match the catalog", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "gpt5",
+              litellm_params: { model: "openai/responses/gpt-5.5" },
+              model_info: { mode: "responses", supports_reasoning: true, litellm_provider: "openai" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    // catalog entry for gpt-5.5 carries a thinkingLevelMap; without stripping
+    // "responses/" the lookup misses and the map is undefined.
+    expect(result.models.find((m) => m.id === "gpt5")?.thinkingLevelMap?.xhigh).toBe("xhigh");
+  });
 });
 
 describe("discoverModels fallback to /v1/models", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -225,6 +225,40 @@ describe("discoverModels via /model/info", () => {
     // catalog entry for deepseek-v4-pro maps xhigh -> "max"
     expect(model?.thinkingLevelMap?.xhigh).toBe("max");
   });
+
+  it("resolves thinkingLevelMap via the underlying key when model_name is an alias", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            // public alias "ds-pro"; real catalog key in litellm_params.model
+            {
+              model_name: "ds-pro",
+              litellm_params: { model: "deepseek/deepseek-v4-pro" },
+              model_info: { mode: "chat", supports_reasoning: true, litellm_provider: "deepseek" },
+            },
+            // same, but the key is carried in model_info.key instead
+            {
+              model_name: "ds-pro-2",
+              model_info: {
+                mode: "chat",
+                supports_reasoning: true,
+                litellm_provider: "deepseek",
+                key: "deepseek/deepseek-v4-pro",
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models.find((m) => m.id === "ds-pro")?.thinkingLevelMap?.xhigh).toBe("max");
+    expect(result.models.find((m) => m.id === "ds-pro-2")?.thinkingLevelMap?.xhigh).toBe("max");
+  });
 });
 
 describe("discoverModels fallback to /v1/models", () => {


### PR DESCRIPTION
The `/model/info` discovery path (`mapFromModelInfo`) builds a leaner `ProviderModelConfig` than the `models_list` and `health` paths, dropping two things that make LiteLLM models work correctly in Pi. Two related fixes.

## 1. Keep `mode: "responses"` models

LiteLLM exposes Responses-API models with `model_info.mode: "responses"` — most notably ChatGPT-subscription routes (`chatgpt/*`), but any model served through `/responses`. They are fully callable via `/chat/completions` through the proxy. But discovery rejected any mode other than `"chat"`:

```ts
if (info.mode && info.mode !== "chat") return undefined;
```

so e.g. a working `chatgpt-5.5` silently vanished from Pi's model list. Now `"responses"` is treated as selectable alongside `"chat"` via a shared `isSelectableMode()` helper; `embedding`/`image_generation`/etc. stay filtered.

## 2. Carry `thinkingLevelMap` on the `/model/info` path

`mapFromModelsList` and `mapFromHealthEndpoint` both set `thinkingLevelMap: catalogModel?.thinkingLevelMap`, but `mapFromModelInfo` did not. So models discovered via `/model/info` lost their per-model thinking levels — e.g. `deepseek-v4-pro` (catalog map `{...,"high":"high","xhigh":"max"}`) was capped at the default level set and `xhigh` was unselectable in Pi, even though the proxy and provider accept it. Now `mapFromModelInfo` looks up the catalog by id (+ `litellm_provider`) and reuses its `thinkingLevelMap`, matching the other two paths.

## Tests

- `responses`-mode model kept with `reasoning: true`; `embedding` still dropped.
- `deepseek-v4-pro` via `/model/info` retains `thinkingLevelMap.xhigh === "max"`.

`tsgo` typecheck clean, `biome check` clean, 26/26 vitest pass.