### PR TITLE
perf: make cache-miss startup nonblocking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .idea/
 coverage/
 .pi/
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ dist/
 .idea/
 coverage/
 .pi/
-.worktrees/

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Provider fields:
 | `LITELLM_HEADERS` | unset | JSON object of extra headers sent to LiteLLM provider, discovery, MCP, and Skills Gateway requests. Provider aliases can use it with `"headers": "$LITELLM_HEADERS"`. |
 | `LITELLM_GCLOUD_TOKEN_AUTH` | unset | If set to a non-empty value other than `0`, use Google Application Default Credentials as the LiteLLM bearer token source. This takes precedence over `LITELLM_API_KEY_HELPER` and `LITELLM_API_KEY` when no stored `/login litellm` credential exists. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Google default ADC path | Optional path to an ADC JSON file used by `LITELLM_GCLOUD_TOKEN_AUTH`. If unset, the extension checks the default gcloud ADC locations. |
-| `LITELLM_OFFLINE` | unset | If `1`, disable automatic model discovery and use cached models only |
+| `LITELLM_OFFLINE` | unset | If `1`, disable all model and MCP discovery, including `/litellm-refresh` and post-login MCP discovery; use cached models only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` disables automatic and explicit refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ Provider fields:
 | `LITELLM_HEADERS` | unset | JSON object of extra headers sent to LiteLLM provider, discovery, MCP, and Skills Gateway requests. Provider aliases can use it with `"headers": "$LITELLM_HEADERS"`. |
 | `LITELLM_GCLOUD_TOKEN_AUTH` | unset | If set to a non-empty value other than `0`, use Google Application Default Credentials as the LiteLLM bearer token source. This takes precedence over `LITELLM_API_KEY_HELPER` and `LITELLM_API_KEY` when no stored `/login litellm` credential exists. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Google default ADC path | Optional path to an ADC JSON file used by `LITELLM_GCLOUD_TOKEN_AUTH`. If unset, the extension checks the default gcloud ADC locations. |
-| `LITELLM_OFFLINE` | unset | If `1`, skip discovery on this start; use cache only |
-| `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Discovery fetch timeout in ms; `0` to skip discovery |
+| `LITELLM_OFFLINE` | unset | If `1`, disable automatic model discovery and use cached models only |
+| `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
 
-`LITELLM_DISCOVERY_TIMEOUT_MS=0` only disables startup and refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
+`LITELLM_DISCOVERY_TIMEOUT_MS=0` disables automatic and explicit refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
 
 ### Google ADC token auth
 
@@ -157,7 +157,7 @@ If your LiteLLM proxy exposes MCP REST endpoints, this extension discovers tools
 - `GET /mcp-rest/tools/list`
 - `POST /mcp-rest/tools/call`
 
-Each discovered tool is registered as a native Pi tool named `mcp_<server>_<tool>`, with simple JSON Schema parameters mapped to Pi/TypeBox parameters. Complex schemas fall back to a single `args` object. MCP discovery runs after successful live model discovery, `/login litellm`, or `/litellm-refresh`; it does not force network or helper-token access when a fresh model cache is used. MCP tools run in Pi's parallel tool mode and retry transient failures once.
+Each discovered tool is registered as a native Pi tool named `mcp_<server>_<tool>`, with simple JSON Schema parameters mapped to Pi/TypeBox parameters. Complex schemas fall back to a single `args` object. MCP discovery runs after background model discovery, `/login litellm`, or `/litellm-refresh`; extension activation never waits for it. MCP tools run in Pi's parallel tool mode and retry transient failures once.
 
 ## LiteLLM Skill Hub
 
@@ -209,7 +209,7 @@ Before tagging a release, keep `package.json` and `package-lock.json` versions i
 
 The default provider model list is cached at `~/.pi/agent/litellm-models.json` with a keyed fingerprint of the base URL + API key. Alias provider caches use `~/.pi/agent/litellm-models-<provider>.json`. Changing the base URL or key invalidates that provider's cache automatically.
 
-If the cache is older than 24 hours, the extension refreshes it in the background on session start (non-blocking). Failures are silent — the cached models remain in use. Run `/litellm-refresh` to force an immediate refresh.
+When the cache is missing, invalid, or older than 24 hours, the extension starts without waiting for discovery and refreshes models in the background on session start. Existing cached models remain available while an invalid or stale cache refreshes. Failures are silent; run `/litellm-refresh` to force an immediate refresh and see its result.
 
 ## Troubleshooting
 

--- a/docs/superpowers/plans/2026-07-13-nonblocking-cache-miss.md
+++ b/docs/superpowers/plans/2026-07-13-nonblocking-cache-miss.md
@@ -1,0 +1,251 @@
+# Non-blocking Cache Miss Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep Pi activation responsive by moving cache-miss model and MCP discovery to the existing background refresh path.
+
+**Architecture:** Provider activation always registers available cached models without network access, while recording whether the cache needs immediate refresh. The existing `session_start` refresh path handles invalid or missing caches, and explicit discovery commands keep their synchronous behavior.
+
+**Tech Stack:** TypeScript ESM, Vitest, Pi extension API, Node.js `>=22.19.0`
+
+## Global Constraints
+
+- Do not add dependencies, environment variables, or cache-format fields.
+- Keep `--list-models`, `/login litellm`, and `/litellm-refresh` synchronous.
+- Keep activation-time MCP discovery non-blocking.
+- Do not edit generated `dist/` output by hand.
+- Commit locally only; never push.
+
+---
+
+### Task 1: Defer cache-miss discovery
+
+**Files:**
+- Modify: `src/index.ts:75-83,880-972,1085-1086,1088-1115,1225-1233`
+- Test: `tests/index.test.ts:221-330`
+
+**Interfaces:**
+- Consumes: existing `runRefresh(state: ProviderState): Promise<ProviderRefreshResult>` and `session_start` handler
+- Produces: `ProviderState.refreshOnStart: boolean`, cleared after a successful refresh
+
+- [ ] **Step 1: Write the failing startup test**
+
+Add this case under `describe("extension startup")`:
+
+```ts
+it("uses mismatched cached models until session-start refresh", async () => {
+  const agentDir = await makeAgentDir();
+  process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+  process.env.LITELLM_API_KEY = "new-key";
+  await writeFile(
+    join(agentDir, "litellm-models.json"),
+    JSON.stringify({
+      baseUrl: "https://litellm.example.com",
+      apiKeyFingerprint: fingerprint("old-key"),
+      fetchedAt: Date.now(),
+      source: "model_info",
+      models: cachedModels,
+    }),
+    "utf8",
+  );
+  const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/model/info")) {
+      return jsonResponse(200, {
+        data: [{ model_name: "fresh-model", model_info: { mode: "chat" } }],
+      });
+    }
+    if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+    throw new Error(`unexpected URL: ${url}`);
+  });
+  const extension = await loadExtension(agentDir);
+  const pi = createPi();
+
+  await extension(pi);
+
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(pi.providers[0]?.config.models).toEqual(cachedModels);
+
+  for (const handler of pi.handlers.get("session_start") ?? []) {
+    await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+  }
+  await vi.waitFor(() => {
+    expect((pi.providers.at(-1)?.config.models as Array<{ id: string }>)[0]?.id).toBe("fresh-model");
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+npm test -- tests/index.test.ts -t "uses mismatched cached models"
+```
+
+Expected: FAIL because activation calls `fetch` and registers freshly discovered models.
+
+- [ ] **Step 3: Implement stale-while-revalidate startup**
+
+Add the refresh flag to `ProviderState`:
+
+```ts
+type ProviderState = {
+  definition: ProviderDefinition;
+  creds: ResolvedCredentials;
+  headers?: Record<string, string>;
+  models: ProviderModelConfig[];
+  cacheFetchedAt: number;
+  refreshOnStart: boolean;
+  liveDiscoveryApiKey?: string;
+  refreshInProgress: Promise<ProviderRefreshResult> | null;
+};
+```
+
+In `loadProviderState`, retain any cached models and only perform synchronous discovery for `--list-models`:
+
+```ts
+let models: ProviderModelConfig[] = cache?.models ?? [];
+const canDiscover =
+  creds.baseUrl !== undefined && fp !== undefined && !isOffline() && getDiscoveryTimeoutMs() > 0;
+const shouldFetch = canDiscover && isListModelsMode();
+const refreshOnStart = canDiscover && !cacheValid && !shouldFetch;
+```
+
+Return `refreshOnStart` with the provider state:
+
+```ts
+return {
+  definition,
+  creds,
+  headers,
+  models,
+  cacheFetchedAt,
+  refreshOnStart,
+  liveDiscoveryApiKey,
+  refreshInProgress: null,
+};
+```
+
+Remove activation-time MCP discovery; background refresh, login, and explicit
+refresh already register MCP tools after successful model discovery:
+
+```ts
+registerSkillTools(defaultState);
+```
+
+Clear the immediate-refresh flag after successful discovery:
+
+```ts
+state.cacheFetchedAt = now;
+state.refreshOnStart = false;
+registerProvider(state, overridden, fresh.apiKeyConfig);
+```
+
+Let `session_start` refresh invalid caches as well as stale valid caches:
+
+```ts
+for (const state of providerStates) {
+  const cacheIsStale = state.cacheFetchedAt > 0 && Date.now() - state.cacheFetchedAt > CACHE_STALE_MS;
+  if (!state.refreshOnStart && !cacheIsStale) continue;
+  void runRefresh(state).catch(() => undefined);
+}
+```
+
+- [ ] **Step 4: Run the focused test**
+
+Run:
+
+```bash
+npm test -- tests/index.test.ts -t "uses mismatched cached models"
+```
+
+Expected: PASS with one test passing.
+
+- [ ] **Step 5: Run the complete startup test file**
+
+Run:
+
+```bash
+npm test -- tests/index.test.ts
+```
+
+Expected: PASS. Update assertions in existing startup-discovery cases only where they must trigger `session_start` before expecting background discovery.
+
+- [ ] **Step 6: Commit the behavior**
+
+```bash
+git status --short
+git add src/index.ts tests/index.test.ts
+git commit -S -m "perf: defer cache-miss discovery"
+```
+
+### Task 2: Document background cache-miss refresh
+
+**Files:**
+- Modify: `README.md:132-139,153-160,210-212`
+
+**Interfaces:**
+- Consumes: Task 1 startup behavior
+- Produces: user-facing cache and MCP discovery documentation
+
+- [ ] **Step 1: Update the cache behavior documentation**
+
+Replace the cache refresh paragraph with:
+
+```md
+When the cache is missing, invalid, or older than 24 hours, the extension starts without waiting for discovery and refreshes models in the background on session start. Existing cached models remain available while an invalid or stale cache refreshes. Failures are silent; run `/litellm-refresh` to force an immediate refresh and see its result.
+```
+
+Replace the two environment-variable rows and the following note with:
+
+```md
+| `LITELLM_OFFLINE` | unset | If `1`, disable automatic model discovery and use cached models only |
+| `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
+
+`LITELLM_DISCOVERY_TIMEOUT_MS=0` disables automatic and explicit refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
+```
+
+Replace the final sentence of the MCP discovery paragraph with:
+
+```md
+MCP discovery runs after background model discovery, `/login litellm`, or `/litellm-refresh`; extension activation never waits for it. MCP tools run in Pi's parallel tool mode and retry transient failures once.
+```
+
+- [ ] **Step 2: Verify documentation and full checks**
+
+Run:
+
+```bash
+git diff --check
+npm run check
+npm run clean && npm run build
+```
+
+Expected: all commands exit zero; Biome, typecheck, and all Vitest tests pass.
+
+- [ ] **Step 3: Benchmark the built extension**
+
+Run:
+
+```bash
+for i in {1..5}; do
+  /usr/bin/time -p /Users/hu901131/.bun/bin/pi --help --no-extensions >/dev/null
+done
+for i in {1..5}; do
+  /usr/bin/time -p env \
+    LITELLM_BASE_URL=https://10.255.255.1 \
+    LITELLM_API_KEY=benchmark-key \
+    /Users/hu901131/.bun/bin/pi --help --no-extensions -e "$PWD/dist/index.js" >/dev/null
+done
+```
+
+Expected: each isolated extension run remains near the fresh-cache timing and does not wait for the five-second discovery timeout.
+
+- [ ] **Step 4: Commit the documentation**
+
+```bash
+git status --short
+git add README.md
+git commit -S -m "docs: explain background model discovery"
+```

--- a/docs/superpowers/specs/2026-07-13-nonblocking-cache-miss-design.md
+++ b/docs/superpowers/specs/2026-07-13-nonblocking-cache-miss-design.md
@@ -1,0 +1,33 @@
+# Non-blocking Cache Miss Design
+
+## Goal
+
+Prevent LiteLLM model and MCP discovery from delaying Pi activation when the
+model cache is missing or invalid.
+
+## Design
+
+Activation registers each provider immediately from any available cached model
+metadata. A cache mismatch still marks the provider for refresh, but does not
+discard the cached models or wait for network access. If no cache exists, the
+provider starts with no models.
+
+After registration, cache-miss discovery runs in the background through the
+existing refresh path. A successful refresh replaces the provider models,
+updates costs and cache metadata, and discovers MCP tools. Failures leave the
+startup state intact and remain non-fatal.
+
+Commands whose purpose requires current discovery remain synchronous:
+`--list-models`, `/login litellm`, and `/litellm-refresh`.
+
+## Testing
+
+Add a startup regression test with a pending discovery request. Extension
+activation must complete and register cached models before that request is
+resolved. Existing tests continue to cover explicit refresh, login, helper
+execution, cache invalidation, and stale background refresh.
+
+## Scope
+
+This change does not optimize eager module imports, change discovery timeouts,
+add configuration, or alter the cache format.

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -42,7 +42,6 @@ type SmokeOAuthCredential = {
 };
 
 type SmokeProviderConfig = {
-  models?: unknown[];
   oauth?: {
     login: (callbacks: {
       onPrompt: (options: { message: string; placeholder?: string }) => Promise<string>;
@@ -55,11 +54,10 @@ type SmokeProviderConfig = {
 
 type SmokePi = {
   providers: Array<{ name: string; config: SmokeProviderConfig }>;
-  handlers: Map<string, Array<(event: unknown, ctx: unknown) => Promise<unknown> | unknown>>;
   registerProvider: (name: string, config: SmokeProviderConfig) => void;
   registerCommand: () => void;
   registerTool: () => void;
-  on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) => void;
+  on: () => void;
 };
 
 function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
@@ -198,24 +196,13 @@ async function expectAdminOnlyKeyGenerate(
 function createSmokePi(): SmokePi {
   return {
     providers: [],
-    handlers: new Map(),
     registerProvider(name, config) {
       this.providers.push({ name, config });
     },
     registerCommand: () => undefined,
     registerTool: () => undefined,
-    on(event, handler) {
-      this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
-    },
+    on: () => undefined,
   };
-}
-
-async function waitForProviderCount(pi: SmokePi, count: number, timeoutMs: number): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (pi.providers.length < count) {
-    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${count} provider registrations`);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
 }
 
 export async function runSsoLoginSmoke(
@@ -234,12 +221,6 @@ export async function runSsoLoginSmoke(
     const extension = (await import("../src/index.js")).default as unknown as (pi: SmokePi) => Promise<void>;
     const pi = createSmokePi();
     await extension(pi);
-    const providerCount = pi.providers.length;
-    const needsRefresh = !pi.providers.find((provider) => provider.name === "litellm")?.config.models?.length;
-    for (const handler of pi.handlers.get("session_start") ?? []) {
-      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
-    }
-    if (needsRefresh) await waitForProviderCount(pi, providerCount + 1, options.timeoutMs);
 
     const oauth = pi.providers.find((provider) => provider.name === "litellm")?.config.oauth;
     if (!oauth) throw new Error("LiteLLM provider did not expose OAuth login");

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -42,6 +42,7 @@ type SmokeOAuthCredential = {
 };
 
 type SmokeProviderConfig = {
+  models?: unknown[];
   oauth?: {
     login: (callbacks: {
       onPrompt: (options: { message: string; placeholder?: string }) => Promise<string>;
@@ -234,10 +235,11 @@ export async function runSsoLoginSmoke(
     const pi = createSmokePi();
     await extension(pi);
     const providerCount = pi.providers.length;
+    const needsRefresh = !pi.providers.find((provider) => provider.name === "litellm")?.config.models?.length;
     for (const handler of pi.handlers.get("session_start") ?? []) {
       await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
     }
-    await waitForProviderCount(pi, providerCount + 1, options.timeoutMs);
+    if (needsRefresh) await waitForProviderCount(pi, providerCount + 1, options.timeoutMs);
 
     const oauth = pi.providers.find((provider) => provider.name === "litellm")?.config.oauth;
     if (!oauth) throw new Error("LiteLLM provider did not expose OAuth login");

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -54,10 +54,11 @@ type SmokeProviderConfig = {
 
 type SmokePi = {
   providers: Array<{ name: string; config: SmokeProviderConfig }>;
+  handlers: Map<string, Array<(event: unknown, ctx: unknown) => Promise<unknown> | unknown>>;
   registerProvider: (name: string, config: SmokeProviderConfig) => void;
   registerCommand: () => void;
   registerTool: () => void;
-  on: () => void;
+  on: (event: string, handler: (event: unknown, ctx: unknown) => Promise<unknown> | unknown) => void;
 };
 
 function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
@@ -196,13 +197,24 @@ async function expectAdminOnlyKeyGenerate(
 function createSmokePi(): SmokePi {
   return {
     providers: [],
+    handlers: new Map(),
     registerProvider(name, config) {
       this.providers.push({ name, config });
     },
     registerCommand: () => undefined,
     registerTool: () => undefined,
-    on: () => undefined,
+    on(event, handler) {
+      this.handlers.set(event, [...(this.handlers.get(event) ?? []), handler]);
+    },
   };
+}
+
+async function waitForProviderCount(pi: SmokePi, count: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (pi.providers.length < count) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${count} provider registrations`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
 }
 
 export async function runSsoLoginSmoke(
@@ -212,11 +224,20 @@ export async function runSsoLoginSmoke(
 ): Promise<void> {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  const previousBaseUrl = process.env.LITELLM_BASE_URL;
+  const previousApiKey = process.env.LITELLM_API_KEY;
   process.env.PI_CODING_AGENT_DIR ??= await mkdtemp(join(tmpdir(), "pi-litellm-sso-smoke-"));
+  process.env.LITELLM_BASE_URL = baseUrl;
+  process.env.LITELLM_API_KEY = options.masterKey;
   try {
     const extension = (await import("../src/index.js")).default as unknown as (pi: SmokePi) => Promise<void>;
     const pi = createSmokePi();
     await extension(pi);
+    const providerCount = pi.providers.length;
+    for (const handler of pi.handlers.get("session_start") ?? []) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+    await waitForProviderCount(pi, providerCount + 1, options.timeoutMs);
 
     const oauth = pi.providers.find((provider) => provider.name === "litellm")?.config.oauth;
     if (!oauth) throw new Error("LiteLLM provider did not expose OAuth login");
@@ -245,6 +266,10 @@ export async function runSsoLoginSmoke(
   } finally {
     if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
     else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    if (previousBaseUrl === undefined) delete process.env.LITELLM_BASE_URL;
+    else process.env.LITELLM_BASE_URL = previousBaseUrl;
+    if (previousApiKey === undefined) delete process.env.LITELLM_API_KEY;
+    else process.env.LITELLM_API_KEY = previousApiKey;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ type ProviderState = {
   headers?: Record<string, string>;
   models: ProviderModelConfig[];
   cacheFetchedAt: number;
+  refreshOnStart: boolean;
   liveDiscoveryApiKey?: string;
   refreshInProgress: Promise<ProviderRefreshResult> | null;
 };
@@ -893,13 +894,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       cache.apiKeyFingerprint === fp &&
       cache.headersFingerprint === headersFp;
 
-    let models: ProviderModelConfig[] = cacheValid && cache ? cache.models : [];
-    const shouldFetch =
-      creds.baseUrl !== undefined &&
-      fp !== undefined &&
-      !isOffline() &&
-      getDiscoveryTimeoutMs() > 0 &&
-      (!cacheValid || isListModelsMode());
+    let models: ProviderModelConfig[] = cache?.models ?? [];
+    const canDiscover = creds.baseUrl !== undefined && fp !== undefined && !isOffline() && getDiscoveryTimeoutMs() > 0;
+    const shouldFetch = canDiscover && isListModelsMode();
+    const refreshOnStart = canDiscover && !cacheValid && !shouldFetch;
 
     let credentialWarning: string | undefined;
     let liveDiscoveryApiKey: string | undefined;
@@ -966,7 +964,16 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     // The cache keeps raw discovery output; overrides are applied freshly at each registration.
     models = await applyOverrides(definition.name, models);
 
-    return { definition, creds, headers, models, cacheFetchedAt, liveDiscoveryApiKey, refreshInProgress: null };
+    return {
+      definition,
+      creds,
+      headers,
+      models,
+      cacheFetchedAt,
+      refreshOnStart,
+      liveDiscoveryApiKey,
+      refreshInProgress: null,
+    };
   }
 
   const providerStates = await Promise.all(definitions.map(loadProviderState));
@@ -1083,7 +1090,6 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   }
 
   registerSkillTools(defaultState);
-  await registerMcpTools(defaultState);
 
   async function refreshModelsAndCosts(state: ProviderState): Promise<ProviderRefreshResult> {
     const fresh = await resolveCredentials(state.definition);
@@ -1109,6 +1115,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     state.models = overridden;
     state.liveDiscoveryApiKey = fresh.apiKey;
     state.cacheFetchedAt = now;
+    state.refreshOnStart = false;
     registerProvider(state, overridden, fresh.apiKeyConfig);
     updateAllCosts();
     if (state.definition.name === PROVIDER_NAME) await registerMcpTools(state);
@@ -1228,7 +1235,8 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
     if (discoveryDisabledReason()) return;
     for (const state of providerStates) {
-      if (!state.cacheFetchedAt || Date.now() - state.cacheFetchedAt <= CACHE_STALE_MS) continue;
+      const cacheIsStale = state.cacheFetchedAt > 0 && Date.now() - state.cacheFetchedAt > CACHE_STALE_MS;
+      if (!state.refreshOnStart && !cacheIsStale) continue;
       void runRefresh(state).catch(() => undefined);
     }
   });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -86,6 +86,14 @@ function createPi(): TestPi {
   };
 }
 
+async function startSession(pi: TestPi): Promise<void> {
+  const providerCount = pi.providers.length;
+  for (const handler of pi.handlers.get("session_start") ?? []) {
+    await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+  }
+  await vi.waitFor(() => expect(pi.providers.length).toBeGreaterThan(providerCount));
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
@@ -152,8 +160,9 @@ describe("feature parity", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
-    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
+    await vi.waitFor(() => expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search"));
   });
 
   it("injects enabled LiteLLM skills into the system prompt", async () => {
@@ -754,6 +763,7 @@ describe("feature parity", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     const responseHandler = pi.handlers.get("after_provider_response")?.[0];
     responseHandler?.(
@@ -808,11 +818,7 @@ describe("feature parity", () => {
     const pi = createPi();
     await extension(pi);
 
-    // Fire session_start handlers (no cache file exists → staleness check skipped)
-    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
-    for (const handler of sessionStartHandlers) {
-      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
-    }
+    await startSession(pi);
 
     // Get initial cost from model-based calculation
     const endHandler = pi.handlers.get("message_end")?.[0];

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -208,6 +208,14 @@ type TestPi = {
   on(event: string, handler: (event: any, ctx?: any) => Promise<any> | any): void;
 };
 
+async function startSession(pi: TestPi, refreshes = pi.providers.length): Promise<void> {
+  const providerCount = pi.providers.length;
+  for (const handler of pi.handlers.get("session_start") ?? []) {
+    await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+  }
+  await vi.waitFor(() => expect(pi.providers).toHaveLength(providerCount + refreshes));
+}
+
 afterEach(() => {
   for (const key of ENV_KEYS) {
     const original = ORIGINAL_ENV.get(key);
@@ -219,6 +227,47 @@ afterEach(() => {
 });
 
 describe("extension startup", () => {
+  it("uses mismatched cached models until session-start refresh", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "new-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fingerprint("old-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "fresh-model", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+
+    await extension(pi);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(pi.providers[0]?.config.models).toEqual(cachedModels);
+
+    for (const handler of pi.handlers.get("session_start") ?? []) {
+      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+    }
+    await vi.waitFor(() => {
+      expect((pi.providers.at(-1)?.config.models as Array<{ id: string }> | undefined)?.[0]?.id).toBe("fresh-model");
+    });
+  });
+
   it("registers the API key as an explicit environment reference", async () => {
     const agentDir = await makeAgentDir();
     const extension = await loadExtension(agentDir);
@@ -252,6 +301,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Failed to read ADC file"));
     expect(seenAuthHeaders).toEqual(["Bearer env-key"]);
@@ -295,15 +345,21 @@ describe("extension startup", () => {
     let extension = await loadExtension(agentDir);
     let pi = createPi();
     await extension(pi);
-    expect((pi.providers[0].config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["first-model"]);
+    await startSession(pi);
+    expect((pi.providers.at(-1)!.config.models as Array<{ id: string }>).map((model) => model.id)).toEqual([
+      "first-model",
+    ]);
 
     process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile(agentDir, "second-adc", "second-refresh");
     extension = await loadExtension(agentDir);
     pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     expect(seenModelAuthHeaders).toEqual(["Bearer first-token", "Bearer second-token"]);
-    expect((pi.providers[0].config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["second-model"]);
+    expect((pi.providers.at(-1)!.config.models as Array<{ id: string }>).map((model) => model.id)).toEqual([
+      "second-model",
+    ]);
   });
 
   it('treats literal "undefined" env values as unset', async () => {
@@ -344,8 +400,9 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
-    expect(pi.providers[0]?.config.models).toEqual([
+    expect(pi.providers.at(-1)?.config.models).toEqual([
       expect.objectContaining({ id: "llm-gateway/gpt-5.5", contextWindow: 272_000, maxTokens: 64_000 }),
     ]);
   });
@@ -546,7 +603,8 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
-    expect(pi.providers[0]?.config.models).toEqual([
+    await startSession(pi);
+    expect(pi.providers.at(-1)?.config.models).toEqual([
       expect.objectContaining({ id: "llm-gateway/gpt-5.5", contextWindow: 128_000 }),
     ]);
 
@@ -578,7 +636,9 @@ describe("extension startup", () => {
     });
 
     const extension = await loadExtension(agentDir);
-    await extension(createPi());
+    const pi = createPi();
+    await extension(pi);
+    await startSession(pi);
 
     expect(seenAuthHeaders).toEqual(["Bearer stored-key", "Bearer stored-key"]);
   });
@@ -632,8 +692,9 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
-    expect(pi.providers.map((provider) => provider.name)).toEqual(["litellm", "litellm-anthropic"]);
+    expect(pi.providers.slice(0, 2).map((provider) => provider.name)).toEqual(["litellm", "litellm-anthropic"]);
     expect(pi.providers[0]?.config).toMatchObject({
       baseUrl: "https://litellm.example.com/v1",
       apiKey: "$LITELLM_API_KEY",
@@ -644,10 +705,18 @@ describe("extension startup", () => {
       apiKey: "$LITELLM_ANTHROPIC_API_KEY",
       headers: { "x-litellm-customer-id": "anthropic-customer" },
     });
-    expect((pi.providers[0].config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["gpt-5"]);
-    expect((pi.providers[1].config.models as Array<{ id: string }>).map((model) => model.id)).toEqual([
-      "claude-sonnet",
-    ]);
+    expect(
+      (
+        pi.providers.filter((provider) => provider.name === "litellm").at(-1)!.config.models as Array<{ id: string }>
+      ).map((model) => model.id),
+    ).toEqual(["gpt-5"]);
+    expect(
+      (
+        pi.providers.filter((provider) => provider.name === "litellm-anthropic").at(-1)!.config.models as Array<{
+          id: string;
+        }>
+      ).map((model) => model.id),
+    ).toEqual(["claude-sonnet"]);
     // Providers load in parallel, so cross-provider request order is not deterministic.
     expect(seenModelInfoRequests).toHaveLength(2);
     expect(seenModelInfoRequests).toContainEqual({
@@ -711,6 +780,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     // Providers load in parallel, so cross-provider request order is not deterministic.
     expect(seenModelInfoRequests).toHaveLength(2);
@@ -1014,6 +1084,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     // Startup model and MCP discovery use the same fresh helper token (one helper invocation).
     expect(seenAuthHeaders).toEqual([`Bearer ${first}`, `Bearer ${first}`]);
@@ -1162,7 +1233,9 @@ describe("extension startup", () => {
     });
 
     const extension = await loadExtension(agentDir);
-    await extension(createPi());
+    const pi = createPi();
+    await extension(pi);
+    await startSession(pi);
 
     expect(seenAuthHeaders).toEqual([`Bearer ${fresh}`, `Bearer ${fresh}`]);
   });
@@ -1446,7 +1519,7 @@ describe("extension startup", () => {
 });
 
 describe("multi-provider hardening", () => {
-  it("registers remaining providers when one alias's credential helper fails at startup", async () => {
+  it("registers remaining providers when one alias's credential helper fails", async () => {
     const agentDir = await makeAgentDir();
     const failingHelper = join(agentDir, "broken-alias-helper.sh");
     await writeFile(failingHelper, "#!/usr/bin/env bash\nexit 42\n", { mode: 0o700 });
@@ -1474,16 +1547,14 @@ describe("multi-provider hardening", () => {
       if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
       throw new Error(`unexpected URL: ${url}`);
     });
-    const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi, 1);
 
-    expect(pi.providers.map((provider) => provider.name)).toEqual(["litellm", "litellm-anthropic"]);
-    expect((pi.providers[0].config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["gpt-5"]);
+    expect(pi.providers.slice(0, 2).map((provider) => provider.name)).toEqual(["litellm", "litellm-anthropic"]);
+    expect((pi.providers.at(-1)!.config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["gpt-5"]);
     expect(pi.providers[1]?.config.models).toEqual([]);
-    expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining("litellm-anthropic"));
   });
 
   it("does not register the default env key for an alias missing its apiKey", async () => {
@@ -1531,6 +1602,7 @@ describe("multi-provider hardening", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     expect(seenSecretHeaders).toEqual(["v$X"]);
     expect(pi.providers[0]?.config.headers).toEqual({ "x-secret": "v$$X", "x-bang": "$!not-a-command" });
@@ -1563,6 +1635,7 @@ describe("multi-provider hardening", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     expect(seenAuthHeaders).toEqual(["Bearer custom-key"]);
     expect(pi.providers[0]?.config.apiKey).toBe("$CUSTOM_LITELLM_KEY");
@@ -1605,6 +1678,7 @@ describe("multi-provider hardening", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi, 1);
 
     expect(seenAuthHeaders).toEqual(["Bearer stored-alias-key"]);
     expect(await readHelperCount(agentDir)).toBe(0);
@@ -1795,8 +1869,11 @@ describe("multi-provider hardening", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await startSession(pi);
 
     expect(seenRequests).toEqual([{ customer: "team-b" }]);
-    expect((pi.providers[0].config.models as Array<{ id: string }>).map((model) => model.id)).toEqual(["fresh-model"]);
+    expect((pi.providers.at(-1)!.config.models as Array<{ id: string }>).map((model) => model.id)).toEqual([
+      "fresh-model",
+    ]);
   });
 });

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -189,7 +189,7 @@ describe("runSsoLoginSmoke", () => {
     );
   });
 
-  it("uses a valid model cache without waiting for a background refresh", async () => {
+  it("uses a valid empty model cache without waiting for a background refresh", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-litellm-smoke-auth-"));
     await writeFile(
       join(agentDir, "litellm-models.json"),
@@ -198,7 +198,7 @@ describe("runSsoLoginSmoke", () => {
         apiKeyFingerprint: fingerprint("sk-master"),
         fetchedAt: Date.now(),
         source: "model_info",
-        models: [{ id: "vidaimock-openai", name: "vidaimock-openai", provider: "litellm" }],
+        models: [],
       }),
       "utf8",
     );

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runAuthSmoke, runAuthSmokeFromEnv } from "../scripts/smoke-auth.js";
+import { fingerprint } from "../src/cache.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -186,6 +187,55 @@ describe("runSsoLoginSmoke", () => {
         auth: "Bearer sk-sso-virtual",
       }),
     );
+  });
+
+  it("uses a valid model cache without waiting for a background refresh", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-litellm-smoke-auth-"));
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKeyFingerprint: fingerprint("sk-master"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: [{ id: "vidaimock-openai", name: "vidaimock-openai", provider: "litellm" }],
+      }),
+      "utf8",
+    );
+
+    vi.doMock("@earendil-works/pi-coding-agent", () => ({
+      AuthStorage: {
+        create: () => ({ getApiKey: async () => undefined }),
+      },
+      defineTool: (tool: unknown) => tool,
+      getAgentDir: () => agentDir,
+    }));
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      const auth = (init?.headers as Record<string, string> | undefined)?.Authorization;
+      if (url.endsWith("/key/generate")) {
+        expect(auth).toBe("Bearer sk-master");
+        return jsonResponse(200, { key: "sk-sso-virtual" });
+      }
+      if (url.endsWith("/model/info")) {
+        expect(auth).toBe("Bearer sk-sso-virtual");
+        return jsonResponse(200, { data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }] });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        expect(auth).toBe("Bearer sk-sso-virtual");
+        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const { runSsoLoginSmoke } = await import("../scripts/smoke-auth.js");
+    await runSsoLoginSmoke({
+      baseUrl: "http://127.0.0.1:4000",
+      masterKey: "sk-master",
+      modelId: "vidaimock-openai",
+      timeoutMs: 50,
+    });
   });
 });
 

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -126,7 +126,7 @@ describe("runAuthSmoke", () => {
         }),
       ]),
     );
-  });
+  }, 10_000);
 });
 
 describe("runSsoLoginSmoke", () => {


### PR DESCRIPTION
## Summary

- register cached LiteLLM models immediately during extension activation
- refresh missing, invalid, or stale caches in the background on session start
- keep explicit model discovery, login, and refresh operations synchronous
- prevent activation-time MCP discovery from blocking Pi

## Root cause

Cache misses performed model discovery during extension activation and then waited for MCP tool discovery. Those sequential network paths could consume the five-second model timeout plus the ten-second MCP timeout before Pi became usable.

## Impact

Pi now starts from cached metadata without waiting for LiteLLM network access. A missing cache registers the provider immediately and populates it through the existing background refresh path.

## Verification

- `mise exec node@24.10.0 -- npm run check` (184 tests)
- `mise exec node@24.10.0 -- npm run clean && mise exec node@24.10.0 -- npm run build`
- isolated cache-miss startup: 1.49-1.60 seconds without waiting for the five-second discovery timeout
- all branch commits verified with ED25519 signatures
