### PR TITLE
feat: Support LiteLLM model overrides

### DIFF
--- a/docs/superpowers/specs/2026-07-05-smoke-on-pr-design.md
+++ b/docs/superpowers/specs/2026-07-05-smoke-on-pr-design.md
@@ -1,0 +1,55 @@
+# Run LiteLLM smoke workflow on pull requests
+
+**Date:** 2026-07-05
+**Status:** Approved
+
+## Problem
+
+The `LiteLLM Smoke` workflow (`.github/workflows/litellm-smoke.yml`) only runs
+on pushes to `main`, a weekly cron, and manual dispatch. Regressions in the
+smoke-covered integration path (LiteLLM proxy discovery, OpenAI-compatible and
+Anthropic routes, Pi CLI loading) are only caught after merge.
+
+## Goal
+
+Run the smoke suite on pull requests as well, so PR updates get the same
+integration coverage before merge.
+
+## Design
+
+1. **Trigger** — add a `pull_request:` trigger to `litellm-smoke.yml` with the
+   same `paths:` filter as the existing `push:` trigger
+   (`.github/workflows/litellm-smoke.yml`, `package-lock.json`, `package.json`,
+   `scripts/smoke*.ts`, `src/**`, `tests/**`). Docs-only PRs skip the run.
+   Fork PRs work: the workflow uses no repository secrets (VidaiMock upstream,
+   dummy master key) and already has `permissions: contents: read`.
+
+2. **Concurrency** — add a workflow-level `concurrency` block:
+
+   ```yaml
+   concurrency:
+     group: ${{ github.workflow }}-${{ github.ref }}
+     cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+   ```
+
+   Rapid pushes to a PR cancel the superseded smoke run instead of stacking
+   20-minute jobs. Runs for `main`, cron, and dispatch are never cancelled.
+
+3. **Guard test** — extend `tests/litellm-smoke-workflow.test.ts` to assert the
+   workflow declares a `pull_request` trigger with a `paths` filter and the
+   concurrency block. Written before the workflow change (TDD).
+
+4. **README** — add one sentence to the "Mocked LiteLLM smoke workflow"
+   section stating the workflow also runs on pull requests that touch the
+   relevant paths.
+
+## Out of scope
+
+- Running the smoke suite against every individual commit of a PR.
+- Restructuring the workflow as a reusable `workflow_call` from `ci.yml`.
+- Any change to the smoke runner or its assertions.
+
+## Success criteria
+
+- `npm test` passes, including the new guard-test assertions.
+- After push, the `LiteLLM Smoke` workflow appears as a check on the PR.

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,14 +57,29 @@ function getCachePath(): string {
   return join(getAgentDir(), CACHE_FILENAME);
 }
 
