### PR TITLE
fix: eliminate duplicated or inconsistent model list after sync

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -368,6 +368,15 @@ async function discoverFromHealth(
   return models.filter((model): model is ProviderModelConfig => model !== undefined);
 }
 
+function deduplicateModels(models: ProviderModelConfig[]): ProviderModelConfig[] {
+  const seen = new Set<string>();
+  return models.filter((m) => {
+    if (seen.has(m.id)) return false;
+    seen.add(m.id);
+    return true;
+  });
+}
+
 export async function discoverModels(
   baseUrl: string,
   apiKey: string,
@@ -379,7 +388,7 @@ export async function discoverModels(
     const models = (infoResult.data.data ?? [])
       .map(mapFromModelInfo)
       .filter((m): m is ProviderModelConfig => m !== undefined);
-    return { source: "model_info", models };
+    return { source: "model_info", models: deduplicateModels(models) };
   }
   if (![401, 403, 404].includes(infoResult.status)) {
     throw new Error(`/model/info returned ${infoResult.status}`);
@@ -388,7 +397,7 @@ export async function discoverModels(
   if (!listResult.ok) {
     if ([401, 403, 404].includes(listResult.status)) {
       const models = await discoverFromHealth(base, apiKey, options);
-      if (models.length > 0) return { source: "health", models };
+      if (models.length > 0) return { source: "health", models: deduplicateModels(models) };
     }
     throw new Error(`/v1/models returned ${listResult.status}`);
   }
@@ -396,5 +405,5 @@ export async function discoverModels(
   const models = (listResult.data.data ?? [])
     .map((entry) => mapFromModelsList(entry, modelsDev))
     .filter((m): m is ProviderModelConfig => m !== undefined);
-  return { source: "models_list", models };
+  return { source: "models_list", models: deduplicateModels(models) };
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -385,10 +385,18 @@ export async function discoverModels(
   const base = normalizeBaseUrl(baseUrl);
   const infoResult = await fetchJson<ModelInfoResponse>(`${base}/model/info`, apiKey, options);
   if (infoResult.ok) {
-    const models = (infoResult.data.data ?? [])
-      .map(mapFromModelInfo)
-      .filter((m): m is ProviderModelConfig => m !== undefined);
-    return { source: "model_info", models: deduplicateModels(models) };
+    const entries = new Map<string, ModelInfoEntry>();
+    for (const entry of infoResult.data.data ?? []) {
+      if (!entry.model_name) continue;
+      const previous = entries.get(entry.model_name);
+      entries.set(entry.model_name, {
+        ...previous,
+        ...entry,
+        model_info: { ...previous?.model_info, ...entry.model_info },
+      });
+    }
+    const models = [...entries.values()].map(mapFromModelInfo).filter((m): m is ProviderModelConfig => m !== undefined);
+    return { source: "model_info", models };
   }
   if (![401, 403, 404].includes(infoResult.status)) {
     throw new Error(`/model/info returned ${infoResult.status}`);

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -197,6 +197,30 @@ describe("discoverModels via /model/info", () => {
     expect(result.source).toBe("model_info");
     expect(result.models[0]?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
   });
+
+  it("deduplicates models by id so that only the first occurrence of each unique ID is retained", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            { model_name: "openai/gpt-4o", model_info: { mode: "chat", max_input_tokens: 128000 } },
+            { model_name: "openai/gpt-4o", model_info: { mode: "chat", max_input_tokens: 8000 } },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("model_info");
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "openai/gpt-4o",
+      contextWindow: 128000,
+    });
+  });
 });
 
 describe("discoverModels response-mode models", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -198,14 +198,23 @@ describe("discoverModels via /model/info", () => {
     expect(result.models[0]?.cost).toEqual({ input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
   });
 
-  it("deduplicates models by id so that only the first occurrence of each unique ID is retained", async () => {
+  it("preserves richer metadata from later duplicate model ids", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = input instanceof URL ? input.toString() : String(input);
       if (url.endsWith("/model/info")) {
         return jsonResponse(200, {
           data: [
-            { model_name: "openai/gpt-4o", model_info: { mode: "chat", max_input_tokens: 128000 } },
-            { model_name: "openai/gpt-4o", model_info: { mode: "chat", max_input_tokens: 8000 } },
+            { model_name: "custom-model", model_info: { mode: "chat" } },
+            {
+              model_name: "custom-model",
+              model_info: {
+                mode: "chat",
+                max_input_tokens: 200000,
+                max_output_tokens: 8192,
+                input_cost_per_token: 0.000003,
+                output_cost_per_token: 0.000015,
+              },
+            },
           ],
         });
       }
@@ -217,8 +226,10 @@ describe("discoverModels via /model/info", () => {
     expect(result.source).toBe("model_info");
     expect(result.models).toHaveLength(1);
     expect(result.models[0]).toMatchObject({
-      id: "openai/gpt-4o",
-      contextWindow: 128000,
+      id: "custom-model",
+      contextWindow: 200000,
+      maxTokens: 8192,
+      cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
     });
   });
 });


### PR DESCRIPTION
Our LiteLLM instance might be returning same models when this extension tries to sync them from multiple paths. I guess it's strictly for compatibility reasons. This ends up in inconsistency and many duplicates models. Here is the `/litellm-refresh` command that I ran 3 times in a row:

<img width="742" height="127" alt="image" src="https://github.com/user-attachments/assets/b9dde7e3-625a-4c11-af73-96ff5401a31e" />
<img width="532" height="52" alt="image" src="https://github.com/user-attachments/assets/007a1748-fda1-4618-8d58-0b50110d02a1" />

<img width="532" height="52" alt="image" src="https://github.com/user-attachments/assets/9c71e0c3-fe54-45bc-8342-26630933ab27" />

We have maybe 30 models tops... This PR fixes the issue for me:

<img width="519" height="62" alt="image" src="https://github.com/user-attachments/assets/71e9e182-7212-44fd-9850-bcf971d2f94f" />
