### PR TITLE
fix: accept null LiteLLM model modes

### DIFF
--- a/docs/superpowers/plans/2026-07-14-null-model-mode.md
+++ b/docs/superpowers/plans/2026-07-14-null-model-mode.md
@@ -1,0 +1,79 @@
+# Null Model Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep LiteLLM models whose `model_info.mode` is `null` available to Pi.
+
+**Architecture:** Extend the existing nullable response boundary and reuse the shared chat-style mode predicate. No new discovery path or configuration is needed.
+
+**Tech Stack:** TypeScript ESM, Vitest, Biome
+
+## Global Constraints
+
+- Treat `null` and `undefined` as an unset mode.
+- Keep explicit non-chat modes filtered.
+- Add no dependencies or new abstractions.
+
+---
+
+### Task 1: Accept nullable model modes
+
+**Files:**
+- Modify: `src/types.ts:28`
+- Modify: `src/discover.ts:48-53`
+- Test: `tests/discover.test.ts`
+
+**Interfaces:**
+- Consumes: LiteLLM `ModelInfoEntry.model_info.mode`
+- Produces: `mode?: string | null` and unchanged `discoverModels()` results containing unset-mode models
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `/model/info` discovery test that returns `{ model_name: "local/model", model_info: { mode: null } }` and expects `result.models.map((model) => model.id)` to equal `["local/model"]`.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `npm test -- tests/discover.test.ts -t "keeps models with a null mode"`
+
+Expected: FAIL because the returned model list is empty.
+
+- [ ] **Step 3: Implement the minimal fix**
+
+Change the response type to:
+
+```ts
+mode?: string | null;
+```
+
+Accept nullish values in the existing predicates:
+
+```ts
+function isResponsesMode(mode: string | null | undefined): boolean {
+  return mode != null && RESPONSES_MODE_PATTERN.test(mode);
+}
+
+function isChatStyleMode(mode: string | null | undefined): boolean {
+  return mode == null || mode === "chat" || isResponsesMode(mode);
+}
+```
+
+- [ ] **Step 4: Run verification**
+
+Run: `npm test -- tests/discover.test.ts`
+
+Expected: PASS.
+
+Run: `npm run check`
+
+Expected: PASS with no warnings.
+
+Run: `npm run clean && npm run build`
+
+Expected: PASS and a fresh `dist/` build.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types.ts src/discover.ts tests/discover.test.ts
+git commit -S -m "fix: accept null LiteLLM model modes"
+```

--- a/docs/superpowers/specs/2026-07-14-null-model-mode-design.md
+++ b/docs/superpowers/specs/2026-07-14-null-model-mode-design.md
@@ -1,0 +1,13 @@
+# Null Model Mode Design
+
+## Problem
+
+LiteLLM may return `model_info.mode: null` for local inference backends. Discovery currently treats only an omitted mode as unset, so these otherwise usable models are filtered out.
+
+## Design
+
+Treat `null` and `undefined` as the same unset value in the shared chat-style mode check. Update the response type to reflect LiteLLM's nullable field. Keep explicit non-chat modes, such as `embedding`, filtered.
+
+## Verification
+
+Add one discovery regression test that returns a model with `mode: null`, fails before the production change, and passes afterward. Run the focused discovery tests and the repository check.

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -45,12 +45,12 @@ export function normalizeBaseUrl(input: string): string {
 
 const RESPONSES_MODE_PATTERN = /^responses?$/i;
 
-function isResponsesMode(mode: string | undefined): boolean {
-  return mode !== undefined && RESPONSES_MODE_PATTERN.test(mode);
+function isResponsesMode(mode: string | null | undefined): boolean {
+  return mode != null && RESPONSES_MODE_PATTERN.test(mode);
 }
 
-function isChatStyleMode(mode: string | undefined): boolean {
-  return mode === undefined || mode === "chat" || isResponsesMode(mode);
+function isChatStyleMode(mode: string | null | undefined): boolean {
+  return mode == null || mode === "chat" || isResponsesMode(mode);
 }
 
 // Matches both the conventional `anthropic/...` prefix and aliases that

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface DiscoveryOptions {
 export interface ModelInfoEntry {
   model_name?: string;
   model_info?: {
-    mode?: string;
+    mode?: string | null;
     input_cost_per_token?: number;
     output_cost_per_token?: number;
     cache_read_input_token_cost?: number;

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -117,6 +117,18 @@ describe("shouldSuppressReasoningContent", () => {
 });
 
 describe("discoverModels via /model/info", () => {
+  it("keeps models with a null mode", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [{ model_name: "local/model", model_info: { mode: null } }],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models.map((model) => model.id)).toEqual(["local/model"]);
+  });
+
   it("parses a /model/info success response with cost mapping", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = input instanceof URL ? input.toString() : String(input);


### PR DESCRIPTION
## Summary

- treat `model_info.mode: null` like an unset chat-style mode
- reflect LiteLLM's nullable mode field in the response type
- add a regression test covering the public discovery flow

## Root cause

Discovery accepted only `undefined` as an unset mode, so LiteLLM models backed by local inference servers were filtered when `/model/info` returned `mode: null`.

## Testing

- `mise exec node@24.10.0 -- biome check --error-on-warnings src tests scripts`
- `mise exec node@24.10.0 -- npm run typecheck`
- `mise exec node@24.10.0 -- vitest --run --exclude '.worktrees/**'` (189 passed, 3 skipped)
- `mise exec node@24.10.0 -- npm run clean && npm run build`

Closes #79