### PR TITLE
Port OdinLayer LiteLLM provider improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ If your LiteLLM proxy exposes MCP REST endpoints, this extension discovers tools
 - `GET /mcp-rest/tools/list`
 - `POST /mcp-rest/tools/call`
 
-Each discovered tool is registered as a native Pi tool named `mcp_<server>_<tool>`, with simple JSON Schema parameters mapped to Pi/TypeBox parameters. Complex schemas fall back to a single `args` object. MCP discovery runs after successful live model discovery, `/login litellm`, or `/litellm-refresh`; it does not force network or helper-token access when a fresh model cache is used.
+Each discovered tool is registered as a native Pi tool named `mcp_<server>_<tool>`, with simple JSON Schema parameters mapped to Pi/TypeBox parameters. Complex schemas fall back to a single `args` object. MCP discovery runs after successful live model discovery, `/login litellm`, or `/litellm-refresh`; it does not force network or helper-token access when a fresh model cache is used. MCP tools run in Pi's parallel tool mode and retry transient failures once.
 
-## LiteLLM Skills Gateway
+## LiteLLM Skill Hub
 
-If your LiteLLM proxy exposes `/v1/skills`, enabled skills are fetched before each agent turn and appended to the system prompt as a `litellm_skills` section. The extension also registers Pi tools for basic Skills Gateway management:
+If your LiteLLM proxy exposes `/claude-code/marketplace.json`, enabled skills are fetched before each agent turn and appended to the system prompt as a `litellm_skills` section. The extension falls back to the legacy `/v1/skills` Skills Gateway path when Skill Hub is unavailable. It also registers Pi tools for basic skill management:
 
 - `litellm_skill_list`
 - `litellm_skill_create`
@@ -224,7 +224,7 @@ If the cache is older than 24 hours, the extension refreshes it in the backgroun
 | Enterprise SSO login shows "virtual key generation failed" | The LiteLLM instance may lack a database (`/key/generate` requires one), your user account may lack key-generation permission, or the request timed out; the JWT is used directly as a fallback |
 | Enterprise SSO token prompt fails with "SSO token is required" | The token field was left empty — paste the token copied from the LiteLLM UI |
 | MCP tools not showing | Verify the proxy exposes `/mcp-rest/tools/list` and run `/litellm-refresh` after fixing the proxy |
-| Skills not affecting prompts | Verify the proxy exposes `/v1/skills` and returns enabled skills |
+| Skills not affecting prompts | Verify the proxy exposes `/claude-code/marketplace.json` or `/v1/skills` and returns enabled skills |
 
 ## License
 

--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noNonNullAssertion": "off",
         "useConst": "error",

--- a/docs/superpowers/plans/2026-07-08-odinlayer-port.md
+++ b/docs/superpowers/plans/2026-07-08-odinlayer-port.md
@@ -1,0 +1,88 @@
+# OdinLayer Behavior Port Plan
+
+## Goal
+
+Port the approved useful OdinLayer behaviors into the current `main` branch with minimal source changes and no new runtime dependencies.
+
+## Architecture
+
+Discovery maps LiteLLM model metadata into Pi model configs. MCP tools translate LiteLLM MCP REST tools into Pi tools. Skills translate LiteLLM skill/plugin endpoints into prompt context and management tools. Each port stays in the owning module.
+
+## Tech Stack
+
+TypeScript ESM, Vitest, existing Pi extension APIs.
+
+## Constraints
+
+- Do not add runtime dependencies.
+- Do not edit `dist/` by hand.
+- Keep `/litellm-refresh` unchanged.
+- Preserve `/v1/skills` compatibility.
+- Use TDD: write the focused failing test first, then implementation.
+
+## Task 1: Responses API Discovery
+
+**Files:**
+
+- Modify: `src/discover.ts`
+- Test: `tests/discover.test.ts`
+
+**Interfaces:**
+
+- Consumes `ModelInfoEntry.model_info.mode`.
+- Produces `ProviderModelConfig.api = "openai-responses"` only for `response` or `responses` modes.
+
+**Steps:**
+
+1. Add failing tests for `/model/info` response-mode models and `/health` fallback response-mode models.
+2. Run `npm test -- tests/discover.test.ts`.
+3. Update discovery mode filtering and model mapping.
+4. Run `npm test -- tests/discover.test.ts`.
+
+## Task 2: MCP Retry And Parallel Execution
+
+**Files:**
+
+- Modify: `src/mcp-tools.ts`
+- Test: `tests/mcp-tools.test.ts`
+
+**Interfaces:**
+
+- Generated MCP tool definitions expose `executionMode: "parallel"`.
+- `executeMcpTool()` retries once for retryable HTTP/network failures.
+
+**Steps:**
+
+1. Add failing tests for `executionMode`, retryable HTTP retry, and non-retryable HTTP no-retry.
+2. Run `npm test -- tests/mcp-tools.test.ts`.
+3. Add one retry attempt in `executeMcpTool()` and set tool execution mode.
+4. Run `npm test -- tests/mcp-tools.test.ts`.
+
+## Task 3: Skill Hub Compatibility
+
+**Files:**
+
+- Modify: `src/skills.ts`
+- Modify: `src/types.ts`
+- Test: `tests/skills.test.ts`
+- Modify: `README.md`
+
+**Interfaces:**
+
+- List from `GET /claude-code/marketplace.json`, falling back to `GET /v1/skills`.
+- Create at `POST /claude-code/plugins`, falling back to `POST /v1/skills` on `404`.
+- Delete at `DELETE /claude-code/plugins/:id`, falling back to `DELETE /v1/skills/:id` on `404`.
+
+**Steps:**
+
+1. Add failing tests for Skill Hub list/create/delete and `/v1/skills` fallback.
+2. Run `npm test -- tests/skills.test.ts`.
+3. Update skill body normalization and endpoint fallback logic.
+4. Update README wording for Skill Hub plus Skills Gateway compatibility.
+5. Run `npm test -- tests/skills.test.ts`.
+
+## Final Verification
+
+1. Run `npm run check`.
+2. Run `npm run clean && npm run build`.
+3. Commit each logical change locally with a conventional commit message.