+// Same tolerance as pi core's models.json loader (stripJsonComments in dist/utils/json.js):
+// strip `//` line comments and trailing commas, leaving string literals untouched.
+function stripJsonComments(input: string): string {
+  return input
+    .replace(/"(?:\\.|[^"\\])*"|\/\/[^\n]*/g, (m) => (m[0] === '"' ? m : ""))
+    .replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (m, tail: string | undefined) => tail ?? m);
+}
+
 async function readModelOverrides(): Promise<Map<string, ModelOverride>> {
+  let raw: string;
   try {
-    const raw = await readFile(join(getAgentDir(), "models.json"), "utf8");
-    const config = JSON.parse(raw) as {
+    raw = await readFile(join(getAgentDir(), "models.json"), "utf8");
+  } catch {
+    return new Map();
+  }
+  try {
+    const config = JSON.parse(stripJsonComments(raw)) as {
       providers?: Record<string, { modelOverrides?: Record<string, ModelOverride> }>;
     };
     return new Map(Object.entries(config.providers?.[PROVIDER_NAME]?.modelOverrides ?? {}));
-  } catch {
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`LiteLLM: ignoring model overrides (failed to parse models.json: ${message}).\n`);
     return new Map();
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,44 @@ function stripJsonComments(input: string): string {
     .replace(/"(?:\\.|[^"\\])*"|,(\s*[}\]])/g, (m, tail: string | undefined) => tail ?? m);
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// Mirrors pi core's ModelOverrideSchema: core rejects the whole models.json on invalid values,
+// so anything dropped here would also have been flagged for built-in providers.
+const MODEL_OVERRIDE_VALIDATORS: Record<keyof ModelOverride, (value: unknown) => boolean> = {
+  name: (value) => typeof value === "string",
+  reasoning: (value) => typeof value === "boolean",
+  thinkingLevelMap: isPlainObject,
+  input: Array.isArray,
+  contextWindow: (value) => typeof value === "number",
+  maxTokens: (value) => typeof value === "number",
+  headers: isPlainObject,
+  compat: isPlainObject,
+  cost: (value) => isPlainObject(value) && Object.values(value).every((entry) => typeof entry === "number"),
+};
+
+function sanitizeModelOverride(modelId: string, raw: unknown): ModelOverride | undefined {
+  if (!isPlainObject(raw)) {
+    process.stderr.write(`LiteLLM: ignoring model override for ${modelId} in models.json (not an object).\n`);
+    return undefined;
+  }
+  const override: Record<string, unknown> = {};
+  const dropped: string[] = [];
+  for (const [key, value] of Object.entries(raw)) {
+    const isValid = MODEL_OVERRIDE_VALIDATORS[key as keyof ModelOverride];
+    if (isValid?.(value)) override[key] = value;
+    else dropped.push(key);
+  }
+  if (dropped.length > 0) {
+    process.stderr.write(
+      `LiteLLM: ignoring invalid model override field(s) for ${modelId} in models.json: ${dropped.join(", ")}.\n`,
+    );
+  }
+  return override as ModelOverride;
+}
+
 async function readModelOverrides(): Promise<Map<string, ModelOverride>> {
   let raw: string;
   try {
@@ -74,9 +112,14 @@ async function readModelOverrides(): Promise<Map<string, ModelOverride>> {
   }
   try {
     const config = JSON.parse(stripJsonComments(raw)) as {
-      providers?: Record<string, { modelOverrides?: Record<string, ModelOverride> }>;
+      providers?: Record<string, { modelOverrides?: Record<string, unknown> }>;
     };
-    return new Map(Object.entries(config.providers?.[PROVIDER_NAME]?.modelOverrides ?? {}));
+    const overrides = new Map<string, ModelOverride>();
+    for (const [id, rawOverride] of Object.entries(config.providers?.[PROVIDER_NAME]?.modelOverrides ?? {})) {
+      const override = sanitizeModelOverride(id, rawOverride);
+      if (override) overrides.set(id, override);
+    }
+    return overrides;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`LiteLLM: ignoring model overrides (failed to parse models.json: ${message}).\n`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,16 +69,20 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+
 // Mirrors pi core's ModelOverrideSchema: core rejects the whole models.json on invalid values,
-// so anything dropped here would also have been flagged for built-in providers.
+// so anything dropped here would also have been flagged for built-in providers. Headers matter
+// most: pi resolves each header value as a config string, so non-strings break requests.
 const MODEL_OVERRIDE_VALIDATORS: Record<keyof ModelOverride, (value: unknown) => boolean> = {
   name: (value) => typeof value === "string",
   reasoning: (value) => typeof value === "boolean",
-  thinkingLevelMap: isPlainObject,
-  input: Array.isArray,
+  thinkingLevelMap: (value) =>
+    isPlainObject(value) && THINKING_LEVELS.every((level) => value[level] == null || typeof value[level] === "string"),
+  input: (value) => Array.isArray(value) && value.every((entry) => entry === "text" || entry === "image"),
   contextWindow: (value) => typeof value === "number",
   maxTokens: (value) => typeof value === "number",
-  headers: isPlainObject,
+  headers: (value) => isPlainObject(value) && Object.values(value).every((entry) => typeof entry === "string"),
   compat: isPlainObject,
   cost: (value) => isPlainObject(value) && Object.values(value).every((entry) => typeof entry === "number"),
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,15 @@ const TOKEN_REFRESH_LEAD_MS = 5 * 60 * 1000;
 const PERMANENT_TOKEN_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
 const EXPIRE_TOKEN_IMMEDIATELY = 0;
 
+type ModelOverride = Partial<
+  Pick<
+    ProviderModelConfig,
+    "name" | "reasoning" | "thinkingLevelMap" | "input" | "contextWindow" | "maxTokens" | "headers" | "compat"
+  >
+> & {
+  cost?: Partial<ProviderModelConfig["cost"]>;
+};
+
 type RefreshResult = { models: ProviderModelConfig[]; source: string };
 
 function getAuthPath(): string {
@@ -46,6 +55,43 @@ function getAuthPath(): string {
 
 function getCachePath(): string {
   return join(getAgentDir(), CACHE_FILENAME);
+}
+
+async function readModelOverrides(): Promise<Map<string, ModelOverride>> {
+  try {
+    const raw = await readFile(join(getAgentDir(), "models.json"), "utf8");
+    const config = JSON.parse(raw) as {
+      providers?: Record<string, { modelOverrides?: Record<string, ModelOverride> }>;
+    };
+    return new Map(Object.entries(config.providers?.[PROVIDER_NAME]?.modelOverrides ?? {}));
+  } catch {
+    return new Map();
+  }
+}
+
+function applyModelOverride(model: ProviderModelConfig, override: ModelOverride): ProviderModelConfig {
+  const next = { ...model };
+  if (override.name !== undefined) next.name = override.name;
+  if (override.reasoning !== undefined) next.reasoning = override.reasoning;
+  if (override.thinkingLevelMap !== undefined) next.thinkingLevelMap = override.thinkingLevelMap;
+  if (override.input !== undefined) next.input = override.input;
+  if (override.contextWindow !== undefined) next.contextWindow = override.contextWindow;
+  if (override.maxTokens !== undefined) next.maxTokens = override.maxTokens;
+  if (override.headers !== undefined) next.headers = override.headers;
+  if (override.compat !== undefined) next.compat = { ...model.compat, ...override.compat };
+  if (override.cost !== undefined) next.cost = { ...model.cost, ...override.cost };
+  return next;
+}
+
+function applyModelOverrides(
+  models: ProviderModelConfig[],
+  overrides: Map<string, ModelOverride>,
+): ProviderModelConfig[] {
+  if (overrides.size === 0) return models;
+  return models.map((model) => {
+    const override = overrides.get(model.id);
+    return override ? applyModelOverride(model, override) : model;
+  });
 }
 
 async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
@@ -467,6 +513,7 @@ function normalizeThinkTags(message: AssistantMessage): AssistantMessage | undef
 
 export default async function (pi: ExtensionAPI): Promise<void> {
   let creds = await resolveCredentials({ executeHelpers: false });
+  const modelOverrides = await readModelOverrides();
   const cache = await readCache(getCachePath());
   let fp = creds.apiKeyFingerprint;
   let cacheFetchedAt = cache?.fetchedAt ?? 0;
@@ -539,7 +586,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       loginLiteLLM(callbacks, (next) => {
         cacheFetchedAt = next.fetchedAt;
         registerProvider(next.baseUrl, next.models);
-        updateCosts(next.models);
+        updateCosts(applyModelOverrides(next.models, modelOverrides));
       }),
     refreshToken: refreshLiteLLM,
     getApiKey: getLiteLLMApiKey,
@@ -551,6 +598,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     models: ProviderModelConfig[],
     apiKeyConfig = creds.apiKeyConfig ?? getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`,
   ): void {
+    const registeredModels = applyModelOverrides(models, modelOverrides);
     pi.registerProvider(PROVIDER_NAME, {
       baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
       // When LITELLM_API_KEY_HELPER is set we register the helper as a `!command` provider key.
@@ -562,14 +610,14 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       // "re-runs the helper command on every request" in tests/index.test.ts.
       apiKey: apiKeyConfig,
       api: "openai-completions",
-      models,
+      models: registeredModels,
       oauth,
     });
   }
 
   registerProvider(creds.baseUrl, models);
 
-  updateCosts = setupLiteLLMCostTracking(pi, models);
+  updateCosts = setupLiteLLMCostTracking(pi, applyModelOverrides(models, modelOverrides));
 
   let refreshInProgress: Promise<RefreshResult> | null = null;
 
@@ -637,7 +685,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       models: result.models,
     });
     registerProvider(fresh.baseUrl, result.models, fresh.apiKeyConfig);
-    updateCosts(result.models);
+    updateCosts(applyModelOverrides(result.models, modelOverrides));
     cacheFetchedAt = now;
     await registerMcpTools(fresh.baseUrl, fresh.apiKey);
     return { models: result.models, source: result.source };
@@ -672,7 +720,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       (next) => {
         cacheFetchedAt = next.fetchedAt;
         registerProvider(next.baseUrl, next.models);
-        updateCosts(next.models);
+        updateCosts(applyModelOverrides(next.models, modelOverrides));
       },
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,6 +172,12 @@ function applyModelOverrides(
   });
 }
 
+// Re-reads models.json on every call so overrides edited mid-session take effect on the next
+// refresh or login, matching pi core's live reload for built-in providers.
+async function applyOverrides(models: ProviderModelConfig[]): Promise<ProviderModelConfig[]> {
+  return applyModelOverrides(models, await readModelOverrides());
+}
+
 async function readAuthEntry(): Promise<AuthFileEntry | undefined> {
   try {
     const raw = await readFile(getAuthPath(), "utf8");
@@ -355,7 +361,7 @@ async function discoverWithFallback(
 
 async function loginLiteLLM(
   callbacks: OAuthLoginCallbacks,
-  onCacheWrite?: (cache: CacheFile) => void,
+  onCacheWrite?: (cache: CacheFile) => void | Promise<void>,
 ): Promise<OAuthCredentials> {
   const rawBaseUrl = (
     await callbacks.onPrompt({
@@ -437,7 +443,7 @@ async function loginLiteLLM(
     models,
   };
   await writeCache(getCachePath(), cache);
-  onCacheWrite?.(cache);
+  await onCacheWrite?.(cache);
   callbacks.onProgress?.(`LiteLLM: ${models.length} models discovered (source: ${source})`);
 
   return {
@@ -591,7 +597,6 @@ function normalizeThinkTags(message: AssistantMessage): AssistantMessage | undef
 
 export default async function (pi: ExtensionAPI): Promise<void> {
   let creds = await resolveCredentials({ executeHelpers: false });
-  const modelOverrides = await readModelOverrides();
   const cache = await readCache(getCachePath());
   let fp = creds.apiKeyFingerprint;
   let cacheFetchedAt = cache?.fetchedAt ?? 0;
@@ -656,15 +661,19 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     }
   }
 
+  // The cache keeps raw discovery output; overrides are applied freshly at each registration.
+  models = await applyOverrides(models);
+
   let updateCosts: (models: ProviderModelConfig[]) => void = () => undefined;
 
   const oauth = {
     name: "LiteLLM",
     login: (callbacks: OAuthLoginCallbacks) =>
-      loginLiteLLM(callbacks, (next) => {
+      loginLiteLLM(callbacks, async (next) => {
         cacheFetchedAt = next.fetchedAt;
-        registerProvider(next.baseUrl, next.models);
-        updateCosts(applyModelOverrides(next.models, modelOverrides));
+        const overridden = await applyOverrides(next.models);
+        registerProvider(next.baseUrl, overridden);
+        updateCosts(overridden);
       }),
     refreshToken: refreshLiteLLM,
     getApiKey: getLiteLLMApiKey,
@@ -676,7 +685,6 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     models: ProviderModelConfig[],
     apiKeyConfig = creds.apiKeyConfig ?? getApiKeyHelperCommand() ?? `$${ENV_API_KEY}`,
   ): void {
-    const registeredModels = applyModelOverrides(models, modelOverrides);
     pi.registerProvider(PROVIDER_NAME, {
       baseUrl: baseUrl ? `${baseUrl}/v1` : "https://litellm.example.com/v1",
       // When LITELLM_API_KEY_HELPER is set we register the helper as a `!command` provider key.
@@ -688,14 +696,14 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       // "re-runs the helper command on every request" in tests/index.test.ts.
       apiKey: apiKeyConfig,
       api: "openai-completions",
-      models: registeredModels,
+      models,
       oauth,
     });
   }
 
   registerProvider(creds.baseUrl, models);
 
-  updateCosts = setupLiteLLMCostTracking(pi, applyModelOverrides(models, modelOverrides));
+  updateCosts = setupLiteLLMCostTracking(pi, models);
 
   let refreshInProgress: Promise<RefreshResult> | null = null;
 
@@ -762,11 +770,12 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       source: result.source,
       models: result.models,
     });
-    registerProvider(fresh.baseUrl, result.models, fresh.apiKeyConfig);
-    updateCosts(applyModelOverrides(result.models, modelOverrides));
+    const overridden = await applyOverrides(result.models);
+    registerProvider(fresh.baseUrl, overridden, fresh.apiKeyConfig);
+    updateCosts(overridden);
     cacheFetchedAt = now;
     await registerMcpTools(fresh.baseUrl, fresh.apiKey);
-    return { models: result.models, source: result.source };
+    return { models: overridden, source: result.source };
   }
 
   function runRefresh(): Promise<RefreshResult> {
@@ -795,10 +804,11 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         onSelect: async () => undefined,
         signal: ctx.signal,
       },
-      (next) => {
+      async (next) => {
         cacheFetchedAt = next.fetchedAt;
-        registerProvider(next.baseUrl, next.models);
-        updateCosts(applyModelOverrides(next.models, modelOverrides));
+        const overridden = await applyOverrides(next.models);
+        registerProvider(next.baseUrl, overridden);
+        updateCosts(overridden);
       },
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,16 +69,36 @@ async function readModelOverrides(): Promise<Map<string, ModelOverride>> {
   }
 }
 
+// Merge semantics must match pi core's applyModelOverride/mergeCompat (dist/core/model-registry.js)
+// so the same models.json entry behaves identically for litellm and built-in providers.
+function mergeCompat(
+  base: ProviderModelConfig["compat"],
+  override: ProviderModelConfig["compat"],
+): ProviderModelConfig["compat"] {
+  if (!override) return base;
+  const merged = { ...base, ...override } as Record<string, unknown>;
+  for (const key of ["openRouterRouting", "vercelGatewayRouting", "chatTemplateKwargs"]) {
+    const baseValue = (base as Record<string, unknown> | undefined)?.[key];
+    const overrideValue = (override as Record<string, unknown>)[key];
+    if (baseValue || overrideValue) {
+      merged[key] = { ...(baseValue as object | undefined), ...(overrideValue as object | undefined) };
+    }
+  }
+  return merged as ProviderModelConfig["compat"];
+}
+
 function applyModelOverride(model: ProviderModelConfig, override: ModelOverride): ProviderModelConfig {
   const next = { ...model };
   if (override.name !== undefined) next.name = override.name;
   if (override.reasoning !== undefined) next.reasoning = override.reasoning;
-  if (override.thinkingLevelMap !== undefined) next.thinkingLevelMap = override.thinkingLevelMap;
+  if (override.thinkingLevelMap !== undefined) {
+    next.thinkingLevelMap = { ...model.thinkingLevelMap, ...override.thinkingLevelMap };
+  }
   if (override.input !== undefined) next.input = override.input;
   if (override.contextWindow !== undefined) next.contextWindow = override.contextWindow;
   if (override.maxTokens !== undefined) next.maxTokens = override.maxTokens;
   if (override.headers !== undefined) next.headers = override.headers;
-  if (override.compat !== undefined) next.compat = { ...model.compat, ...override.compat };
+  if (override.compat !== undefined) next.compat = mergeCompat(model.compat, override.compat);
   if (override.cost !== undefined) next.cost = { ...model.cost, ...override.cost };
   return next;
 }

--- a/tests/gcloud-token.test.ts
+++ b/tests/gcloud-token.test.ts
@@ -109,8 +109,8 @@ describe("getGcloudToken", () => {
 
   it("returns null and warns when no ADC file exists", async () => {
     delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
-    delete process.env.HOME;
     delete process.env.APPDATA;
+    process.env.HOME = await mkdtemp(join(tmpdir(), "pi-litellm-no-adc-"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     await expect(getGcloudToken()).resolves.toBeNull();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -418,6 +418,55 @@ describe("extension startup", () => {
     ]);
   });
 
+  it("applies overrides from models.json with comments and trailing commas", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath);
+    await writeFile(
+      join(agentDir, "models.json"),
+      `{
+  // raise the context window
+  "providers": {
+    "litellm": {
+      "modelOverrides": {
+        "cached-model": { "contextWindow": 272000, },
+      },
+    },
+  },
+}`,
+      "utf8",
+    );
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({ id: "cached-model", contextWindow: 272_000 }),
+    ]);
+  });
+
+  it("warns and ignores overrides when models.json is malformed", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath);
+    await writeFile(join(agentDir, "models.json"), "{ not json", "utf8");
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([expect.objectContaining({ id: "cached-model" })]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("models.json"));
+  });
+
   it("discovers with the resolved stored auth key before LITELLM_API_KEY", async () => {
     const agentDir = await makeAgentDir();
     await writeFile(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -467,6 +467,28 @@ describe("extension startup", () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("models.json"));
   });
 
+  it("warns and drops override fields with invalid types", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath, [
+      { id: "cached-model", name: "cached-model", provider: "litellm", contextWindow: 128_000 },
+    ]);
+    await writeModelsConfig(agentDir, { "cached-model": { contextWindow: "272000", maxTokens: 64_000 } });
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({ id: "cached-model", contextWindow: 128_000, maxTokens: 64_000 }),
+    ]);
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("contextWindow"));
+  });
+
   it("discovers with the resolved stored auth key before LITELLM_API_KEY", async () => {
     const agentDir = await makeAgentDir();
     await writeFile(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -121,6 +121,14 @@ async function readHelperCount(agentDir: string): Promise<number> {
 
 const cachedModels = [{ id: "cached-model", name: "cached-model", provider: "litellm" }];
 
+async function writeModelsConfig(agentDir: string, modelOverrides: Record<string, unknown>): Promise<void> {
+  await writeFile(
+    join(agentDir, "models.json"),
+    JSON.stringify({ providers: { litellm: { modelOverrides } } }),
+    "utf8",
+  );
+}
+
 async function writeModelCache(agentDir: string, helperPath: string): Promise<void> {
   await writeFile(
     join(agentDir, "litellm-models.json"),
@@ -305,6 +313,56 @@ describe("extension startup", () => {
     await extension(pi);
 
     expect(pi.providers[0]?.config.baseUrl).toBe("https://litellm.example.com/v1");
+  });
+
+  it("applies models.json overrides to discovered models", async () => {
+    const agentDir = await makeAgentDir();
+    await writeModelsConfig(agentDir, {
+      "llm-gateway/gpt-5.5": { contextWindow: 272_000, maxTokens: 64_000 },
+    });
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "llm-gateway/gpt-5.5",
+              model_info: { mode: "chat", max_input_tokens: 128_000, max_output_tokens: 16_384 },
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({ id: "llm-gateway/gpt-5.5", contextWindow: 272_000, maxTokens: 64_000 }),
+    ]);
+  });
+
+  it("applies models.json overrides to cached models", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath);
+    await writeModelsConfig(agentDir, { "cached-model": { contextWindow: 272_000 } });
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({ id: "cached-model", contextWindow: 272_000 }),
+    ]);
   });
 
   it("discovers with the resolved stored auth key before LITELLM_API_KEY", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -489,6 +489,37 @@ describe("extension startup", () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("contextWindow"));
   });
 
+  it("drops override fields whose values violate the core schema", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath, [
+      { id: "cached-model", name: "cached-model", provider: "litellm", contextWindow: 128_000 },
+    ]);
+    await writeModelsConfig(agentDir, {
+      "cached-model": {
+        headers: { "X-Team": "core", "X-Retries": 3 },
+        thinkingLevelMap: { low: 42 },
+        input: ["text", "audio"],
+        maxTokens: 64_000,
+      },
+    });
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const model = pi.providers[0]?.config.models?.[0] as Record<string, unknown>;
+    expect(model).toEqual(expect.objectContaining({ id: "cached-model", maxTokens: 64_000 }));
+    expect(model.headers).toBeUndefined();
+    expect(model.thinkingLevelMap).toBeUndefined();
+    expect(model.input).toBeUndefined();
+    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("headers, thinkingLevelMap, input"));
+  });
+
   it("applies models.json overrides written after startup on refresh", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -489,6 +489,42 @@ describe("extension startup", () => {
     expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("contextWindow"));
   });
 
+  it("applies models.json overrides written after startup on refresh", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "llm-gateway/gpt-5.5",
+              model_info: { mode: "chat", max_input_tokens: 128_000, max_output_tokens: 16_384 },
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({ id: "llm-gateway/gpt-5.5", contextWindow: 128_000 }),
+    ]);
+
+    await writeModelsConfig(agentDir, { "llm-gateway/gpt-5.5": { contextWindow: 272_000 } });
+    const notify = vi.fn();
+    await pi.commands.get("litellm-refresh")?.handler("", { ui: { notify } });
+
+    expect(pi.providers.at(-1)?.config.models).toEqual([
+      expect.objectContaining({ id: "llm-gateway/gpt-5.5", contextWindow: 272_000 }),
+    ]);
+  });
+
   it("discovers with the resolved stored auth key before LITELLM_API_KEY", async () => {
     const agentDir = await makeAgentDir();
     await writeFile(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -129,7 +129,7 @@ async function writeModelsConfig(agentDir: string, modelOverrides: Record<string
   );
 }
 
-async function writeModelCache(agentDir: string, helperPath: string): Promise<void> {
+async function writeModelCache(agentDir: string, helperPath: string, models: unknown[] = cachedModels): Promise<void> {
   await writeFile(
     join(agentDir, "litellm-models.json"),
     JSON.stringify({
@@ -137,7 +137,7 @@ async function writeModelCache(agentDir: string, helperPath: string): Promise<vo
       apiKeyFingerprint: fingerprint(`!${helperPath}`),
       fetchedAt: Date.now(),
       source: "model_info",
-      models: cachedModels,
+      models,
     }),
     "utf8",
   );
@@ -362,6 +362,59 @@ describe("extension startup", () => {
 
     expect(pi.providers[0]?.config.models).toEqual([
       expect.objectContaining({ id: "cached-model", contextWindow: 272_000 }),
+    ]);
+  });
+
+  it("merges partial thinkingLevelMap overrides with existing mappings", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath, [
+      {
+        id: "cached-model",
+        name: "cached-model",
+        provider: "litellm",
+        thinkingLevelMap: { low: "low", high: "high" },
+      },
+    ]);
+    await writeModelsConfig(agentDir, { "cached-model": { thinkingLevelMap: { high: "xhigh" } } });
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({ id: "cached-model", thinkingLevelMap: { low: "low", high: "xhigh" } }),
+    ]);
+  });
+
+  it("deep-merges nested compat overrides", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, [makeJwt(Math.floor(Date.now() / 1000) + 3600)]);
+    await writeModelCache(agentDir, helperPath, [
+      {
+        id: "cached-model",
+        name: "cached-model",
+        provider: "litellm",
+        compat: { supportsStore: false, chatTemplateKwargs: { enable_thinking: true } },
+      },
+    ]);
+    await writeModelsConfig(agentDir, { "cached-model": { compat: { chatTemplateKwargs: { max_thinking: 4 } } } });
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.providers[0]?.config.models).toEqual([
+      expect.objectContaining({
+        id: "cached-model",
+        compat: { supportsStore: false, chatTemplateKwargs: { enable_thinking: true, max_thinking: 4 } },
+      }),
     ]);
   });
 


### PR DESCRIPTION
Applies local pi model overrides from models.json to LiteLLM-discovered and cached models before provider registration.

This keeps the cache as raw LiteLLM metadata, while allowing local config to correct fields like contextWindow and maxTokens at runtime. Also isolates the no-ADC gcloud token test from the developer machine's real ADC file.

You can set up an override in `~/.pi/agent/models.json` like:


```json
{
  "providers": {
    "litellm": {
      "modelOverrides": {
        "llm-gateway/gpt-5.4": { "contextWindow": 272000 },
        "llm-gateway/gpt-5.4-mini": { "contextWindow": 272000 },
        "llm-gateway/gpt-5.5": { "contextWindow": 272000 }
      }
    }
  }
}
```