### PR TITLE
fix: drop reasoning for gpt-5.5 tool requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .vscode/
 .idea/
 coverage/
+.pi/

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -51,9 +51,17 @@ export function normalizeBaseUrl(input: string): string {
 const ANTHROPIC_MODEL_PATTERN = /(?:^|[-_/.:])(?:anthropic\/|(?:claude|opus|sonnet|haiku)(?=$|[-_/.:]))/i;
 const MOONSHOT_MODEL_PATTERN = /^(moonshotai\/|moonshot\/|kimi[-/])/i;
 const FORCED_THINKING_MODEL_PATTERN = /(?:^|[-/])thinking(?:[-/]|$)/i;
+// Deployments expose the gpt-5.5 route under varying names (`llm-gateway/gpt-5.5`,
+// bare `gpt-5.5`, dated ids like `gpt-5.5-20260504143601`); match them all so the
+// tool+reasoning workaround survives route renames.
+const GPT55_MODEL_PATTERN = /(?:^|\/)gpt-5\.5(?:$|[-.])/i;
 
 export function isMoonshotModel(modelId: string): boolean {
   return MOONSHOT_MODEL_PATTERN.test(modelId);
+}
+
+export function isGpt55Model(modelId: string): boolean {
+  return GPT55_MODEL_PATTERN.test(modelId);
 }
 
 export function shouldSuppressReasoningContent(modelId: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,6 +359,7 @@ function prepareLiteLLMRequestPayload(
   if (modelId === "llm-gateway/gpt-5.5" && Array.isArray(payload.tools) && payload.tools.length > 0) {
     next ??= { ...payload };
     delete next.reasoning;
+    delete next.reasoning_effort;
     delete next.include_reasoning;
     delete next.reasoning_content;
     delete next.merge_reasoning_content_in_choices;

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,22 +361,32 @@ function prepareLiteLLMRequestPayload(
   // LiteLLM still routes gpt-5.5 tool+reasoning requests through chat completions.
   // Drop reasoning until the gateway honors /v1/responses for this route.
   if (modelId && isGpt55Model(modelId) && Array.isArray(payload.tools) && payload.tools.length > 0) {
-    next ??= { ...payload };
-    delete next.reasoning;
-    delete next.reasoning_effort;
-    delete next.include_reasoning;
-    delete next.reasoning_content;
-    delete next.merge_reasoning_content_in_choices;
-    delete next.thinking;
-    if (Array.isArray(next.include)) {
-      const filteredInclude = next.include.filter((value) => value !== "reasoning.encrypted_content");
-      next.include = filteredInclude;
+    const reasoningKeys = [
+      "reasoning",
+      "reasoning_effort",
+      "include_reasoning",
+      "reasoning_content",
+      "merge_reasoning_content_in_choices",
+      "thinking",
+    ];
+    for (const key of reasoningKeys) {
+      if (payload[key] === undefined) continue;
+      next ??= { ...payload };
+      delete next[key];
+    }
+    const include = (next ?? payload).include;
+    if (Array.isArray(include) && include.includes("reasoning.encrypted_content")) {
+      next ??= { ...payload };
+      const filteredInclude = include.filter((value) => value !== "reasoning.encrypted_content");
       if (filteredInclude.length === 0) delete next.include;
+      else next.include = filteredInclude;
     }
     // Prior turns may have replayed reasoning items (with encrypted_content)
     // into the input; they are rejected once reasoning is stripped.
-    if (Array.isArray(next.input)) {
-      next.input = next.input.filter((item) => !isReasoningItem(item));
+    const input = (next ?? payload).input;
+    if (Array.isArray(input) && input.some(isReasoningItem)) {
+      next ??= { ...payload };
+      next.input = input.filter((item) => !isReasoningItem(item));
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,13 @@ import type { ExtensionAPI, ExtensionContext, ProviderModelConfig } from "@earen
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
-import { discoverModels, isGpt55Model, normalizeBaseUrl, shouldSuppressReasoningContent, withTimeout } from "./discover.js";
+import {
+  discoverModels,
+  isGpt55Model,
+  normalizeBaseUrl,
+  shouldSuppressReasoningContent,
+  withTimeout,
+} from "./discover.js";
 import {
   getGcloudToken,
   getGcloudTokenCacheKey,
@@ -339,6 +345,15 @@ function isReasoningItem(item: unknown): boolean {
   return typeof item === "object" && item !== null && (item as { type?: unknown }).type === "reasoning";
 }
 
+// Reasoning fields LiteLLM forwards to chat-completions providers. The Moonshot
+// path defaults them off; the gpt-5.5 tool path strips them entirely.
+const REASONING_SUPPRESSION_DEFAULTS: Record<string, unknown> = {
+  include_reasoning: false,
+  reasoning_content: false,
+  merge_reasoning_content_in_choices: true,
+  thinking: { type: "disabled" },
+};
+
 function prepareLiteLLMRequestPayload(
   payload: Record<string, unknown>,
   modelId: string | undefined,
@@ -352,23 +367,13 @@ function prepareLiteLLMRequestPayload(
   };
 
   if (modelId && shouldSuppressReasoningContent(modelId)) {
-    update("include_reasoning", false);
-    update("reasoning_content", false);
-    update("merge_reasoning_content_in_choices", true);
-    update("thinking", { type: "disabled" });
+    for (const [key, value] of Object.entries(REASONING_SUPPRESSION_DEFAULTS)) update(key, value);
   }
 
   // LiteLLM still routes gpt-5.5 tool+reasoning requests through chat completions.
   // Drop reasoning until the gateway honors /v1/responses for this route.
   if (modelId && isGpt55Model(modelId) && Array.isArray(payload.tools) && payload.tools.length > 0) {
-    const reasoningKeys = [
-      "reasoning",
-      "reasoning_effort",
-      "include_reasoning",
-      "reasoning_content",
-      "merge_reasoning_content_in_choices",
-      "thinking",
-    ];
+    const reasoningKeys = ["reasoning", "reasoning_effort", ...Object.keys(REASONING_SUPPRESSION_DEFAULTS)];
     for (const key of reasoningKeys) {
       if (payload[key] === undefined) continue;
       next ??= { ...payload };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import type { ExtensionAPI, ExtensionContext, ProviderModelConfig } from "@earen
 import { AuthStorage, getAgentDir } from "@earendil-works/pi-coding-agent";
 import { fingerprint, readCache, writeCache } from "./cache.js";
 import { setupLiteLLMCostTracking } from "./cost.js";
-import { discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent, withTimeout } from "./discover.js";
+import { discoverModels, isGpt55Model, normalizeBaseUrl, shouldSuppressReasoningContent, withTimeout } from "./discover.js";
 import {
   getGcloudToken,
   getGcloudTokenCacheKey,
@@ -354,9 +354,9 @@ function prepareLiteLLMRequestPayload(
     update("thinking", { type: "disabled" });
   }
 
-  // ponytail: LiteLLM still routes gpt-5.5 tool+reasoning requests through chat completions.
+  // LiteLLM still routes gpt-5.5 tool+reasoning requests through chat completions.
   // Drop reasoning until the gateway honors /v1/responses for this route.
-  if (modelId === "llm-gateway/gpt-5.5" && Array.isArray(payload.tools) && payload.tools.length > 0) {
+  if (modelId && isGpt55Model(modelId) && Array.isArray(payload.tools) && payload.tools.length > 0) {
     next ??= { ...payload };
     delete next.reasoning;
     delete next.reasoning_effort;

--- a/src/index.ts
+++ b/src/index.ts
@@ -354,6 +354,22 @@ function prepareLiteLLMRequestPayload(
     update("thinking", { type: "disabled" });
   }
 
+  // ponytail: LiteLLM still routes gpt-5.5 tool+reasoning requests through chat completions.
+  // Drop reasoning until the gateway honors /v1/responses for this route.
+  if (modelId === "llm-gateway/gpt-5.5" && Array.isArray(payload.tools) && payload.tools.length > 0) {
+    next ??= { ...payload };
+    delete next.reasoning;
+    delete next.include_reasoning;
+    delete next.reasoning_content;
+    delete next.merge_reasoning_content_in_choices;
+    delete next.thinking;
+    if (Array.isArray(next.include)) {
+      const filteredInclude = next.include.filter((value) => value !== "reasoning.encrypted_content");
+      next.include = filteredInclude;
+      if (filteredInclude.length === 0) delete next.include;
+    }
+  }
+
   if (sessionId) {
     next ??= { ...payload };
     next.litellm_session_id = sessionId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,6 +335,10 @@ function modifyLiteLLMModels(models: Model<Api>[], cred: OAuthCredentials): Mode
   return models.map((m) => (m.provider === PROVIDER_NAME ? { ...m, baseUrl: `${baseUrl}/v1` } : m));
 }
 
+function isReasoningItem(item: unknown): boolean {
+  return typeof item === "object" && item !== null && (item as { type?: unknown }).type === "reasoning";
+}
+
 function prepareLiteLLMRequestPayload(
   payload: Record<string, unknown>,
   modelId: string | undefined,
@@ -368,6 +372,11 @@ function prepareLiteLLMRequestPayload(
       const filteredInclude = next.include.filter((value) => value !== "reasoning.encrypted_content");
       next.include = filteredInclude;
       if (filteredInclude.length === 0) delete next.include;
+    }
+    // Prior turns may have replayed reasoning items (with encrypted_content)
+    // into the input; they are rejected once reasoning is stripped.
+    if (Array.isArray(next.input)) {
+      next.input = next.input.filter((item) => !isReasoningItem(item));
     }
   }
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -390,6 +390,7 @@ describe("feature parity", () => {
           messages: [],
           tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
           reasoning: { effort: "high", summary: "auto" },
+          reasoning_effort: "high",
           include: ["reasoning.encrypted_content", "other"],
           include_reasoning: true,
           reasoning_content: true,

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -387,7 +387,10 @@ describe("feature parity", () => {
     const updated = beforeRequest?.(
       {
         payload: {
-          messages: [],
+          input: [
+            { type: "reasoning", id: "rs_1", encrypted_content: "opaque" },
+            { type: "message", role: "user", content: "hi" },
+          ],
           tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
           reasoning: { effort: "high", summary: "auto" },
           reasoning_effort: "high",
@@ -401,7 +404,7 @@ describe("feature parity", () => {
       { model: { provider: "litellm", id: "llm-gateway/gpt-5.5" } },
     );
     expect(updated).toEqual({
-      messages: [],
+      input: [{ type: "message", role: "user", content: "hi" }],
       tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
       include: ["other"],
     });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -410,6 +410,44 @@ describe("feature parity", () => {
     });
   });
 
+  it("leaves gpt-5.5 tool requests without reasoning fields unchanged", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "llm-gateway/gpt-5.5",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      {
+        payload: {
+          input: [{ type: "message", role: "user", content: "hi" }],
+          tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
+          include: ["other"],
+        },
+      },
+      { model: { provider: "litellm", id: "llm-gateway/gpt-5.5" } },
+    );
+    expect(updated).toBeUndefined();
+  });
+
   it("drops reasoning fields for gpt-5.5 route aliases", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -359,6 +359,53 @@ describe("feature parity", () => {
     });
   });
 
+  it("drops reasoning fields for llm-gateway/gpt-5.5 tool requests", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "llm-gateway/gpt-5.5",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      {
+        payload: {
+          messages: [],
+          tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
+          reasoning: { effort: "high", summary: "auto" },
+          include: ["reasoning.encrypted_content", "other"],
+          include_reasoning: true,
+          reasoning_content: true,
+          merge_reasoning_content_in_choices: false,
+          thinking: { type: "enabled" },
+        },
+      },
+      { model: { provider: "litellm", id: "llm-gateway/gpt-5.5" } },
+    );
+    expect(updated).toEqual({
+      messages: [],
+      tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
+      include: ["other"],
+    });
+  });
+
   it("normalizes Kimi think tags into Pi thinking blocks", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -407,6 +407,49 @@ describe("feature parity", () => {
     });
   });
 
+  it("drops reasoning fields for gpt-5.5 route aliases", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "gpt-5.5-20260504143601",
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    for (const id of ["gpt-5.5", "openai/gpt-5.5", "gpt-5.5-20260504143601"]) {
+      const updated = beforeRequest?.(
+        {
+          payload: {
+            messages: [],
+            tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
+            reasoning: { effort: "high" },
+          },
+        },
+        { model: { provider: "litellm", id } },
+      );
+      expect(updated, id).toEqual({
+        messages: [],
+        tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
+      });
+    }
+  });
+
   it("normalizes Kimi think tags into Pi thinking blocks", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";


### PR DESCRIPTION
Fixes the LiteLLM gpt-5.5 route when Pi sends function tools together with reasoning fields.

The gateway still rejects that combination even when the model is configured for `openai-responses`, because the request ends up behaving like chat completions and returns:

```text
Function tools with reasoning_effort are not supported for gpt-5.5-20260504143601 in /v1/chat/completions. Please use /v1/responses instead.
```

This keeps the workaround narrow: for `llm-gateway/gpt-5.5` requests that include tools, we drop the reasoning fields before the provider request is sent.

Also:
- keeps non-tool requests unchanged
- strips `reasoning.encrypted_content` from `include`
- adds a focused feature test for the payload rewrite

Verification:
- `npm test -- tests/features.test.ts`
- `npm run typecheck`
- `./node_modules/.bin/biome check src/index.ts tests/features.test.ts`

Note: `npm test` already fails on `main` in `tests/gcloud-token.test.ts` because this environment picks up a real ADC token, so verification here stays scoped to the touched path.