### PR TITLE
Provider-scope cost tracking and harden LiteLLM smoke coverage

### DIFF
--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -29,6 +29,7 @@ jobs:
       LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
       LITELLM_SMOKE_EXPECT_SOURCE: model_info
       LITELLM_CLI_SMOKE_MODEL: vidaimock-openai
+      LITELLM_CLI_SMOKE_MODEL_ANTHROPIC: anthropic/vidaimock-claude
       VIDAIMOCK_BASE_URL: http://127.0.0.1:8100
       VIDAIMOCK_VERSION: v0.2.7
 
@@ -160,6 +161,17 @@ jobs:
             --no-session \
             -p "Reply with one short word." | tee /tmp/pi-litellm-response.txt
           grep -F "mock response" /tmp/pi-litellm-response.txt
+
+          # Anthropic-backed route: covers the cacheControlFormat "anthropic"
+          # compat path through LiteLLM's Anthropic translation.
+          ./node_modules/.bin/pi \
+            -e ./dist/index.js \
+            --provider litellm \
+            --model "$LITELLM_CLI_SMOKE_MODEL_ANTHROPIC" \
+            --no-tools \
+            --no-session \
+            -p "Reply with one short word." | tee /tmp/pi-litellm-response-anthropic.txt
+          grep -F "Anthropic mock response" /tmp/pi-litellm-response-anthropic.txt
 
       - name: Dump LiteLLM logs
         if: failure()

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -27,6 +27,7 @@ jobs:
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
       LITELLM_IMAGE: docker.litellm.ai/berriai/litellm:main-latest
       LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
+      LITELLM_SMOKE_EXPECT_SOURCE: model_info
       LITELLM_CLI_SMOKE_MODEL: vidaimock-openai
       VIDAIMOCK_BASE_URL: http://127.0.0.1:8100
       VIDAIMOCK_VERSION: v0.2.7

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If your LiteLLM proxy exposes `/v1/skills`, enabled skills are fetched before ea
 
 The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes OpenAI-compatible and Anthropic routes whose upstreams are served by VidaiMock, then this extension's smoke runner discovers those models through LiteLLM and sends `/v1/chat/completions` requests through the proxy.
 
-This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The smoke runner also asserts that discovery came from `/model/info` (`LITELLM_SMOKE_EXPECT_SOURCE`) so a silent fallback to `/v1/models` fails the run. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` so extension loading, model discovery, and a real completion path are covered without opening the TUI.
+This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The smoke runner also asserts that discovery came from `/model/info` (`LITELLM_SMOKE_EXPECT_SOURCE`) so a silent fallback to `/v1/models` fails the run. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` against both the OpenAI-compatible and Anthropic-backed routes, so extension loading, model discovery, and real completion paths are covered without opening the TUI.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If your LiteLLM proxy exposes `/v1/skills`, enabled skills are fetched before ea
 
 The `LiteLLM Smoke` GitHub Actions workflow starts VidaiMock and a real LiteLLM proxy on the runner. LiteLLM exposes OpenAI-compatible and Anthropic routes whose upstreams are served by VidaiMock, then this extension's smoke runner discovers those models through LiteLLM and sends `/v1/chat/completions` requests through the proxy.
 