--- a/docs/superpowers/specs/2026-07-08-odinlayer-port-design.md
+++ b/docs/superpowers/specs/2026-07-08-odinlayer-port-design.md
@@ -1,0 +1,56 @@
+# OdinLayer Behavior Port Design
+
+**Status:** Approved
+
+## Goal
+
+Port useful behavior from `@odinlayer/pi-provider-litellm@1.0.19` into this extension without copying branding, release metadata, or UI/dependency churn.
+
+## Scope
+
+Implement three behaviors:
+
+1. Discover LiteLLM Responses API models from `/model/info`.
+2. Make LiteLLM MCP tool execution more resilient and parallel-friendly.
+3. Support LiteLLM Skill Hub endpoints while keeping the existing Skills Gateway path working.
+
+Out of scope:
+
+- Compact MCP TUI rendering, because OdinLayer imports `@earendil-works/pi-tui` and this package currently has no runtime dependencies.
+- Renaming `/litellm-refresh` to `/litellm:models-refresh`, because the existing command already supports all configured providers and changing it would be mostly user-facing churn.
+
+## Design
+
+### Responses API Discovery
+
+`src/discover.ts` will treat `model_info.mode` values of `chat`, `response`, `responses`, or missing as chat-style models. It will continue filtering non-chat workloads such as embeddings. Response-mode models will get a per-model `api: "openai-responses"` override so Pi routes them through the Responses API while the provider default stays `openai-completions`.
+
+Tests will cover direct `/model/info` entries and `/health` per-endpoint `/model/info` fallback entries.
+
+### MCP Tools
+
+`src/mcp-tools.ts` will mark generated MCP tools with `executionMode: "parallel"` and retry `executeMcpTool()` once for transient failures. Retryable failures are HTTP `408`, `425`, `429`, `500`, `502`, `503`, `504`, plus timeout/network errors. Auth and other non-retryable failures return immediately.
+
+No new dependency is needed.
+
+### Skill Hub Compatibility
+
+`src/skills.ts` will first read Skill Hub catalog data from `GET /claude-code/marketplace.json`, accepting array bodies or `plugins`, `data`, or `skills` arrays. If that endpoint is unavailable, it will fall back to the existing `GET /v1/skills`.
+
+Create/delete tools will use Skill Hub plugin endpoints by default:
+
+- `POST /claude-code/plugins`
+- `DELETE /claude-code/plugins/:id`
+
+If those endpoints return `404`, the existing `/v1/skills` paths remain the fallback. This preserves current LiteLLM Skills Gateway installs while supporting the newer Skill Hub surface.
+
+## Verification
+
+- Start from the current `npm run check` green baseline.
+- Add focused failing tests first:
+  - `tests/discover.test.ts` for response-mode model inclusion and API override.
+  - `tests/mcp-tools.test.ts` for retry and parallel execution metadata.
+  - `tests/skills.test.ts` for Skill Hub fetch/create/delete plus fallback behavior.
+- Run focused test files until green.
+- Run `npm run check`.
+- Run `npm run clean && npm run build` because runtime source changes affect `dist`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.5",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "1.2.5",
+      "version": "1.2.9",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.2.5",
+  "version": "1.2.9",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -43,6 +43,16 @@ export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
 }
 
+const RESPONSES_MODE_PATTERN = /^responses?$/i;
+
+function isResponsesMode(mode: string | undefined): boolean {
+  return mode !== undefined && RESPONSES_MODE_PATTERN.test(mode);
+}
+
+function isChatStyleMode(mode: string | undefined): boolean {
+  return mode === undefined || mode === "chat" || isResponsesMode(mode);
+}
+
 // Matches both the conventional `anthropic/...` prefix and aliases that
 // LiteLLM deployments commonly assign to Anthropic-backed routes (e.g.
 // `google/claude-sonnet-4-6`, `opus-4.7`, `sonnet-4.6`, `haiku-4.5`). Without
@@ -257,7 +267,8 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
   const id = entry.model_name;
   if (!id) return undefined;
   const info = entry.model_info ?? {};
-  if (info.mode && info.mode !== "chat") return undefined;
+  if (!isChatStyleMode(info.mode)) return undefined;
+  const responsesMode = isResponsesMode(info.mode);
   const catalogModel = findCatalogModel(id);
   return {
     id,
@@ -268,6 +279,7 @@ function mapFromModelInfo(entry: ModelInfoEntry): ProviderModelConfig | undefine
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
+    ...(responsesMode ? { api: "openai-responses" as const } : {}),
   };
 }
 
