### PR TITLE
feat: disable mcp and skills via settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,25 @@ Provider fields:
 
 `/login litellm` and Google ADC token auth remain scoped to the default `litellm` provider. Aliases use their configured `apiKey` or manually stored auth entries matching the alias name.
 
+### Optional LiteLLM features
+
+LiteLLM Skills and MCP integration are enabled by default. Disable either feature globally in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "litellm": {
+    "skills": {
+      "enabled": false
+    },
+    "mcp": {
+      "enabled": false
+    }
+  }
+}
+```
+
+Setting `skills.enabled` to `false` disables the Skills Gateway management tools, skill fetching, and system-prompt injection. Setting `mcp.enabled` to `false` disables LiteLLM MCP discovery and tool registration. Restart Pi after changing these settings so previously registered tools are removed.
+
 ## Use
 
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -574,8 +574,12 @@ function normalizeProviderSettings(raw: unknown): RawProviderSettings | undefine
   return record;
 }
 
-async function getProviderDefinitions(): Promise<ProviderDefinition[]> {
-  const settings = await readGlobalLiteLLMSettings();
+function isFeatureEnabled(settings: Record<string, unknown> | undefined, feature: "skills" | "mcp"): boolean {
+  const raw = settings?.[feature];
+  return !isPlainObject(raw) || raw.enabled !== false;
+}
+
+function getProviderDefinitions(settings: Record<string, unknown> | undefined): ProviderDefinition[] {
   const rawProviders = settings?.providers && typeof settings.providers === "object" ? settings.providers : undefined;
   const providerSettings = rawProviders as Record<string, unknown> | undefined;
   const defaultSettings = normalizeProviderSettings(providerSettings?.[PROVIDER_NAME]);
@@ -888,7 +892,10 @@ function normalizeThinkTags(
 }
 
 export default async function (pi: ExtensionAPI): Promise<void> {
-  const definitions = await getProviderDefinitions();
+  const settings = await readGlobalLiteLLMSettings();
+  const definitions = getProviderDefinitions(settings);
+  const skillsEnabled = isFeatureEnabled(settings, "skills");
+  const mcpEnabled = isFeatureEnabled(settings, "mcp");
   const providerNames = new Set(definitions.map((definition) => definition.name));
 
   function discoveryDisabledReason(): string | null {
@@ -1073,7 +1080,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   }
 
   function registerSkillTools(state = defaultState): void {
-    if (!state.creds.baseUrl) return;
+    if (!skillsEnabled || !state.creds.baseUrl) return;
     for (const tool of createSkillToolDefinitions(
       state.creds.baseUrl,
       () => resolveRuntimeApiKey(state),
@@ -1096,7 +1103,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   }
 
   async function registerMcpTools(state: ProviderState, onProgress?: ProgressCallback): Promise<void> {
-    if (!state.creds.baseUrl || !state.liveDiscoveryApiKey || discoveryDisabledReason()) return;
+    if (!mcpEnabled || !state.creds.baseUrl || !state.liveDiscoveryApiKey || discoveryDisabledReason()) return;
     try {
       const tools = await createMcpToolDefinitions(
         state.creds.baseUrl,
@@ -1251,7 +1258,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   });
 
   pi.on("before_agent_start", async (event) => {
-    if (discoveryDisabledReason()) return;
+    if (!skillsEnabled || discoveryDisabledReason()) return;
     const fresh = await resolveCredentials(defaultState.definition);
     if (!fresh.baseUrl || !fresh.apiKey) return;
     const skills = await listSkills(fresh.baseUrl, fresh.apiKey, defaultState.headers);

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -185,6 +185,51 @@ describe("feature parity", () => {
     expect(result.systemPrompt).toContain("Terraform conventions");
   });
 
+  it("disables LiteLLM skills through settings", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    await writeFile(
+      join(agentDir, "settings.json"),
+      JSON.stringify({ litellm: { skills: { enabled: false } } }),
+      "utf8",
+    );
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    expect(pi.tools.map((tool) => tool.name)).not.toContain("litellm_skill_list");
+    const beforeAgentStart = pi.handlers.get("before_agent_start")?.[0];
+    await expect(beforeAgentStart?.({ systemPrompt: "Base prompt" }, {})).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("disables LiteLLM MCP discovery through settings", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    await writeFile(join(agentDir, "settings.json"), JSON.stringify({ litellm: { mcp: { enabled: false } } }), "utf8");
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    const requestedUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/model/info")) return jsonResponse(200, { data: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    await startSession(pi);
+
+    expect(requestedUrls).toEqual(["https://litellm.example.com/model/info"]);
+    expect(pi.tools.map((tool) => tool.name)).toContain("litellm_skill_list");
+    expect(pi.tools.some((tool) => tool.name.startsWith("mcp_"))).toBe(false);
+  });
+
   it("registers cost tracking and session grouping handlers", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";


### PR DESCRIPTION
This PR adds options to toggle the Skills and MCP integrations by LiteLLM, to prevent unnecessary tool definition context injected by the plugin. 

## Validation

```bash
npm run check
```