-This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` so extension loading, model discovery, and a real completion path are covered without opening the TUI.
+This keeps the LiteLLM integration path under test but does not call real LLM APIs. No provider API keys or GitHub Models permission are required. The smoke runner also asserts that discovery came from `/model/info` (`LITELLM_SMOKE_EXPECT_SOURCE`) so a silent fallback to `/v1/models` fails the run. The workflow also runs a non-interactive Pi CLI smoke with `--list-models` and `-p` so extension loading, model discovery, and a real completion path are covered without opening the TUI.
 
 ## Development
 

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -20,7 +20,19 @@ export type SmokeOptions = {
   apiKey: string;
   modelIds: string[];
   timeoutMs?: number;
+  expectedSource?: DiscoverySource;
 };
+
+const DISCOVERY_SOURCES: DiscoverySource[] = ["model_info", "models_list", "health"];
+
+export function parseExpectedSource(raw: string | undefined): DiscoverySource | undefined {
+  const trimmed = raw?.trim();
+  if (!trimmed) return undefined;
+  if (!(DISCOVERY_SOURCES as string[]).includes(trimmed)) {
+    throw new Error(`LITELLM_SMOKE_EXPECT_SOURCE must be one of ${DISCOVERY_SOURCES.join(", ")}; got ${trimmed}`);
+  }
+  return trimmed as DiscoverySource;
+}
 
 type ChatCompletionResponse = {
   choices?: Array<{
@@ -102,6 +114,9 @@ export async function runSmoke(options: SmokeOptions): Promise<SmokeResult> {
   }
 
   const discovery = await discoverModels(baseUrl, options.apiKey, { timeoutMs });
+  if (options.expectedSource && discovery.source !== options.expectedSource) {
+    throw new Error(`Discovery source mismatch: expected ${options.expectedSource}, got ${discovery.source}`);
+  }
   const discovered = new Set(discovery.models.map((model) => model.id));
   const missing = options.modelIds.filter((modelId) => !discovered.has(modelId));
   if (missing.length > 0) {
@@ -135,5 +150,6 @@ export async function runSmokeFromEnv(env: NodeJS.ProcessEnv = process.env): Pro
     apiKey,
     modelIds: parseSmokeModels(env.LITELLM_SMOKE_MODELS),
     timeoutMs: Number.isNaN(timeoutMs) || timeoutMs <= 0 ? DEFAULT_TIMEOUT_MS : timeoutMs,
+    expectedSource: parseExpectedSource(env.LITELLM_SMOKE_EXPECT_SOURCE),
   });
 }

--- a/src/cost.ts
+++ b/src/cost.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 
+const PROVIDER_NAME = "litellm";
+
 export interface ModelCostInfo {
   inputCostPerToken: number;
   outputCostPerToken: number;
@@ -30,7 +32,9 @@ export function setupLiteLLMCostTracking(
 
   updateCosts(models);
 
-  pi.on("after_provider_response", (event) => {
+  pi.on("after_provider_response", (event, ctx) => {
+    // Global Pi hook: responses from other providers must not feed LiteLLM cost state.
+    if (ctx.model?.provider !== PROVIDER_NAME) return;
     const costHeader = event.headers?.["x-litellm-response-cost"] ?? event.headers?.["X-Litellm-Response-Cost"];
     if (costHeader) {
       const cost = Number.parseFloat(String(costHeader));
@@ -43,7 +47,7 @@ export function setupLiteLLMCostTracking(
   });
 
   pi.on("message_end", async (event) => {
-    if (event.message.role !== "assistant") return;
+    if (event.message.role !== "assistant" || event.message.provider !== PROVIDER_NAME) return;
 
     const usage = event.message.usage;
     if (!usage) return;

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -608,12 +608,16 @@ describe("feature parity", () => {
     }
 
     const responseHandler = pi.handlers.get("after_provider_response")?.[0];
-    responseHandler?.({ headers: { "x-litellm-response-cost": "0.42" } });
+    responseHandler?.(
+      { headers: { "x-litellm-response-cost": "0.42" } },
+      { model: { provider: "litellm", id: "anthropic/claude-3-5-sonnet" } },
+    );
 
     const endHandler = pi.handlers.get("message_end")?.[0];
     const result = await endHandler?.({
       message: {
         role: "assistant",
+        provider: "litellm",
         model: "anthropic/claude-3-5-sonnet",
         usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5 },
       },
@@ -628,6 +632,99 @@ describe("feature parity", () => {
         },
       },
     });
+  });
+
+  it("does not apply LiteLLM model costs to other providers' messages", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "anthropic/claude-3-5-sonnet",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    // Same model id discovered through LiteLLM, but the message came from
+    // a direct provider — LiteLLM pricing must not overwrite its cost.
+    const endHandler = pi.handlers.get("message_end")?.[0];
+    const result = await endHandler?.({
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "anthropic/claude-3-5-sonnet",
+        usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5 },
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores LiteLLM cost headers captured from non-LiteLLM responses", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "anthropic/claude-3-5-sonnet",
+              model_info: {
+                mode: "chat",
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+                cache_read_input_token_cost: 0.0000003,
+                cache_creation_input_token_cost: 0.00000375,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const responseHandler = pi.handlers.get("after_provider_response")?.[0];
+    responseHandler?.(
+      { headers: { "x-litellm-response-cost": "0.42" } },
+      { model: { provider: "openai-codex", id: "gpt-5.5" } },
+    );
+
+    const endHandler = pi.handlers.get("message_end")?.[0];
+    const result = await endHandler?.({
+      message: {
+        role: "assistant",
+        provider: "litellm",
+        model: "anthropic/claude-3-5-sonnet",
+        usage: { input: 100, output: 50, cacheRead: 10, cacheWrite: 5 },
+      },
+    });
+
+    // Falls back to per-token pricing instead of the foreign header cost.
+    expect(result.message.usage.cost.total).toBeCloseTo(0.00107175, 10);
   });
 
   it("updates costs after litellm-refresh", async () => {
@@ -674,6 +771,7 @@ describe("feature parity", () => {
     const initialResult = await endHandler?.({
       message: {
         role: "assistant",
+        provider: "litellm",
         model: "test-model",
         usage: { input: 1000, output: 1000 },
       },
@@ -697,6 +795,7 @@ describe("feature parity", () => {
     const refreshedResult = await endHandler?.({
       message: {
         role: "assistant",
+        provider: "litellm",
         model: "test-model",
         usage: { input: 1000, output: 1000 },
       },
@@ -831,6 +930,7 @@ describe("feature parity", () => {
       const result = await endHandler?.({
         message: {
           role: "assistant",
+          provider: "litellm",
           model: "test-model",
           usage: { input: 1000, output: 1000 },
         },
@@ -892,6 +992,7 @@ describe("feature parity", () => {
     const result = await endHandler?.({
       message: {
         role: "assistant",
+        provider: "litellm",
         model: "test-model",
         usage: { input: 1000, output: 1000 },
       },

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -35,6 +35,9 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("./node_modules/.bin/pi -e ./dist/index.js --list-models litellm");
     expect(workflow).toContain("--provider litellm");
     expect(workflow).toContain('--model "$LITELLM_CLI_SMOKE_MODEL"');
+    expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL_ANTHROPIC: anthropic/vidaimock-claude");
+    expect(workflow).toContain('--model "$LITELLM_CLI_SMOKE_MODEL_ANTHROPIC"');
+    expect(workflow).toContain('grep -F "Anthropic mock response"');
 
     expect(workflow).not.toContain("models: read");
     expect(workflow).not.toContain("GH_MODELS_SMOKE_MODEL");

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -21,6 +21,7 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("Wait for VidaiMock");
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
     expect(workflow).toContain("LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude");
+    expect(workflow).toContain("LITELLM_SMOKE_EXPECT_SOURCE: model_info");
     expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL: vidaimock-openai");
     expect(workflow).toContain("model_name: vidaimock-openai");
     expect(workflow).toContain("model_name: anthropic/vidaimock-claude");

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -180,6 +180,31 @@ describe("runSmoke", () => {
     ).rejects.toThrow(/Timed out after 25ms/);
   });
 
+  it("fails before completion calls when discovery uses an unexpected source", async () => {
+    const requestedUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["github-models-openai"],
+        timeoutMs: 1000,
+        expectedSource: "models_list",
+      }),
+    ).rejects.toThrow(/Discovery source mismatch: expected models_list, got model_info/);
+    expect(requestedUrls).toEqual(["http://127.0.0.1:4000/model/info"]);
+  });
+
   it("truncates oversized provider error bodies in failures", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
@@ -263,6 +288,45 @@ describe("runSmokeFromEnv", () => {
       url: "http://127.0.0.1:4000/model/info",
       headers: { Authorization: "Bearer sk-env" },
     });
+  });
+
+  it("accepts a matching LITELLM_SMOKE_EXPECT_SOURCE", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await runSmokeFromEnv({
+      LITELLM_BASE_URL: "http://127.0.0.1:4000",
+      LITELLM_API_KEY: "sk-env",
+      LITELLM_SMOKE_MODELS: "github-models-openai",
+      LITELLM_SMOKE_TIMEOUT_MS: "1000",
+      LITELLM_SMOKE_EXPECT_SOURCE: "model_info",
+    });
+
+    expect(result.source).toBe("model_info");
+  });
+
+  it("rejects an invalid LITELLM_SMOKE_EXPECT_SOURCE without any network calls", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unexpected fetch"));
+
+    await expect(
+      runSmokeFromEnv({
+        LITELLM_BASE_URL: "http://127.0.0.1:4000",
+        LITELLM_API_KEY: "sk-env",
+        LITELLM_SMOKE_MODELS: "github-models-openai",
+        LITELLM_SMOKE_EXPECT_SOURCE: "bogus",
+      }),
+    ).rejects.toThrow(/LITELLM_SMOKE_EXPECT_SOURCE must be one of model_info, models_list, health/);
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("requires LiteLLM base URL and API key settings", async () => {


### PR DESCRIPTION
## Summary

Applies three findings from a full-repository review:

- **`src/cost.ts`: scope cost-tracking hooks to the `litellm` provider.** Both `after_provider_response` and `message_end` are global Pi hooks; previously any assistant message whose model id collided with a LiteLLM-discovered route (e.g. `gpt-4o` via a direct provider) could get its cost overwritten with LiteLLM pricing, and cost headers could be consumed across providers. Now `after_provider_response` checks `ctx.model?.provider` and `message_end` checks `event.message.provider`, matching the provider-scoping rule in AGENTS.md and the existing pattern in `normalizeThinkTags`.
- **Smoke runner: assert the discovery source.** `runSmoke` accepts `expectedSource`, and `runSmokeFromEnv` reads `LITELLM_SMOKE_EXPECT_SOURCE` (validated; invalid values fail before any network call). The workflow pins it to `model_info`, so if a future LiteLLM `main-latest` breaks `/model/info`, the smoke fails loudly instead of silently falling back to `/v1/models` + a live models.dev fetch.
- **Smoke workflow: exercise the Anthropic route through the Pi CLI.** A second non-interactive `pi -p` run against `anthropic/vidaimock-claude` covers the `cacheControlFormat: "anthropic"` compat path end-to-end (Pi → LiteLLM Anthropic translation → VidaiMock). The grep target (`Anthropic mock response`) matches the actual VidaiMock reply observed in recent CI run logs.

All changes were done test-first; each new test was observed failing before the fix.

## Test plan

- [x] `npm run check` — Biome, typecheck, and 129/129 Vitest tests pass (5 new tests)
- [x] `LiteLLM Smoke` workflow dispatched against this branch to validate the new `LITELLM_SMOKE_EXPECT_SOURCE` assertion and the Anthropic CLI leg pre-merge — passed: https://github.com/balcsida/pi-provider-litellm/actions/runs/28715412924 (`Source: model_info` asserted; Anthropic route reply matched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
