### PR TITLE
expand LiteLLM smoke auth coverage

### DIFF
--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -27,7 +27,7 @@ jobs:
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
       LITELLM_LICENSE: ${{ secrets.LITELLM_LICENSE }}
       LITELLM_DATABASE_URL: postgresql://litellm:litellm@host.docker.internal:5432/litellm
-      LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
+      LITELLM_IMAGE: ${{ secrets.LITELLM_LICENSE != '' && 'docker.litellm.ai/berriai/litellm-database:main-latest' || 'docker.litellm.ai/berriai/litellm:main-latest' }}
       LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
       LITELLM_SMOKE_EXPECT_SOURCE: model_info
       LITELLM_CLI_SMOKE_MODEL: vidaimock-openai

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -26,6 +26,7 @@ jobs:
       LITELLM_API_KEY: sk-ci-litellm-smoke
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
       LITELLM_LICENSE: ${{ secrets.LITELLM_LICENSE }}
+      LITELLM_DATABASE_URL: postgresql://litellm:litellm@host.docker.internal:5432/litellm
       LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
       LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
       LITELLM_SMOKE_EXPECT_SOURCE: model_info
@@ -86,6 +87,35 @@ jobs:
           cat .tmp/vidaimock.log >&2 || true
           exit 1
 
+      - name: Start LiteLLM smoke database
+        if: ${{ env.LITELLM_LICENSE != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run -d \
+            --name litellm-smoke-db \
+            -e POSTGRES_USER=litellm \
+            -e POSTGRES_PASSWORD=litellm \
+            -e POSTGRES_DB=litellm \
+            -p 5432:5432 \
+            postgres:16-alpine
+
+      - name: Wait for LiteLLM smoke database
+        if: ${{ env.LITELLM_LICENSE != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for _ in {1..30}; do
+            if docker exec litellm-smoke-db pg_isready -U litellm -d litellm; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs litellm-smoke-db >&2 || true
+          exit 1
+
       - name: Write LiteLLM smoke config
         shell: bash
         run: |
@@ -107,6 +137,13 @@ jobs:
           general_settings:
             master_key: ${LITELLM_MASTER_KEY}
           YAML
+          if [[ -n "${LITELLM_LICENSE:-}" ]]; then
+            cat >> .tmp/litellm_config.yaml <<YAML
+            database_url: ${LITELLM_DATABASE_URL}
+            store_model_in_db: true
+            admin_only_routes: ["/key/generate"]
+          YAML
+          fi
 
       - name: Start LiteLLM proxy
         shell: bash
@@ -142,6 +179,11 @@ jobs:
         env:
           LITELLM_SMOKE_TIMEOUT_MS: '60000'
         run: npx tsx scripts/smoke.ts
+
+      - name: Run auth smoke
+        env:
+          LITELLM_SMOKE_TIMEOUT_MS: '60000'
+        run: npx tsx scripts/smoke-auth.ts
 
       - name: Run Pi CLI smoke
         env:
@@ -186,6 +228,10 @@ jobs:
       - name: Stop LiteLLM proxy
         if: always()
         run: docker rm -f litellm-smoke || true
+
+      - name: Stop LiteLLM smoke database
+        if: always()
+        run: docker rm -f litellm-smoke-db || true
 
       - name: Stop VidaiMock
         if: always()

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -25,6 +25,7 @@ jobs:
       LITELLM_BASE_URL: http://127.0.0.1:4000
       LITELLM_API_KEY: sk-ci-litellm-smoke
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
+      LITELLM_LICENSE: ${{ secrets.LITELLM_LICENSE }}
       LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
       LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
       LITELLM_SMOKE_EXPECT_SOURCE: model_info
@@ -117,6 +118,7 @@ jobs:
             -p 4000:4000 \
             -v "$PWD/.tmp/litellm_config.yaml:/app/config.yaml:ro" \
             -e LITELLM_MASTER_KEY \
+            -e LITELLM_LICENSE \
             "$LITELLM_IMAGE" \
             --config /app/config.yaml
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ If your LiteLLM proxy exposes `/v1/skills`, enabled skills are fetched before ea
 
 The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes OpenAI-compatible and Anthropic routes whose upstreams are served by VidaiMock, then this extension's smoke runner discovers those models through LiteLLM and sends `/v1/chat/completions` requests through the proxy.
 
-This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The smoke runner also asserts that discovery came from `/model/info` (`LITELLM_SMOKE_EXPECT_SOURCE`) so a silent fallback to `/v1/models` fails the run. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` against both the OpenAI-compatible and Anthropic-backed routes, so extension loading, model discovery, and real completion paths are covered without opening the TUI.
+This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The smoke runner also asserts that discovery came from `/model/info` (`LITELLM_SMOKE_EXPECT_SOURCE`) so a silent fallback to `/v1/models` fails the run. The workflow also runs auth checks plus optional Postgres-backed auth checks when `LITELLM_LICENSE` is configured for virtual-key and admin-route behavior, then runs a non-interactive Pi CLI smoke with `--list-models` and `-p` against both the OpenAI-compatible and Anthropic-backed routes, so extension loading, model discovery, and real completion paths are covered without opening the TUI.
 
 ## Development
 

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -2,6 +2,9 @@
 // Reads LITELLM_BASE_URL, LITELLM_API_KEY, LITELLM_CLI_SMOKE_MODEL, and optional LITELLM_LICENSE.
 // Run: npx tsx scripts/smoke-auth.ts
 
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { normalizeBaseUrl } from "../src/discover.js";
 
@@ -32,6 +35,29 @@ type ChatCompletionResponse = {
 
 type KeyGenerateResponse = {
   key?: unknown;
+};
+
+type SmokeOAuthCredential = {
+  access: string;
+};
+
+type SmokeProviderConfig = {
+  oauth?: {
+    login: (callbacks: {
+      onPrompt: (options: { message: string; placeholder?: string }) => Promise<string>;
+      onAuth?: (info: { url: string; instructions?: string }) => void;
+      onProgress?: (message: string) => void;
+      signal?: AbortSignal;
+    }) => Promise<SmokeOAuthCredential>;
+  };
+};
+
+type SmokePi = {
+  providers: Array<{ name: string; config: SmokeProviderConfig }>;
+  registerProvider: (name: string, config: SmokeProviderConfig) => void;
+  registerCommand: () => void;
+  registerTool: () => void;
+  on: () => void;
 };
 
 function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
@@ -167,6 +193,61 @@ async function expectAdminOnlyKeyGenerate(
   await expectAuthFailure("/key/generate with virtual key", response);
 }
 
+function createSmokePi(): SmokePi {
+  return {
+    providers: [],
+    registerProvider(name, config) {
+      this.providers.push({ name, config });
+    },
+    registerCommand: () => undefined,
+    registerTool: () => undefined,
+    on: () => undefined,
+  };
+}
+
+export async function runSsoLoginSmoke(
+  options: Required<Pick<AuthSmokeOptions, "baseUrl" | "masterKey" | "modelId">> & {
+    timeoutMs: number;
+  },
+): Promise<void> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR ??= await mkdtemp(join(tmpdir(), "pi-litellm-sso-smoke-"));
+  try {
+    const extension = (await import("../src/index.js")).default as unknown as (pi: SmokePi) => Promise<void>;
+    const pi = createSmokePi();
+    await extension(pi);
+
+    const oauth = pi.providers.find((provider) => provider.name === "litellm")?.config.oauth;
+    if (!oauth) throw new Error("LiteLLM provider did not expose OAuth login");
+
+    const authInfos: Array<{ url: string; instructions?: string }> = [];
+    const credential = await oauth.login({
+      onAuth: (info) => authInfos.push(info),
+      onPrompt: async ({ message, placeholder }) => {
+        if (placeholder) return baseUrl;
+        if (message.includes("Select login method")) return "2";
+        if (message.includes("SSO token")) return `Bearer ${options.masterKey}`;
+        if (message.includes("Generate a LiteLLM virtual key")) return "y";
+        return "";
+      },
+      signal: new AbortController().signal,
+    });
+
+    if (!authInfos.some((info) => info.url === `${baseUrl}/sso/key/generate`)) {
+      throw new Error("SSO login did not request /sso/key/generate");
+    }
+    if (!credential.access || credential.access === options.masterKey) {
+      throw new Error("SSO login did not return a generated virtual key");
+    }
+
+    await smokeChat(baseUrl, credential.access, options.modelId, options.timeoutMs);
+  } finally {
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+  }
+}
+
 function firstSmokeModel(env: NodeJS.ProcessEnv): string | undefined {
   const cliModel = env.LITELLM_CLI_SMOKE_MODEL?.trim();
   if (cliModel) return cliModel;
@@ -200,6 +281,14 @@ export async function runAuthSmoke(options: AuthSmokeOptions): Promise<AuthSmoke
 
     await expectAdminOnlyKeyGenerate(baseUrl, virtualKey, options.modelId, timeoutMs);
     checks.push("enterprise-admin-route");
+
+    await runSsoLoginSmoke({
+      baseUrl,
+      masterKey: options.masterKey,
+      modelId: options.modelId,
+      timeoutMs,
+    });
+    checks.push("sso-login", "sso-virtual-key-chat");
   }
 
   return {

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -1,0 +1,245 @@
+// CI auth smoke test against a real LiteLLM proxy.
+// Reads LITELLM_BASE_URL, LITELLM_API_KEY, LITELLM_CLI_SMOKE_MODEL, and optional LITELLM_LICENSE.
+// Run: npx tsx scripts/smoke-auth.ts
+
+import { pathToFileURL } from "node:url";
+import { normalizeBaseUrl } from "../src/discover.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const BAD_SMOKE_KEY = "bad-smoke-key";
+const SMOKE_PROMPT = "Reply with one short word.";
+
+export type AuthSmokeResult = {
+  enterprise: boolean;
+  checks: string[];
+};
+
+export type AuthSmokeOptions = {
+  baseUrl: string;
+  masterKey: string;
+  modelId: string;
+  timeoutMs?: number;
+  enterprise?: boolean;
+};
+
+type ChatCompletionResponse = {
+  choices?: Array<{
+    message?: {
+      content?: unknown;
+    };
+  }>;
+};
+
+type KeyGenerateResponse = {
+  key?: unknown;
+};
+
+function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timer),
+  };
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const body = await response.text();
+    return body ? `: ${body.slice(0, 500)}` : "";
+  } catch {
+    return "";
+  }
+}
+
+async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const { signal, cancel } = withTimeout(timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal });
+  } finally {
+    cancel();
+  }
+}
+
+function authHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+  return headers;
+}
+
+function jsonHeaders(apiKey: string): Record<string, string> {
+  return {
+    ...authHeaders(apiKey),
+    "Content-Type": "application/json",
+  };
+}
+
+function isAuthFailure(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+async function expectAuthFailure(label: string, response: Response): Promise<void> {
+  if (!isAuthFailure(response.status)) {
+    throw new Error(`${label} should reject auth, got ${response.status}${await readErrorBody(response)}`);
+  }
+}
+
+async function expectOk(label: string, response: Response): Promise<void> {
+  if (!response.ok) {
+    throw new Error(`${label} returned ${response.status}${await readErrorBody(response)}`);
+  }
+}
+
+async function fetchModels(baseUrl: string, apiKey: string | undefined, timeoutMs: number): Promise<Response> {
+  return fetchWithTimeout(
+    `${baseUrl}/v1/models`,
+    {
+      method: "GET",
+      headers: authHeaders(apiKey),
+    },
+    timeoutMs,
+  );
+}
+
+async function smokeChat(baseUrl: string, apiKey: string, modelId: string, timeoutMs: number): Promise<void> {
+  const response = await fetchWithTimeout(
+    `${baseUrl}/v1/chat/completions`,
+    {
+      method: "POST",
+      headers: jsonHeaders(apiKey),
+      body: JSON.stringify({
+        model: modelId,
+        messages: [{ role: "user", content: SMOKE_PROMPT }],
+        max_tokens: 16,
+        temperature: 0,
+      }),
+    },
+    timeoutMs,
+  );
+  await expectOk(`/v1/chat/completions for ${modelId}`, response);
+
+  const data = (await response.json()) as ChatCompletionResponse;
+  const content = data.choices?.[0]?.message?.content;
+  if (typeof content !== "string" || content.trim().length === 0) {
+    throw new Error(`/v1/chat/completions for ${modelId} returned no assistant text`);
+  }
+}
+
+async function generateVirtualKey(
+  baseUrl: string,
+  masterKey: string,
+  modelId: string,
+  timeoutMs: number,
+): Promise<string> {
+  const response = await fetchWithTimeout(
+    `${baseUrl}/key/generate`,
+    {
+      method: "POST",
+      headers: jsonHeaders(masterKey),
+      body: JSON.stringify({ models: [modelId], duration: "1h" }),
+    },
+    timeoutMs,
+  );
+  await expectOk("/key/generate with master key", response);
+
+  const data = (await response.json()) as KeyGenerateResponse;
+  if (typeof data.key !== "string" || data.key.length === 0) {
+    throw new Error("/key/generate returned no key");
+  }
+  return data.key;
+}
+
+async function expectAdminOnlyKeyGenerate(
+  baseUrl: string,
+  apiKey: string,
+  modelId: string,
+  timeoutMs: number,
+): Promise<void> {
+  const response = await fetchWithTimeout(
+    `${baseUrl}/key/generate`,
+    {
+      method: "POST",
+      headers: jsonHeaders(apiKey),
+      body: JSON.stringify({ models: [modelId], duration: "1h" }),
+    },
+    timeoutMs,
+  );
+  await expectAuthFailure("/key/generate with virtual key", response);
+}
+
+function firstSmokeModel(env: NodeJS.ProcessEnv): string | undefined {
+  const cliModel = env.LITELLM_CLI_SMOKE_MODEL?.trim();
+  if (cliModel) return cliModel;
+  return (env.LITELLM_SMOKE_MODELS ?? "")
+    .split(/[,\s]+/)
+    .map((model) => model.trim())
+    .find((model) => model.length > 0);
+}
+
+export async function runAuthSmoke(options: AuthSmokeOptions): Promise<AuthSmokeResult> {
+  const baseUrl = normalizeBaseUrl(options.baseUrl);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const checks: string[] = [];
+
+  await expectAuthFailure("missing-token /v1/models", await fetchModels(baseUrl, undefined, timeoutMs));
+  checks.push("missing-token");
+
+  await expectAuthFailure("bad-token /v1/models", await fetchModels(baseUrl, BAD_SMOKE_KEY, timeoutMs));
+  checks.push("bad-token");
+
+  await expectOk("master-key /v1/models", await fetchModels(baseUrl, options.masterKey, timeoutMs));
+  checks.push("master-key-models");
+
+  await smokeChat(baseUrl, options.masterKey, options.modelId, timeoutMs);
+  checks.push("master-key-chat");
+
+  if (options.enterprise) {
+    const virtualKey = await generateVirtualKey(baseUrl, options.masterKey, options.modelId, timeoutMs);
+    await smokeChat(baseUrl, virtualKey, options.modelId, timeoutMs);
+    checks.push("virtual-key-chat");
+
+    await expectAdminOnlyKeyGenerate(baseUrl, virtualKey, options.modelId, timeoutMs);
+    checks.push("enterprise-admin-route");
+  }
+
+  return {
+    enterprise: Boolean(options.enterprise),
+    checks,
+  };
+}
+
+export async function runAuthSmokeFromEnv(env: NodeJS.ProcessEnv = process.env): Promise<AuthSmokeResult> {
+  const baseUrl = env.LITELLM_BASE_URL?.trim();
+  const masterKey = env.LITELLM_API_KEY?.trim();
+  const modelId = firstSmokeModel(env);
+  if (!baseUrl || !masterKey || !modelId) {
+    throw new Error("LITELLM_BASE_URL, LITELLM_API_KEY, and LITELLM_CLI_SMOKE_MODEL must be set");
+  }
+
+  const timeoutMs = env.LITELLM_SMOKE_TIMEOUT_MS
+    ? Number.parseInt(env.LITELLM_SMOKE_TIMEOUT_MS, 10)
+    : DEFAULT_TIMEOUT_MS;
+
+  return runAuthSmoke({
+    baseUrl,
+    masterKey,
+    modelId,
+    timeoutMs: Number.isNaN(timeoutMs) || timeoutMs <= 0 ? DEFAULT_TIMEOUT_MS : timeoutMs,
+    enterprise: Boolean(env.LITELLM_LICENSE?.trim()),
+  });
+}
+
+async function main(): Promise<void> {
+  const result = await runAuthSmokeFromEnv();
+  console.log(`Enterprise auth smoke: ${result.enterprise ? "enabled" : "skipped"}`);
+  for (const check of result.checks) {
+    console.log(`Auth smoke OK: ${check}`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -21,6 +21,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("Wait for VidaiMock");
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
     expect(workflow).toContain("LITELLM_LICENSE: $" + "{{ secrets.LITELLM_LICENSE }}");
+    expect(workflow).toContain("LITELLM_DATABASE_URL: postgresql://litellm:litellm@host.docker.internal:5432/litellm");
     expect(workflow).toContain("LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude");
     expect(workflow).toContain("LITELLM_SMOKE_EXPECT_SOURCE: model_info");
     expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL: vidaimock-openai");
@@ -32,6 +33,11 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("api_base: http://host.docker.internal:8100");
     expect(workflow).toContain("--add-host=host.docker.internal:host-gateway");
     expect(workflow).toContain("-e LITELLM_LICENSE");
+    expect(workflow).toContain("Start LiteLLM smoke database");
+    expect(workflow).toContain("postgres:16-alpine");
+    expect(workflow).toContain('admin_only_routes: ["/key/generate"]');
+    expect(workflow).toContain("Run auth smoke");
+    expect(workflow).toContain("npx tsx scripts/smoke-auth.ts");
     expect(workflow.match(/curl -fsS --connect-timeout 1 --max-time 3/g)).toHaveLength(2);
     expect(workflow).toContain("Run Pi CLI smoke");
     expect(workflow).toContain("./node_modules/.bin/pi -e ./dist/index.js --list-models litellm");
@@ -66,6 +72,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(readme).toContain("does not call real LLM APIs");
     expect(readme).toContain("No provider API keys or GitHub Models permission are required");
     expect(readme).toContain("OpenAI-compatible and Anthropic routes");
+    expect(readme).toContain("optional Postgres-backed auth checks when `LITELLM_LICENSE` is configured");
     expect(readme).toContain("non-interactive Pi CLI smoke");
     expect(readme).not.toContain("Kimi-shaped routes");
 

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -20,6 +20,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("Start VidaiMock");
     expect(workflow).toContain("Wait for VidaiMock");
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
+    expect(workflow).toContain("LITELLM_LICENSE: $" + "{{ secrets.LITELLM_LICENSE }}");
     expect(workflow).toContain("LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude");
     expect(workflow).toContain("LITELLM_SMOKE_EXPECT_SOURCE: model_info");
     expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL: vidaimock-openai");
@@ -30,6 +31,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("api_base: http://host.docker.internal:8100/v1");
     expect(workflow).toContain("api_base: http://host.docker.internal:8100");
     expect(workflow).toContain("--add-host=host.docker.internal:host-gateway");
+    expect(workflow).toContain("-e LITELLM_LICENSE");
     expect(workflow.match(/curl -fsS --connect-timeout 1 --max-time 3/g)).toHaveLength(2);
     expect(workflow).toContain("Run Pi CLI smoke");
     expect(workflow).toContain("./node_modules/.bin/pi -e ./dist/index.js --list-models litellm");

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -22,6 +22,8 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
     expect(workflow).toContain("LITELLM_LICENSE: $" + "{{ secrets.LITELLM_LICENSE }}");
     expect(workflow).toContain("LITELLM_DATABASE_URL: postgresql://litellm:litellm@host.docker.internal:5432/litellm");
+    expect(workflow).toContain("docker.litellm.ai/berriai/litellm-database:main-latest");
+    expect(workflow).toContain("docker.litellm.ai/berriai/litellm:main-latest");
     expect(workflow).toContain("LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude");
     expect(workflow).toContain("LITELLM_SMOKE_EXPECT_SOURCE: model_info");
     expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL: vidaimock-openai");

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runAuthSmoke, runAuthSmokeFromEnv } from "../scripts/smoke-auth.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("runAuthSmoke", () => {
+  it("checks missing, bad, and master-key auth without enterprise checks", async () => {
+    const requests: Array<{ url: string; body?: unknown; auth?: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      const auth = headers?.Authorization;
+      requests.push({
+        url,
+        auth,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+
+      if (url.endsWith("/v1/models")) {
+        if (!auth) return jsonResponse(401, { error: "missing token" });
+        if (auth === "Bearer bad-smoke-key") return jsonResponse(403, { error: "bad token" });
+        return jsonResponse(200, { data: [{ id: "vidaimock-openai" }] });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await runAuthSmoke({
+      baseUrl: "http://127.0.0.1:4000/v1",
+      masterKey: "sk-master",
+      modelId: "vidaimock-openai",
+      timeoutMs: 1000,
+      enterprise: false,
+    });
+
+    expect(result).toEqual({
+      enterprise: false,
+      checks: ["missing-token", "bad-token", "master-key-models", "master-key-chat"],
+    });
+    expect(requests.map((request) => request.url)).toEqual([
+      "http://127.0.0.1:4000/v1/models",
+      "http://127.0.0.1:4000/v1/models",
+      "http://127.0.0.1:4000/v1/models",
+      "http://127.0.0.1:4000/v1/chat/completions",
+    ]);
+  });
+
+  it("checks virtual-key auth and enterprise admin-route enforcement", async () => {
+    const requests: Array<{ url: string; body?: unknown; auth?: string }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      const auth = headers?.Authorization;
+      requests.push({
+        url,
+        auth,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+
+      if (url.endsWith("/v1/models")) {
+        if (!auth) return jsonResponse(401, { error: "missing token" });
+        if (auth === "Bearer bad-smoke-key") return jsonResponse(403, { error: "bad token" });
+        return jsonResponse(200, { data: [{ id: "vidaimock-openai" }] });
+      }
+      if (url.endsWith("/key/generate") && auth === "Bearer sk-master") {
+        return jsonResponse(200, { key: "sk-virtual" });
+      }
+      if (url.endsWith("/key/generate") && auth === "Bearer sk-virtual") {
+        return jsonResponse(403, { error: "admin only" });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await runAuthSmoke({
+      baseUrl: "http://127.0.0.1:4000",
+      masterKey: "sk-master",
+      modelId: "vidaimock-openai",
+      timeoutMs: 1000,
+      enterprise: true,
+    });
+
+    expect(result).toEqual({
+      enterprise: true,
+      checks: [
+        "missing-token",
+        "bad-token",
+        "master-key-models",
+        "master-key-chat",
+        "virtual-key-chat",
+        "enterprise-admin-route",
+      ],
+    });
+    expect(requests.filter((request) => request.url.endsWith("/key/generate"))).toMatchObject([
+      {
+        auth: "Bearer sk-master",
+        body: { models: ["vidaimock-openai"], duration: "1h" },
+      },
+      {
+        auth: "Bearer sk-virtual",
+        body: { models: ["vidaimock-openai"], duration: "1h" },
+      },
+    ]);
+  });
+});
+
+describe("runAuthSmokeFromEnv", () => {
+  it("loads auth smoke settings from the environment", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      const auth = headers?.Authorization;
+      if (url.endsWith("/v1/models")) {
+        if (!auth) return jsonResponse(401, { error: "missing token" });
+        if (auth === "Bearer bad-smoke-key") return jsonResponse(403, { error: "bad token" });
+        return jsonResponse(200, { data: [{ id: "vidaimock-openai" }] });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await runAuthSmokeFromEnv({
+      LITELLM_BASE_URL: " http://127.0.0.1:4000/v1 ",
+      LITELLM_API_KEY: " sk-master ",
+      LITELLM_CLI_SMOKE_MODEL: " vidaimock-openai ",
+      LITELLM_SMOKE_TIMEOUT_MS: "1000",
+    });
+
+    expect(result.enterprise).toBe(false);
+    expect(result.checks).toContain("master-key-chat");
+  });
+});

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runAuthSmoke, runAuthSmokeFromEnv } from "../scripts/smoke-auth.js";
 
@@ -10,6 +13,7 @@ function jsonResponse(status: number, body: unknown): Response {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.resetModules();
 });
 
 describe("runAuthSmoke", () => {
@@ -56,7 +60,7 @@ describe("runAuthSmoke", () => {
     ]);
   });
 
-  it("checks virtual-key auth and enterprise admin-route enforcement", async () => {
+  it("checks virtual-key auth, enterprise admin-route enforcement, and SSO login", async () => {
     const requests: Array<{ url: string; body?: unknown; auth?: string }> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
@@ -78,6 +82,9 @@ describe("runAuthSmoke", () => {
       }
       if (url.endsWith("/key/generate") && auth === "Bearer sk-virtual") {
         return jsonResponse(403, { error: "admin only" });
+      }
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, { data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }] });
       }
       if (url.endsWith("/v1/chat/completions")) {
         return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
@@ -102,18 +109,83 @@ describe("runAuthSmoke", () => {
         "master-key-chat",
         "virtual-key-chat",
         "enterprise-admin-route",
+        "sso-login",
+        "sso-virtual-key-chat",
       ],
     });
-    expect(requests.filter((request) => request.url.endsWith("/key/generate"))).toMatchObject([
-      {
+    expect(requests.filter((request) => request.url.endsWith("/key/generate"))).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          auth: "Bearer sk-master",
+          body: { models: ["vidaimock-openai"], duration: "1h" },
+        }),
+        expect.objectContaining({
+          auth: "Bearer sk-virtual",
+          body: { models: ["vidaimock-openai"], duration: "1h" },
+        }),
+      ]),
+    );
+  });
+});
+
+describe("runSsoLoginSmoke", () => {
+  it("drives the extension SSO login callback path and validates the generated key", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-litellm-smoke-auth-"));
+    const requests: Array<{ url: string; body?: unknown; auth?: string }> = [];
+
+    vi.doMock("@earendil-works/pi-coding-agent", () => ({
+      AuthStorage: {
+        create: () => ({ getApiKey: async () => undefined }),
+      },
+      defineTool: (tool: unknown) => tool,
+      getAgentDir: () => agentDir,
+    }));
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const headers = init?.headers as Record<string, string> | undefined;
+      const auth = headers?.Authorization;
+      requests.push({
+        url,
+        auth,
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, { data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }] });
+      }
+      if (url.endsWith("/key/generate")) {
+        expect(auth).toBe("Bearer sk-master");
+        return jsonResponse(200, { key: "sk-sso-virtual" });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        expect(auth).toBe("Bearer sk-sso-virtual");
+        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const { runSsoLoginSmoke } = await import("../scripts/smoke-auth.js");
+    await runSsoLoginSmoke({
+      baseUrl: "http://127.0.0.1:4000",
+      masterKey: "sk-master",
+      modelId: "vidaimock-openai",
+      timeoutMs: 1000,
+    });
+
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        url: "http://127.0.0.1:4000/key/generate",
         auth: "Bearer sk-master",
-        body: { models: ["vidaimock-openai"], duration: "1h" },
-      },
-      {
-        auth: "Bearer sk-virtual",
-        body: { models: ["vidaimock-openai"], duration: "1h" },
-      },
-    ]);
+        body: {},
+      }),
+    );
+    expect(requests).toContainEqual(
+      expect.objectContaining({
+        url: "http://127.0.0.1:4000/v1/chat/completions",
+        auth: "Bearer sk-sso-virtual",
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- pass the LiteLLM Enterprise trial license into the smoke proxy through the `LITELLM_LICENSE` Actions secret
- add auth smoke coverage for missing token, bad token, master-key chat, virtual-key chat, and admin-only route enforcement
- mock the provider's Enterprise SSO login callback path and verify the generated virtual key can complete chat

## Why

The smoke workflow previously covered model discovery and chat routing through VidaiMock, but it did not exercise LiteLLM auth behavior or the provider's SSO login flow. This adds coverage without calling real model providers or standing up a full browser IdP.

## Validation

- `npm run check`