@@ -277,8 +289,9 @@ function mapFromHealthModelInfo(
 ): ProviderModelConfig | undefined {
   const model = mapFromModelInfo(entry);
   if (model || !fallbackId) return model;
-  if (entry.model_info?.mode && entry.model_info.mode !== "chat") return undefined;
+  if (!isChatStyleMode(entry.model_info?.mode)) return undefined;
   const info = entry.model_info ?? {};
+  const responsesMode = isResponsesMode(info.mode);
   const catalogModel = findCatalogModel(fallbackId);
   return {
     id: fallbackId,
@@ -289,6 +302,7 @@ function mapFromHealthModelInfo(
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(fallbackId),
+    ...(responsesMode ? { api: "openai-responses" as const } : {}),
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -749,6 +749,7 @@ const REASONING_SUPPRESSION_DEFAULTS: Record<string, unknown> = {
 function prepareLiteLLMRequestPayload(
   payload: Record<string, unknown>,
   modelId: string | undefined,
+  api: Api | undefined,
   sessionId: string | undefined,
 ): Record<string, unknown> | undefined {
   let next: Record<string, unknown> | undefined;
@@ -764,7 +765,13 @@ function prepareLiteLLMRequestPayload(
 
   // LiteLLM still routes gpt-5.5 tool+reasoning requests through chat completions.
   // Drop reasoning until the gateway honors /v1/responses for this route.
-  if (modelId && isGpt55Model(modelId) && Array.isArray(payload.tools) && payload.tools.length > 0) {
+  if (
+    api !== "openai-responses" &&
+    modelId &&
+    isGpt55Model(modelId) &&
+    Array.isArray(payload.tools) &&
+    payload.tools.length > 0
+  ) {
     const reasoningKeys = ["reasoning", "reasoning_effort", ...Object.keys(REASONING_SUPPRESSION_DEFAULTS)];
     for (const key of reasoningKeys) {
       if (payload[key] === undefined) continue;
@@ -1229,7 +1236,12 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   pi.on("before_provider_request", (event, ctx) => {
     if (!ctx.model?.provider || !providerNames.has(ctx.model.provider)) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
-    return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model?.id, sessionId);
+    return prepareLiteLLMRequestPayload(
+      event.payload as Record<string, unknown>,
+      ctx.model?.id,
+      ctx.model?.api,
+      sessionId,
+    );
   });
 
   pi.on("before_agent_start", async (event) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -759,7 +759,7 @@ function prepareLiteLLMRequestPayload(
     next[key] = value;
   };
 
-  if (modelId && shouldSuppressReasoningContent(modelId)) {
+  if (api !== "openai-responses" && modelId && shouldSuppressReasoningContent(modelId)) {
     for (const [key, value] of Object.entries(REASONING_SUPPRESSION_DEFAULTS)) update(key, value);
   }
 

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -103,9 +103,10 @@ export async function executeMcpTool(
   serverId: string,
   toolName: string,
   args: Record<string, unknown>,
+  headers?: Record<string, string>,
 ): Promise<string> {
   for (let attempt = 0; attempt <= MCP_RETRY_ATTEMPTS; attempt++) {
-    const result = await executeMcpToolOnce(baseUrl, apiKey, serverId, toolName, args);
+    const result = await executeMcpToolOnce(baseUrl, apiKey, serverId, toolName, args, headers);
     if (attempt < MCP_RETRY_ATTEMPTS && isRetryableMcpResult(result)) {
       await sleep(MCP_RETRY_DELAY_MS);
       continue;

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -10,6 +10,11 @@ const MCP_RETRY_DELAY_MS = 350;
 const MCP_RETRY_ATTEMPTS = 1;
 const RETRYABLE_HTTP_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 
+interface McpExecutionResult {
+  text: string;
+  retryable: boolean;
+}
+
 interface RawLiteLLMMcpTool {
   name?: unknown;
   description?: unknown;
@@ -36,14 +41,22 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
 }
 
-function isRetryableMcpResult(result: string): boolean {
-  const status = /: HTTP (\d+)$/.exec(result)?.[1];
-  if (status) return RETRYABLE_HTTP_STATUS.has(Number(status));
-  return result.startsWith("Error calling ");
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function formatMcpToolError(toolName: string, serverId: string, error: unknown): string {
+  return `Error calling ${toolName} on ${serverId}: ${error instanceof Error ? error.message : String(error)}`;
+}
+
+function isRetryableTransportError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "AbortError" || error.name === "TimeoutError") return true;
+  if (error.message.startsWith("Timed out after ")) return true;
+  if (error.name !== "TypeError") return false;
+  return /fetch failed|failed to fetch|network|terminated|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|ENOTFOUND|socket/i.test(
+    error.message,
+  );
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -107,11 +120,11 @@ export async function executeMcpTool(
 ): Promise<string> {
   for (let attempt = 0; attempt <= MCP_RETRY_ATTEMPTS; attempt++) {
     const result = await executeMcpToolOnce(baseUrl, apiKey, serverId, toolName, args, headers);
-    if (attempt < MCP_RETRY_ATTEMPTS && isRetryableMcpResult(result)) {
+    if (attempt < MCP_RETRY_ATTEMPTS && result.retryable) {
       await sleep(MCP_RETRY_DELAY_MS);
       continue;
     }
-    return result;
+    return result.text;
   }
   return `Error calling ${toolName} on ${serverId}: retry attempts exhausted`;
 }
@@ -123,24 +136,47 @@ async function executeMcpToolOnce(
   toolName: string,
   args: Record<string, unknown>,
   headers?: Record<string, string>,
-): Promise<string> {
+): Promise<McpExecutionResult> {
   const { signal, cancel } = withTimeout(CALL_TIMEOUT_MS);
   try {
-    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/call`, {
-      method: "POST",
-      headers: {
-        ...headers,
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ server_id: serverId, name: toolName, arguments: args }),
-      signal,
-    });
-    if (!response.ok) return `Error calling ${toolName} on ${serverId}: HTTP ${response.status}`;
-    const body = (await response.json()) as Record<string, unknown>;
-    return JSON.stringify("result" in body ? body.result : body, null, 2);
+    let response: Response;
+    try {
+      response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/call`, {
+        method: "POST",
+        headers: {
+          ...headers,
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ server_id: serverId, name: toolName, arguments: args }),
+        signal,
+      });
+    } catch (error) {
+      return {
+        text: formatMcpToolError(toolName, serverId, error),
+        retryable: isRetryableTransportError(error),
+      };
+    }
+
+    if (!response.ok) {
+      return {
+        text: `Error calling ${toolName} on ${serverId}: HTTP ${response.status}`,
+        retryable: RETRYABLE_HTTP_STATUS.has(response.status),
+      };
+    }
+
+    try {
+      const body = (await response.json()) as unknown;
+      const bodyRecord = asRecord(body);
+      return {
+        text: JSON.stringify(bodyRecord && "result" in bodyRecord ? bodyRecord.result : body, null, 2),
+        retryable: false,
+      };
+    } catch (error) {
+      return { text: formatMcpToolError(toolName, serverId, error), retryable: false };
+    }
   } catch (error) {
-    return `Error calling ${toolName} on ${serverId}: ${error instanceof Error ? error.message : String(error)}`;
+    return { text: formatMcpToolError(toolName, serverId, error), retryable: false };
   } finally {
     cancel();
   }

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -6,6 +6,9 @@ import type { LiteLLMMcpTool } from "./types.js";
 
 const LIST_TIMEOUT_MS = 10_000;
 const CALL_TIMEOUT_MS = 30_000;
+const MCP_RETRY_DELAY_MS = 350;
+const MCP_RETRY_ATTEMPTS = 1;
+const RETRYABLE_HTTP_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 
 interface RawLiteLLMMcpTool {
   name?: unknown;
@@ -31,6 +34,16 @@ function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => vo
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function isRetryableMcpResult(result: string): boolean {
+  const status = /: HTTP (\d+)$/.exec(result)?.[1];
+  if (status) return RETRYABLE_HTTP_STATUS.has(Number(status));
+  return result.startsWith("Error calling ");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -85,6 +98,24 @@ export async function discoverMcpTools(
 }
 
 export async function executeMcpTool(
+  baseUrl: string,
+  apiKey: string,
+  serverId: string,
+  toolName: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  for (let attempt = 0; attempt <= MCP_RETRY_ATTEMPTS; attempt++) {
+    const result = await executeMcpToolOnce(baseUrl, apiKey, serverId, toolName, args);
+    if (attempt < MCP_RETRY_ATTEMPTS && isRetryableMcpResult(result)) {
+      await sleep(MCP_RETRY_DELAY_MS);
+      continue;
+    }
+    return result;
+  }
+  return `Error calling ${toolName} on ${serverId}: retry attempts exhausted`;
+}
+
+async function executeMcpToolOnce(
   baseUrl: string,
   apiKey: string,
   serverId: string,
@@ -151,6 +182,7 @@ export async function createMcpToolDefinitions(
       label: `${mcpTool.server_name}: ${mcpTool.name}`,
       description: `${mcpTool.description} (via ${mcpTool.server_name} MCP server)`,
       promptSnippet: `${mcpTool.description} via ${mcpTool.server_name} MCP server`,
+      executionMode: "parallel",
       parameters,
       async execute(_toolCallId, params: Static<typeof parameters>) {
         const apiKey = await getApiKey();

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -141,14 +141,11 @@ export async function deleteSkill(
 ): Promise<void> {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   let skillHubError: unknown;
-  const skillHubResponse = await fetch(
-    `${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(skillId)}`,
-    {
-      method: "DELETE",
-      headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
-      signal: AbortSignal.timeout(10_000),
-    },
-  ).catch((error: unknown) => {
+  const skillHubResponse = await fetch(`${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(skillId)}`, {
+    method: "DELETE",
+    headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+    signal: AbortSignal.timeout(10_000),
+  }).catch((error: unknown) => {
     skillHubError = error;
     return undefined;
   });

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -86,7 +86,7 @@ export async function createSkill(
         code: input.code,
         input_schema: input.inputSchema ?? { type: "object", properties: {} },
       };
-  let response = await fetch(`${normalizedBaseUrl}/claude-code/plugins`, {
+  let response = await fetch(`${normalizedBaseUrl}${input.source ? "/claude-code/plugins" : "/v1/skills"}`, {
     method: "POST",
     headers: {
       ...headers,
@@ -96,7 +96,7 @@ export async function createSkill(
     body: JSON.stringify(skillHubPayload),
     signal: AbortSignal.timeout(10_000),
   });
-  if (response.status === 404) {
+  if (input.source && response.status === 404) {
     response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
       method: "POST",
       headers: {

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -46,7 +46,7 @@ export async function listSkills(
       headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
       signal: AbortSignal.timeout(10_000),
     });
-    if (!response.ok) {
+    if (response.status === 404) {
       response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
         headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
         signal: AbortSignal.timeout(10_000),

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -142,8 +142,8 @@ export async function deleteSkill(
     method: "DELETE",
     headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
     signal: AbortSignal.timeout(10_000),
-  });
-  if (response.status === 404) {
+  }).catch(() => undefined);
+  if (!response || response.status === 404 || response.status >= 500) {
     response = await fetch(`${normalizedBaseUrl}/v1/skills/${encodeURIComponent(skillId)}`, {
       method: "DELETE",
       headers: { ...headers, Authorization: `Bearer ${apiKey}` },

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -45,8 +45,8 @@ export async function listSkills(
     let response = await fetch(`${normalizedBaseUrl}/claude-code/marketplace.json`, {
       headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
       signal: AbortSignal.timeout(10_000),
-    });
-    if (response.status === 404) {
+    }).catch(() => undefined);
+    if (!response || response.status === 404 || response.status >= 500) {
       response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
         headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
         signal: AbortSignal.timeout(10_000),

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -74,6 +74,18 @@ export async function createSkill(
   headers?: Record<string, string>,
 ): Promise<unknown> {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const skillHubPayload = input.source
+    ? {
+        name: input.name,
+        description: input.description,
+        source: input.source,
+      }
+    : {
+        name: input.name,
+        description: input.description,
+        code: input.code,
+        input_schema: input.inputSchema ?? { type: "object", properties: {} },
+      };
   let response = await fetch(`${normalizedBaseUrl}/claude-code/plugins`, {
     method: "POST",
     headers: {
@@ -81,13 +93,7 @@ export async function createSkill(
       Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({
-      name: input.name,
-      description: input.description,
-      source: input.source,
-      code: input.code,
-      input_schema: input.inputSchema ?? { type: "object", properties: {} },
-    }),
+    body: JSON.stringify(skillHubPayload),
     signal: AbortSignal.timeout(10_000),
   });
   if (response.status === 404) {
@@ -161,14 +167,23 @@ function formatSkills(skills: LiteLLMSkill[]): string {
 
 const CreateSkillParams = Type.Object({
   name: Type.String({ description: "Skill name" }),
-  description: Type.String({ description: "Skill description" }),
-  code: Type.String({ description: "Skill implementation or prompt code" }),
+  description: Type.Optional(Type.String({ description: "Skill description" })),
+  sourceJson: Type.Optional(Type.String({ description: "Optional Skill Hub source metadata JSON object" })),
+  code: Type.Optional(Type.String({ description: "Legacy Skills Gateway implementation or prompt code" })),
   inputSchemaJson: Type.Optional(Type.String({ description: "Optional JSON Schema string for skill inputs" })),
 });
 
 const DeleteSkillParams = Type.Object({
   skillId: Type.String({ description: "LiteLLM skill id" }),
 });
+
+function parseJsonObject(value: string, fieldName: string): Record<string, unknown> {
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${fieldName} must be a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
 
 export function createSkillToolDefinitions(
   baseUrl: string,
@@ -195,10 +210,22 @@ export function createSkillToolDefinitions(
       parameters: CreateSkillParams,
       async execute(_toolCallId, params: Static<typeof CreateSkillParams>) {
         const apiKey = await getApiKey();
+        const source = params.sourceJson ? parseJsonObject(params.sourceJson, "sourceJson") : undefined;
         const inputSchema = params.inputSchemaJson
-          ? (JSON.parse(params.inputSchemaJson) as Record<string, unknown>)
+          ? parseJsonObject(params.inputSchemaJson, "inputSchemaJson")
           : undefined;
-        const result = await createSkill(baseUrl, apiKey, { ...params, inputSchema }, headers);
+        const result = await createSkill(
+          baseUrl,
+          apiKey,
+          {
+            name: params.name,
+            description: params.description,
+            source,
+            code: params.code,
+            inputSchema,
+          },
+          headers,
+        );
         return { content: [{ type: "text", text: "LiteLLM skill created." }], details: { result } };
       },
     }),

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -41,24 +41,26 @@ export async function listSkills(
     return skillsCache.skills;
   }
 
-  try {
-    let response = await fetch(`${normalizedBaseUrl}/claude-code/marketplace.json`, {
-      headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
-      signal: AbortSignal.timeout(10_000),
-    }).catch(() => undefined);
-    if (!response || response.status === 404 || response.status >= 500) {
-      response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
+  const fetchSkills = async (path: string): Promise<LiteLLMSkill[]> => {
+    try {
+      const response = await fetch(`${normalizedBaseUrl}${path}`, {
         headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
         signal: AbortSignal.timeout(10_000),
       });
+      return response.ok ? getSkillsFromBody(await response.json()) : [];
+    } catch {
+      return [];
     }
-    if (!response.ok) return [];
-    const skills = getSkillsFromBody(await response.json());
-    skillsCache = { baseUrl: normalizedBaseUrl, apiKey, fetchedAt: Date.now(), skills };
-    return skills;
-  } catch {
-    return [];
-  }
+  };
+
+  const [skillHub, legacy] = await Promise.all([
+    fetchSkills("/claude-code/marketplace.json"),
+    fetchSkills("/v1/skills"),
+  ]);
+  const skillHubNames = new Set(skillHub.map((skill) => skill.name));
+  const skills = [...skillHub, ...legacy.filter((skill) => !skillHubNames.has(skill.name))];
+  skillsCache = { baseUrl: normalizedBaseUrl, apiKey, fetchedAt: Date.now(), skills };
+  return skills;
 }
 
 export async function createSkill(

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -18,7 +18,8 @@ let skillsCache:
 function getSkillsFromBody(body: unknown): LiteLLMSkill[] {
   if (Array.isArray(body)) return body as LiteLLMSkill[];
   if (body && typeof body === "object") {
-    const record = body as { data?: unknown; skills?: unknown };
+    const record = body as { plugins?: unknown; data?: unknown; skills?: unknown };
+    if (Array.isArray(record.plugins)) return record.plugins as LiteLLMSkill[];
     if (Array.isArray(record.data)) return record.data as LiteLLMSkill[];
     if (Array.isArray(record.skills)) return record.skills as LiteLLMSkill[];
   }
@@ -41,10 +42,16 @@ export async function listSkills(
   }
 
   try {
-    const response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
+    let response = await fetch(`${normalizedBaseUrl}/claude-code/marketplace.json`, {
       headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
       signal: AbortSignal.timeout(10_000),
     });
+    if (!response.ok) {
+      response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
+        headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      });
+    }
     if (!response.ok) return [];
     const skills = getSkillsFromBody(await response.json());
     skillsCache = { baseUrl: normalizedBaseUrl, apiKey, fetchedAt: Date.now(), skills };
@@ -57,10 +64,17 @@ export async function listSkills(
 export async function createSkill(
   baseUrl: string,
   apiKey: string,
-  input: { name: string; description: string; code: string; inputSchema?: Record<string, unknown> },
+  input: {
+    name: string;
+    description?: string;
+    source?: Record<string, unknown>;
+    code?: string;
+    inputSchema?: Record<string, unknown>;
+  },
   headers?: Record<string, string>,
 ): Promise<unknown> {
-  const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/skills`, {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  let response = await fetch(`${normalizedBaseUrl}/claude-code/plugins`, {
     method: "POST",
     headers: {
       ...headers,
@@ -70,11 +84,29 @@ export async function createSkill(
     body: JSON.stringify({
       name: input.name,
       description: input.description,
+      source: input.source,
       code: input.code,
       input_schema: input.inputSchema ?? { type: "object", properties: {} },
     }),
     signal: AbortSignal.timeout(10_000),
   });
+  if (response.status === 404) {
+    response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
+      method: "POST",
+      headers: {
+        ...headers,
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: input.name,
+        description: input.description,
+        code: input.code,
+        input_schema: input.inputSchema ?? { type: "object", properties: {} },
+      }),
+      signal: AbortSignal.timeout(10_000),
+    });
+  }
   if (!response.ok) throw new Error(`LiteLLM skill create failed: HTTP ${response.status}`);
   skillsCache = undefined;
   return response.json().catch(() => ({}));
@@ -86,11 +118,19 @@ export async function deleteSkill(
   skillId: string,
   headers?: Record<string, string>,
 ): Promise<void> {
-  const response = await fetch(`${normalizeBaseUrl(baseUrl)}/v1/skills/${encodeURIComponent(skillId)}`, {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  let response = await fetch(`${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(skillId)}`, {
     method: "DELETE",
-    headers: { ...headers, Authorization: `Bearer ${apiKey}` },
+    headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
     signal: AbortSignal.timeout(10_000),
   });
+  if (response.status === 404) {
+    response = await fetch(`${normalizedBaseUrl}/v1/skills/${encodeURIComponent(skillId)}`, {
+      method: "DELETE",
+      headers: { ...headers, Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(10_000),
+    });
+  }
   if (!response.ok && response.status !== 404) throw new Error(`LiteLLM skill delete failed: HTTP ${response.status}`);
   skillsCache = undefined;
 }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -118,6 +118,7 @@ export async function createSkill(
     });
   }
   if (!response.ok) throw new Error(`LiteLLM skill create failed: HTTP ${response.status}`);
+  skillsCache = undefined;
   if (usedSkillHub) {
     const enableResponse = await fetch(
       `${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(input.name)}/enable`,
@@ -129,7 +130,6 @@ export async function createSkill(
     );
     if (!enableResponse.ok) throw new Error(`LiteLLM skill enable failed: HTTP ${enableResponse.status}`);
   }
-  skillsCache = undefined;
   return response.json().catch(() => ({}));
 }
 

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -74,6 +74,7 @@ export async function createSkill(
   headers?: Record<string, string>,
 ): Promise<unknown> {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  let usedSkillHub = input.source !== undefined;
   const skillHubPayload = input.source
     ? {
         name: input.name,
@@ -97,6 +98,7 @@ export async function createSkill(
     signal: AbortSignal.timeout(10_000),
   });
   if (input.source && response.status === 404) {
+    usedSkillHub = false;
     response = await fetch(`${normalizedBaseUrl}/v1/skills`, {
       method: "POST",
       headers: {
@@ -114,6 +116,17 @@ export async function createSkill(
     });
   }
   if (!response.ok) throw new Error(`LiteLLM skill create failed: HTTP ${response.status}`);
+  if (usedSkillHub) {
+    const enableResponse = await fetch(
+      `${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(input.name)}/enable`,
+      {
+        method: "POST",
+        headers: { ...headers, Authorization: `Bearer ${apiKey}` },
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!enableResponse.ok) throw new Error(`LiteLLM skill enable failed: HTTP ${enableResponse.status}`);
+  }
   skillsCache = undefined;
   return response.json().catch(() => ({}));
 }

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -75,6 +75,7 @@ export async function createSkill(
   },
   headers?: Record<string, string>,
 ): Promise<unknown> {
+  if (!input.source && !input.code) throw new Error("code is required when source is omitted");
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
   let usedSkillHub = input.source !== undefined;
   const skillHubPayload = input.source

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -140,17 +140,29 @@ export async function deleteSkill(
   headers?: Record<string, string>,
 ): Promise<void> {
   const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
-  let response = await fetch(`${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(skillId)}`, {
-    method: "DELETE",
-    headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
-    signal: AbortSignal.timeout(10_000),
-  }).catch(() => undefined);
+  let skillHubError: unknown;
+  const skillHubResponse = await fetch(
+    `${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(skillId)}`,
+    {
+      method: "DELETE",
+      headers: { ...headers, Authorization: `Bearer ${apiKey}`, Accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+    },
+  ).catch((error: unknown) => {
+    skillHubError = error;
+    return undefined;
+  });
+  let response = skillHubResponse;
   if (!response || response.status === 404 || response.status >= 500) {
     response = await fetch(`${normalizedBaseUrl}/v1/skills/${encodeURIComponent(skillId)}`, {
       method: "DELETE",
       headers: { ...headers, Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(10_000),
     });
+  }
+  if (response.status === 404 && skillHubResponse?.status !== 404) {
+    if (skillHubError instanceof Error) throw skillHubError;
+    throw new Error(`LiteLLM skill delete failed: HTTP ${skillHubResponse?.status}`);
   }
   if (!response.ok && response.status !== 404) throw new Error(`LiteLLM skill delete failed: HTTP ${response.status}`);
   skillsCache = undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,14 @@ export interface LiteLLMSkill {
   name: string;
   description?: string;
   enabled?: boolean;
+  source?: Record<string, unknown>;
+  version?: string;
+  keywords?: string[];
+  domain?: string;
+  namespace?: string;
+  category?: string;
+  author?: string;
+  homepage?: string;
   input_schema?: Record<string, unknown>;
   code?: string;
 }

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -199,6 +199,73 @@ describe("discoverModels via /model/info", () => {
   });
 });
 
+describe("discoverModels response-mode models", () => {
+  it("keeps /model/info response-mode models with a Responses API override", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "openai/gpt-5.3-codex-openai",
+              model_info: {
+                mode: "responses",
+                max_input_tokens: 272000,
+                max_output_tokens: 128000,
+              },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("model_info");
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "openai/gpt-5.3-codex-openai",
+      api: "openai-responses",
+      contextWindow: 272000,
+      maxTokens: 128000,
+    });
+  });
+
+  it("keeps /health response-mode model_info fallbacks with a Responses API override", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) return jsonResponse(404, {});
+      if (url.endsWith("/v1/models")) return jsonResponse(404, {});
+      if (url.endsWith("/health")) {
+        return jsonResponse(200, {
+          healthy_endpoints: [{ model: "openai/gpt-5.3-codex-openai", model_id: "uuid-1" }],
+        });
+      }
+      if (url.endsWith("/model/info?litellm_model_id=uuid-1")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "openai/gpt-5.3-codex-openai",
+              model_info: { mode: "response" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("health");
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "openai/gpt-5.3-codex-openai",
+      api: "openai-responses",
+    });
+  });
+});
+
 describe("discoverModels fallback to /v1/models", () => {
   for (const status of [401, 403, 404]) {
     it(`falls back when /model/info returns ${status}`, async () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -360,6 +360,26 @@ describe("feature parity", () => {
     });
   });
 
+  it("leaves Kimi Responses requests unchanged", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      { payload: { input: [{ type: "message", role: "user", content: "hi" }] } },
+      { model: { provider: "litellm", id: "kimi-k2.6", api: "openai-responses" } },
+    );
+
+    expect(updated).toBeUndefined();
+  });
+
   it("drops reasoning fields for llm-gateway/gpt-5.5 tool requests", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -449,6 +449,33 @@ describe("feature parity", () => {
     expect(updated).toBeUndefined();
   });
 
+  it("keeps reasoning fields for gpt-5.5 Responses tool requests", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      {
+        payload: {
+          input: [{ type: "reasoning", id: "rs_1", encrypted_content: "opaque" }],
+          tools: [{ type: "function", function: { name: "noop", parameters: { type: "object" } } }],
+          reasoning: { effort: "high", summary: "auto" },
+          reasoning_effort: "high",
+        },
+      },
+      { model: { provider: "litellm", id: "llm-gateway/gpt-5.5", api: "openai-responses" } },
+    );
+
+    expect(updated).toBeUndefined();
+  });
+
   it("drops reasoning fields for gpt-5.5 route aliases", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -165,6 +165,7 @@ describe("feature parity", () => {
       const url = String(input);
       if (url.endsWith("/model/info")) return jsonResponse(200, { data: [] });
       if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, []);
+      if (url.endsWith("/claude-code/marketplace.json")) return jsonResponse(404, {});
       if (url.endsWith("/v1/skills")) {
         return jsonResponse(200, {
           data: [{ id: "skill-1", name: "terraform", description: "Terraform conventions", enabled: true }],

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -94,14 +94,14 @@ describe("executeMcpTool", () => {
       .mockResolvedValue(jsonResponse(200, { result: { content: [{ type: "text", text: "found" }] } }));
 
     await expect(
-      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }),
+      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }, { "X-Team": "agent" }),
     ).resolves.toBe(JSON.stringify({ content: [{ type: "text", text: "found" }] }, null, 2));
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://litellm.example.com/mcp-rest/tools/call",
       expect.objectContaining({
         method: "POST",
-        headers: expect.objectContaining({ Authorization: "Bearer sk-test" }),
+        headers: expect.objectContaining({ Authorization: "Bearer sk-test", "X-Team": "agent" }),
         body: JSON.stringify({ server_id: "brave", name: "search", arguments: { query: "pi" } }),
       }),
     );

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -136,6 +136,18 @@ describe("executeMcpTool", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not retry response parse failures after a successful HTTP response", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response("not json", { status: 200, headers: { "content-type": "application/json" } }));
+
+    await expect(
+      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }),
+    ).resolves.toMatch(/^Error calling search on brave:/);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createMcpToolDefinitions", () => {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -94,7 +94,14 @@ describe("executeMcpTool", () => {
       .mockResolvedValue(jsonResponse(200, { result: { content: [{ type: "text", text: "found" }] } }));
 
     await expect(
-      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }, { "X-Team": "agent" }),
+      executeMcpTool(
+        "https://litellm.example.com",
+        "sk-test",
+        "brave",
+        "search",
+        { query: "pi" },
+        { "X-Team": "agent" },
+      ),
     ).resolves.toBe(JSON.stringify({ content: [{ type: "text", text: "found" }] }, null, 2));
 
     expect(fetchMock).toHaveBeenCalledWith(

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -106,6 +106,29 @@ describe("executeMcpTool", () => {
       }),
     );
   });
+
+  it("retries retryable HTTP failures once", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(503, { error: "busy" }))
+      .mockResolvedValueOnce(jsonResponse(200, { result: "ok" }));
+
+    await expect(
+      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }),
+    ).resolves.toBe(JSON.stringify("ok", null, 2));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry non-retryable HTTP failures", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(401, { error: "nope" }));
+
+    await expect(
+      executeMcpTool("https://litellm.example.com", "sk-test", "brave", "search", { query: "pi" }),
+    ).resolves.toBe("Error calling search on brave: HTTP 401");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("createMcpToolDefinitions", () => {
@@ -134,6 +157,7 @@ describe("createMcpToolDefinitions", () => {
     const definitions = await createMcpToolDefinitions("https://litellm.example.com", async () => "sk-test");
 
     expect(definitions.map((tool) => tool.name)).toEqual(["mcp_brave_api_web_search"]);
+    expect(definitions[0]?.executionMode).toBe("parallel");
     expect(definitions[0]?.description).toBe("Search the web (via Brave API MCP server)");
     const parameters = definitions[0]?.parameters as { required?: string[]; properties?: Record<string, unknown> };
     expect(parameters.required).toEqual(["query"]);

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -37,11 +37,18 @@ describe("listSkills", () => {
 
   it("includes legacy skills when the LiteLLM Skill Hub marketplace is available", async () => {
     vi.spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse(200, { plugins: [{ name: "hub" }] }))
-      .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "skill-1", name: "legacy" }] }));
+      .mockResolvedValueOnce(jsonResponse(200, { plugins: [{ name: "hub", description: "Hub guidance" }] }))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          data: [
+            { id: "duplicate", name: "hub", description: "Legacy guidance" },
+            { id: "skill-1", name: "legacy" },
+          ],
+        }),
+      );
 
     await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual([
-      { name: "hub" },
+      { name: "hub", description: "Hub guidance" },
       { id: "skill-1", name: "legacy" },
     ]);
   });

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -44,15 +44,26 @@ describe("listSkills", () => {
     await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
   });
 
-  it("does not fall back to the LiteLLM Skills Gateway when Skill Hub returns a non-404 error", async () => {
+  it("falls back when the LiteLLM Skill Hub returns a server error", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(jsonResponse(500, { error: "skill hub unavailable" }))
       .mockResolvedValueOnce(jsonResponse(200, { data: [{ name: "legacy" }] }));
 
-    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual([]);
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual([{ name: "legacy" }]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back when the LiteLLM Skill Hub request fails", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new DOMException("Timed out", "TimeoutError"))
+      .mockResolvedValueOnce(jsonResponse(200, { data: [{ name: "legacy" }] }));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual([{ name: "legacy" }]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("returns skills from the LiteLLM Skills Gateway", async () => {

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -1,6 +1,7 @@
 import type { Static, TSchema } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  createSkill,
   createSkillsPromptSection,
   createSkillToolDefinitions,
   deleteSkill,
@@ -22,6 +23,27 @@ afterEach(() => {
 });
 
 describe("listSkills", () => {
+  it("returns skills from the LiteLLM Skill Hub marketplace", async () => {
+    const skills: LiteLLMSkill[] = [{ name: "terraform", description: "Terraform conventions", enabled: true }];
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { plugins: skills }));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/claude-code/marketplace.json",
+      expect.objectContaining({ headers: expect.objectContaining({ Accept: "application/json" }) }),
+    );
+  });
+
+  it("falls back to the LiteLLM Skills Gateway list endpoint", async () => {
+    const skills: LiteLLMSkill[] = [{ id: "skill-1", name: "terraform", description: "Terraform conventions" }];
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(200, { data: skills }));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
+  });
+
   it("returns skills from the LiteLLM Skills Gateway", async () => {
     const skills: LiteLLMSkill[] = [
       { id: "skill-1", name: "terraform", description: "Terraform conventions", enabled: true },
@@ -43,12 +65,63 @@ describe("listSkills", () => {
 });
 
 describe("skill helpers", () => {
+  it("creates skills through the LiteLLM Skill Hub plugins endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { name: "terraform" }));
+
+    await expect(
+      createSkill("https://litellm.example.com", "sk-test", {
+        name: "terraform",
+        description: "Terraform conventions",
+        source: { type: "git", url: "https://github.com/acme/skills.git" },
+      }),
+    ).resolves.toEqual({ name: "terraform" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/claude-code/plugins",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("falls back to creating skills through the LiteLLM Skills Gateway", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(jsonResponse(200, { id: "skill-1" }));
+
+    await expect(
+      createSkill("https://litellm.example.com", "sk-test", {
+        name: "terraform",
+        description: "Terraform conventions",
+        code: "Use Terraform conventions.",
+      }),
+    ).resolves.toEqual({ id: "skill-1" });
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://litellm.example.com/v1/skills",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
   it("deletes skills by id", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
 
     await expect(deleteSkill("https://litellm.example.com", "sk-test", "skill-1")).resolves.toBeUndefined();
 
     expect(fetchMock).toHaveBeenCalledWith(
+      "https://litellm.example.com/claude-code/plugins/skill-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("falls back to deleting skills through the LiteLLM Skills Gateway", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(404, {}))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(deleteSkill("https://litellm.example.com", "sk-test", "skill-1")).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenLastCalledWith(
       "https://litellm.example.com/v1/skills/skill-1",
       expect.objectContaining({ method: "DELETE" }),
     );

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -93,11 +93,8 @@ describe("skill helpers", () => {
     );
   });
 
-  it("falls back to creating skills through the LiteLLM Skills Gateway", async () => {
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(jsonResponse(404, {}))
-      .mockResolvedValueOnce(jsonResponse(200, { id: "skill-1" }));
+  it("creates legacy skills through the LiteLLM Skills Gateway", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { id: "skill-1" }));
 
     await expect(
       createSkill("https://litellm.example.com", "sk-test", {
@@ -107,7 +104,8 @@ describe("skill helpers", () => {
       }),
     ).resolves.toEqual({ id: "skill-1" });
 
-    expect(fetchMock).toHaveBeenLastCalledWith(
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
       "https://litellm.example.com/v1/skills",
       expect.objectContaining({ method: "POST" }),
     );

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -164,4 +164,32 @@ describe("createSkillToolDefinitions", () => {
     expect(result?.content[0]).toMatchObject({ type: "text", text: expect.stringContaining("terraform") });
     expect(getApiKey).toHaveBeenCalledOnce();
   });
+
+  it("executes the create tool with Skill Hub source metadata", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { name: "terraform" }));
+    const getApiKey = vi.fn().mockResolvedValue("fresh-token");
+    const [, createTool] = createSkillToolDefinitions("https://litellm.example.com", getApiKey);
+    type Params = Static<TSchema>;
+
+    const result = await createTool?.execute(
+      "call-1",
+      {
+        name: "terraform",
+        description: "Terraform conventions",
+        sourceJson: JSON.stringify({ type: "git", url: "https://github.com/acme/skills.git" }),
+      } as Params,
+      undefined,
+      undefined,
+      {} as never,
+    );
+
+    expect(result?.content).toEqual([{ type: "text", text: "LiteLLM skill created." }]);
+    expect(getApiKey).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string);
+    expect(body).toEqual({
+      name: "terraform",
+      description: "Terraform conventions",
+      source: { type: "git", url: "https://github.com/acme/skills.git" },
+    });
+  });
 });

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -44,6 +44,17 @@ describe("listSkills", () => {
     await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
   });
 
+  it("does not fall back to the LiteLLM Skills Gateway when Skill Hub returns a non-404 error", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(500, { error: "skill hub unavailable" }))
+      .mockResolvedValueOnce(jsonResponse(200, { data: [{ name: "legacy" }] }));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual([]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("returns skills from the LiteLLM Skills Gateway", async () => {
     const skills: LiteLLMSkill[] = [
       { id: "skill-1", name: "terraform", description: "Terraform conventions", enabled: true },

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -35,6 +35,17 @@ describe("listSkills", () => {
     );
   });
 
+  it("includes legacy skills when the LiteLLM Skill Hub marketplace is available", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(200, { plugins: [{ name: "hub" }] }))
+      .mockResolvedValueOnce(jsonResponse(200, { data: [{ id: "skill-1", name: "legacy" }] }));
+
+    await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual([
+      { name: "hub" },
+      { id: "skill-1", name: "legacy" },
+    ]);
+  });
+
   it("falls back to the LiteLLM Skills Gateway list endpoint", async () => {
     const skills: LiteLLMSkill[] = [{ id: "skill-1", name: "terraform", description: "Terraform conventions" }];
     vi.spyOn(globalThis, "fetch")
@@ -82,7 +93,7 @@ describe("listSkills", () => {
     await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
     await expect(listSkills("https://litellm.example.com", "sk-test")).resolves.toEqual(skills);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -154,6 +154,28 @@ describe("skill helpers", () => {
     );
   });
 
+  it("falls back when the LiteLLM Skill Hub delete returns a server error", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(500, { error: "skill hub unavailable" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(deleteSkill("https://litellm.example.com", "sk-test", "skill-1")).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back when the LiteLLM Skill Hub delete request fails", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new DOMException("Timed out", "TimeoutError"))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    await expect(deleteSkill("https://litellm.example.com", "sk-test", "skill-1")).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("formats enabled skills as a system-prompt section", () => {
     const section = createSkillsPromptSection([
       { id: "enabled", name: "terraform", description: "Terraform conventions", enabled: true },

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -88,7 +88,10 @@ describe("listSkills", () => {
 
 describe("skill helpers", () => {
   it("creates skills through the LiteLLM Skill Hub plugins endpoint", async () => {
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { name: "terraform" }));
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(200, { name: "terraform" }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
 
     await expect(
       createSkill("https://litellm.example.com", "sk-test", {
@@ -100,6 +103,10 @@ describe("skill helpers", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://litellm.example.com/claude-code/plugins",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "https://litellm.example.com/claude-code/plugins/terraform/enable",
       expect.objectContaining({ method: "POST" }),
     );
   });

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -105,6 +105,16 @@ describe("listSkills", () => {
 });
 
 describe("skill helpers", () => {
+  it("rejects legacy skills without code", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(createSkill("https://litellm.example.com", "sk-test", { name: "terraform" })).rejects.toThrow(
+      "code is required when source is omitted",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("creates skills through the LiteLLM Skill Hub plugins endpoint", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -187,6 +187,16 @@ describe("skill helpers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("reports the Skill Hub failure when the legacy delete finds nothing", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(500, { error: "skill hub unavailable" }))
+      .mockResolvedValueOnce(jsonResponse(404, {}));
+
+    await expect(deleteSkill("https://litellm.example.com", "sk-test", "skill-1")).rejects.toThrow(
+      "LiteLLM skill delete failed: HTTP 500",
+    );
+  });
+
   it("formats enabled skills as a system-prompt section", () => {
     const section = createSkillsPromptSection([
       { id: "enabled", name: "terraform", description: "Terraform conventions", enabled: true },


### PR DESCRIPTION
## Summary
- add LiteLLM Responses API model routing for response/responses modes
- add MCP parallel execution plus one retry for retryable HTTP/transport failures
- add Skill Hub list/create/delete support with 404-only /v1/skills fallback
- update Biome config schema to 2.5.1 and replace deprecated recommended setting

## Verification
- npm run check

Thanks @peixotorms for these 🙇 