### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are provided for the latest published npm package and the current
+`main` branch. Older versions should be upgraded to the latest release.
+
+## Reporting a Vulnerability
+
+Please report suspected vulnerabilities privately through GitHub:
+
+https://github.com/balcsida/pi-provider-litellm/security/advisories/new
+
+If you cannot use GitHub private vulnerability reporting, email
+balcsida@gmail.com.
+
+Include enough detail to reproduce or understand the issue, such as affected
+versions, configuration, impact, and a proof of concept if you have one. Do not
+include real API keys, credentials, or other secrets.
+
+Please do not disclose the issue publicly until it has been reviewed and a fix
+or mitigation is available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,6 @@ Please report suspected vulnerabilities privately through GitHub:
 
 https://github.com/balcsida/pi-provider-litellm/security/advisories/new
 
-If you cannot use GitHub private vulnerability reporting, email
-balcsida@gmail.com.
-
 Include enough detail to reproduce or understand the issue, such as affected
 versions, configuration, impact, and a proof of concept if you have one. Do not
 include real API keys, credentials, or other secrets.


### PR DESCRIPTION
## Summary
- Add a root SECURITY.md that points vulnerability reports to GitHub private advisories.
- Keep the policy limited to the latest npm release and main branch.

## Issue
Closes #64.

## Validation
- npm run check
- npm pack --dry-run
