### PR TITLE
feat: silent discovery by default (LITELLM_VERBOSE_DISCOVERY)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Setting `skills.enabled` to `false` disables the Skills Gateway management tools
 | `GOOGLE_APPLICATION_CREDENTIALS` | Google default ADC path | Optional path to an ADC JSON file used by `LITELLM_GCLOUD_TOKEN_AUTH`. If unset, the extension checks the default gcloud ADC locations. |
 | `LITELLM_OFFLINE` | unset | If `1`, disable all model and MCP discovery, including `/litellm-refresh` and post-login MCP discovery; use cached models only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
+| `LITELLM_VERBOSE_DISCOVERY` | unset | If `1`, enable progress messages during model and MCP discovery (login, refresh, startup); discovery is silent by default |
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` disables automatic and explicit refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -350,13 +350,14 @@ function mapFromModelsList(
 async function discoverFromHealth(
   base: string,
   apiKey: string,
-  options: DiscoveryOptions & { onProgress?: (message: string) => void },
+  options: DiscoveryOptions & { onProgress?: (message: string) => void; silent?: boolean },
 ): Promise<ProviderModelConfig[]> {
-  options.onProgress?.("Querying /health endpoint...");
+  const progress = options.silent ? undefined : options.onProgress;
+  progress?.("Querying /health endpoint...");
   const healthResult = await fetchJson<HealthResponse>(`${base}/health`, apiKey, options);
   if (!healthResult.ok) return [];
   const endpoints = (healthResult.data.healthy_endpoints ?? []).filter((entry) => entry.model || entry.model_id);
-  options.onProgress?.(`Discovered ${endpoints.length} model endpoints, fetching details...`);
+  progress?.(`Discovered ${endpoints.length} model endpoints, fetching details...`);
   let completed = 0;
   const models = await Promise.all(
     endpoints.map(async (endpoint) => {
@@ -372,7 +373,7 @@ async function discoverFromHealth(
       }
       completed++;
       if (completed % 10 === 0 || completed === endpoints.length) {
-        options.onProgress?.(`Fetched ${completed}/${endpoints.length} models...`);
+        progress?.(`Fetched ${completed}/${endpoints.length} models...`);
       }
       return model;
     }),
@@ -392,10 +393,11 @@ function deduplicateModels(models: ProviderModelConfig[]): ProviderModelConfig[]
 export async function discoverModels(
   baseUrl: string,
   apiKey: string,
-  options: DiscoveryOptions & { onProgress?: (message: string) => void } = {},
+  options: DiscoveryOptions & { onProgress?: (message: string) => void; silent?: boolean } = {},
 ): Promise<DiscoveryResult> {
   const base = normalizeBaseUrl(baseUrl);
-  options.onProgress?.("Querying /model/info endpoint...");
+  const progress = options.silent ? undefined : options.onProgress;
+  progress?.("Querying /model/info endpoint...");
   const infoResult = await fetchJson<ModelInfoResponse>(`${base}/model/info`, apiKey, options);
   if (infoResult.ok) {
     const entries = new Map<string, ModelInfoEntry>();
@@ -414,17 +416,17 @@ export async function discoverModels(
   if (![401, 403, 404].includes(infoResult.status)) {
     throw new Error(`/model/info returned ${infoResult.status}`);
   }
-  options.onProgress?.("/model/info unavailable, trying /v1/models...");
+  progress?.("/model/info unavailable, trying /v1/models...");
   const listResult = await fetchJson<ModelsListResponse>(`${base}/v1/models`, apiKey, options);
   if (!listResult.ok) {
     if ([401, 403, 404].includes(listResult.status)) {
-      options.onProgress?.("/v1/models unavailable, falling back to /health endpoint...");
+      progress?.("/v1/models unavailable, falling back to /health endpoint...");
       const models = await discoverFromHealth(base, apiKey, options);
       if (models.length > 0) return { source: "health", models: deduplicateModels(models) };
     }
     throw new Error(`/v1/models returned ${listResult.status}`);
   }
-  options.onProgress?.("Fetching models.dev catalog for metadata enrichment...");
+  progress?.("Fetching models.dev catalog for metadata enrichment...");
   const modelsDev = await getModelsDevCatalog(options);
   const models = (listResult.data.data ?? [])
     .map((entry) => mapFromModelsList(entry, modelsDev))

--- a/src/index.ts
+++ b/src/index.ts
@@ -1210,7 +1210,11 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         statesToRefresh.map((state) =>
           runRefresh(
             state,
-            isVerboseDiscovery() ? (ctx.ui?.notify ? (message) => ctx.ui.notify(message, "info") : undefined) : undefined,
+            isVerboseDiscovery()
+              ? ctx.ui?.notify
+                ? (message) => ctx.ui.notify(message, "info")
+                : undefined
+              : undefined,
           ),
         ),
       );
@@ -1258,9 +1262,8 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     for (const state of providerStates) {
       const cacheIsStale = state.cacheFetchedAt > 0 && Date.now() - state.cacheFetchedAt > CACHE_STALE_MS;
       if (!state.refreshOnStart && !cacheIsStale) continue;
-      const progress = isVerboseDiscovery() && ctx.ui?.notify
-        ? (message: string) => ctx.ui.notify(message, "info")
-        : undefined;
+      const progress =
+        isVerboseDiscovery() && ctx.ui?.notify ? (message: string) => ctx.ui.notify(message, "info") : undefined;
       void runRefresh(state, progress).catch(() => undefined);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ const ENV_API_KEY_HELPER = "LITELLM_API_KEY_HELPER";
 const ENV_HEADERS = "LITELLM_HEADERS";
 const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
 const ENV_OFFLINE = "LITELLM_OFFLINE";
+const ENV_VERBOSE_DISCOVERY = "LITELLM_VERBOSE_DISCOVERY";
 const DEFAULT_TIMEOUT_MS = 5000;
 const LOGIN_TIMEOUT_MS = 10_000;
 const CACHE_FILENAME = "litellm-models.json";
@@ -563,6 +564,10 @@ function isOffline(): boolean {
   return process.env[ENV_OFFLINE] === "1";
 }
 
+function isVerboseDiscovery(): boolean {
+  return process.env[ENV_VERBOSE_DISCOVERY] === "1";
+}
+
 function isListModelsMode(): boolean {
   return process.argv.includes("--list-models");
 }
@@ -625,7 +630,7 @@ function getProviderDefinitions(settings: Record<string, unknown> | undefined): 
 async function discoverWithFallback(
   baseUrl: string,
   apiKey: string,
-  options: DiscoveryOptions & { onProgress?: (message: string) => void },
+  options: DiscoveryOptions & { onProgress?: (message: string) => void; silent?: boolean },
 ): Promise<{ result: DiscoveryResult; warning?: string }> {
   try {
     return { result: await discoverModels(baseUrl, apiKey, options) };
@@ -717,6 +722,7 @@ async function loginLiteLLM(
     timeoutMs: LOGIN_TIMEOUT_MS,
     signal: callbacks.signal,
     headers: options.headers,
+    silent: !isVerboseDiscovery(),
     onProgress: (message) => callbacks.onProgress?.(`LiteLLM: ${message}`),
   });
 
@@ -730,7 +736,9 @@ async function loginLiteLLM(
   };
   await writeCache(options.cachePath, cache);
   await options.onCacheWrite?.(cache);
-  callbacks.onProgress?.(`LiteLLM: ${models.length} models discovered (source: ${source})`);
+  if (isVerboseDiscovery()) {
+    callbacks.onProgress?.(`LiteLLM: ${models.length} models discovered (source: ${source})`);
+  }
 
   return {
     access: apiKey,
@@ -955,6 +963,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       const { result, warning } = await discoverWithFallback(creds.baseUrl, creds.apiKey, {
         timeoutMs,
         headers,
+        silent: !isVerboseDiscovery(),
         onProgress: (message) => process.stderr.write(`LiteLLM: ${message}\n`),
       });
       if (warning) {
@@ -1109,8 +1118,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         state.creds.baseUrl,
         seededRuntimeApiKey(state, state.liveDiscoveryApiKey),
         state.headers,
-        (message) =>
-          onProgress ? onProgress(`LiteLLM MCP: ${message}`) : process.stderr.write(`LiteLLM MCP: ${message}\n`),
+        isVerboseDiscovery()
+          ? (message) =>
+              onProgress ? onProgress(`LiteLLM MCP: ${message}`) : process.stderr.write(`LiteLLM MCP: ${message}\n`)
+          : undefined,
       );
       for (const tool of tools) {
         pi.registerTool(tool);
@@ -1142,6 +1153,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       timeoutMs: getDiscoveryTimeoutMs(),
       signal,
       headers: state.headers,
+      silent: !isVerboseDiscovery(),
       onProgress: progress,
     });
     signal?.throwIfAborted();
@@ -1195,7 +1207,12 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         return;
       }
       const settled = await Promise.allSettled(
-        statesToRefresh.map((state) => runRefresh(state, (message) => ctx.ui.notify(message, "info"))),
+        statesToRefresh.map((state) =>
+          runRefresh(
+            state,
+            isVerboseDiscovery() ? (ctx.ui?.notify ? (message) => ctx.ui.notify(message, "info") : undefined) : undefined,
+          ),
+        ),
       );
       const succeeded = settled.filter((result) => result.status === "fulfilled").map((result) => result.value);
       const failed = settled
@@ -1241,7 +1258,9 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     for (const state of providerStates) {
       const cacheIsStale = state.cacheFetchedAt > 0 && Date.now() - state.cacheFetchedAt > CACHE_STALE_MS;
       if (!state.refreshOnStart && !cacheIsStale) continue;
-      const progress = ctx.ui?.notify ? (message: string) => ctx.ui.notify(message, "info") : undefined;
+      const progress = isVerboseDiscovery() && ctx.ui?.notify
+        ? (message: string) => ctx.ui.notify(message, "info")
+        : undefined;
       void runRefresh(state, progress).catch(() => undefined);
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1055,7 +1055,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         if (!state.refreshOnStart && cacheIsFresh && !state.refreshInProgress && !force && !credentialChanged) {
           const registerTools =
             state.definition.name === PROVIDER_NAME && !state.mcpRegistered
-              ? registerMcpTools(state)
+              ? registerMcpTools(state, undefined, signal, supplied?.apiKey)
               : Promise.resolve();
           return registerTools.then(() => state.models);
         }
@@ -1070,6 +1070,13 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       cachePath: getCachePath(PROVIDER_NAME),
       headers: defaultState.headers,
       onCacheWrite: async (next) => {
+        if (
+          next.baseUrl !== defaultState.creds.baseUrl ||
+          next.apiKeyFingerprint !== defaultState.creds.apiKeyFingerprint
+        ) {
+          defaultState.mcpRegistered = false;
+          defaultState.liveDiscoveryApiKey = undefined;
+        }
         defaultState.cacheFetchedAt = next.fetchedAt;
         const overridden = await applyOverrides(PROVIDER_NAME, next.models);
         defaultState.models = overridden;
@@ -1126,11 +1133,21 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     };
   }
 
-  async function registerMcpTools(state: ProviderState, onProgress?: ProgressCallback): Promise<void> {
+  async function registerMcpTools(
+    state: ProviderState,
+    onProgress?: ProgressCallback,
+    signal?: AbortSignal,
+    suppliedApiKey?: string,
+  ): Promise<void> {
     if (!mcpEnabled || !state.creds.baseUrl || discoveryDisabledReason()) return;
-    const apiKey = state.liveDiscoveryApiKey ?? (await resolveCredentials(state.definition)).apiKey;
-    if (!apiKey) return;
     try {
+      signal?.throwIfAborted();
+      state.mcpRegistered = true;
+      const apiKey = suppliedApiKey ?? state.liveDiscoveryApiKey ?? (await resolveCredentials(state.definition)).apiKey;
+      if (!apiKey) {
+        state.mcpRegistered = false;
+        return;
+      }
       const tools = await createMcpToolDefinitions(
         state.creds.baseUrl,
         seededRuntimeApiKey(state, apiKey),
@@ -1139,12 +1156,15 @@ export default async function (pi: ExtensionAPI): Promise<void> {
           ? (message) =>
               onProgress ? onProgress(`LiteLLM MCP: ${message}`) : process.stderr.write(`LiteLLM MCP: ${message}\n`)
           : undefined,
+        signal,
       );
+      signal?.throwIfAborted();
       for (const tool of tools) {
         pi.registerTool(tool);
       }
-      state.mcpRegistered = true;
     } catch (error) {
+      state.mcpRegistered = false;
+      if (signal?.aborted) throw signal.reason;
       process.stderr.write(
         `LiteLLM (${state.definition.name}): MCP tool discovery failed (${error instanceof Error ? error.message : String(error)}).\n`,
       );
@@ -1194,7 +1214,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     state.refreshOnStart = false;
     registerProvider(state, overridden, fresh.apiKeyConfig);
     updateAllCosts();
-    if (state.definition.name === PROVIDER_NAME) await registerMcpTools(state, onProgress);
+    if (state.definition.name === PROVIDER_NAME) await registerMcpTools(state, onProgress, signal);
     return { providerName: state.definition.name, models: overridden, source: result.source };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,21 +89,23 @@ type ProviderState = {
   cacheFetchedAt: number;
   refreshOnStart: boolean;
   liveDiscoveryApiKey?: string;
+  mcpRegistered: boolean;
   refreshInProgress: Promise<ProviderRefreshResult> | null;
 };
 
-function credentialsFromRefresh(state: ProviderState, credential: Credential): ResolvedCredentials {
+async function credentialsFromRefresh(state: ProviderState, credential: Credential): Promise<ResolvedCredentials> {
+  const current = await resolveCredentials(state.definition, { executeHelpers: false });
   const apiKey = credential.type === "oauth" ? credential.access : credential.key;
   const credentialBaseUrl = credential.type === "oauth" ? credential.baseUrl : undefined;
   const fingerprintSource =
-    credential.type === "api_key" && state.creds.apiKeyConfig?.startsWith("!")
-      ? state.creds.apiKeyConfig
+    credential.type === "api_key" && current.apiKeyConfig?.startsWith("!")
+      ? current.apiKeyConfig
       : credential.type === "oauth" && credential.refresh.startsWith("!")
         ? credential.refresh
         : apiKey;
   return {
-    ...state.creds,
-    baseUrl: typeof credentialBaseUrl === "string" ? normalizeBaseUrl(credentialBaseUrl) : state.creds.baseUrl,
+    ...current,
+    baseUrl: typeof credentialBaseUrl === "string" ? normalizeBaseUrl(credentialBaseUrl) : current.baseUrl,
     apiKey,
     apiKeyFingerprint: fingerprintSource ? fingerprint(fingerprintSource) : undefined,
   };
@@ -1008,6 +1010,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       cacheFetchedAt,
       refreshOnStart,
       liveDiscoveryApiKey,
+      mcpRegistered: false,
       refreshInProgress: null,
     };
   }
@@ -1042,14 +1045,19 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       api: "openai-completions",
       headers: escapeHeaderConfig(state.headers),
       models,
-      refreshModels: ({ allowNetwork, force, credential, signal }) => {
+      refreshModels: async ({ allowNetwork, force, credential, signal }) => {
         const cacheIsFresh = state.cacheFetchedAt > 0 && Date.now() - state.cacheFetchedAt <= CACHE_STALE_MS;
-        if (
-          !allowNetwork ||
-          discoveryDisabledReason() ||
-          (!state.refreshOnStart && cacheIsFresh && !state.refreshInProgress && !force)
-        ) {
-          return Promise.resolve(state.models);
+        const supplied = credential ? await credentialsFromRefresh(state, credential) : undefined;
+        const credentialChanged =
+          supplied !== undefined &&
+          (supplied.baseUrl !== state.creds.baseUrl || supplied.apiKeyFingerprint !== state.creds.apiKeyFingerprint);
+        if (!allowNetwork || discoveryDisabledReason()) return Promise.resolve(state.models);
+        if (!state.refreshOnStart && cacheIsFresh && !state.refreshInProgress && !force && !credentialChanged) {
+          const registerTools =
+            state.definition.name === PROVIDER_NAME && !state.mcpRegistered
+              ? registerMcpTools(state)
+              : Promise.resolve();
+          return registerTools.then(() => state.models);
         }
         return runRefresh(state, undefined, credential, signal).then((result) => result.models);
       },
@@ -1119,11 +1127,13 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   }
 
   async function registerMcpTools(state: ProviderState, onProgress?: ProgressCallback): Promise<void> {
-    if (!mcpEnabled || !state.creds.baseUrl || !state.liveDiscoveryApiKey || discoveryDisabledReason()) return;
+    if (!mcpEnabled || !state.creds.baseUrl || discoveryDisabledReason()) return;
+    const apiKey = state.liveDiscoveryApiKey ?? (await resolveCredentials(state.definition)).apiKey;
+    if (!apiKey) return;
     try {
       const tools = await createMcpToolDefinitions(
         state.creds.baseUrl,
-        seededRuntimeApiKey(state, state.liveDiscoveryApiKey),
+        seededRuntimeApiKey(state, apiKey),
         state.headers,
         isVerboseDiscovery()
           ? (message) =>
@@ -1133,6 +1143,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       for (const tool of tools) {
         pi.registerTool(tool);
       }
+      state.mcpRegistered = true;
     } catch (error) {
       process.stderr.write(
         `LiteLLM (${state.definition.name}): MCP tool discovery failed (${error instanceof Error ? error.message : String(error)}).\n`,
@@ -1148,7 +1159,9 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     credential?: Credential,
     signal?: AbortSignal,
   ): Promise<ProviderRefreshResult> {
-    const fresh = credential ? credentialsFromRefresh(state, credential) : await resolveCredentials(state.definition);
+    const fresh = credential
+      ? await credentialsFromRefresh(state, credential)
+      : await resolveCredentials(state.definition);
     const freshFp = fresh.apiKeyFingerprint;
     if (!fresh.baseUrl || !fresh.apiKey || !freshFp) {
       throw new Error(`no credentials for ${state.definition.name}. Run /login litellm or set env vars.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1042,10 +1042,17 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       api: "openai-completions",
       headers: escapeHeaderConfig(state.headers),
       models,
-      refreshModels: ({ allowNetwork, credential, signal }) =>
-        allowNetwork && !discoveryDisabledReason()
-          ? runRefresh(state, undefined, credential, signal).then((result) => result.models)
-          : Promise.resolve(state.models),
+      refreshModels: ({ allowNetwork, force, credential, signal }) => {
+        const cacheIsFresh = state.cacheFetchedAt > 0 && Date.now() - state.cacheFetchedAt <= CACHE_STALE_MS;
+        if (
+          !allowNetwork ||
+          discoveryDisabledReason() ||
+          (!state.refreshOnStart && cacheIsFresh && !state.refreshInProgress && !force)
+        ) {
+          return Promise.resolve(state.models);
+        }
+        return runRefresh(state, undefined, credential, signal).then((result) => result.models);
+      },
       oauth: definition.enableOAuth ? oauth : undefined,
     });
   }

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -28,12 +28,18 @@ interface RawLiteLLMMcpTool {
   };
 }
 
-function withTimeout(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
+function withTimeout(timeoutMs: number, parentSignal?: AbortSignal): { signal: AbortSignal; cancel: () => void } {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  const abort = () => controller.abort(parentSignal?.reason);
+  if (parentSignal?.aborted) abort();
+  else parentSignal?.addEventListener("abort", abort, { once: true });
   return {
     signal: controller.signal,
-    cancel: () => clearTimeout(timer),
+    cancel: () => {
+      clearTimeout(timer);
+      parentSignal?.removeEventListener("abort", abort);
+    },
   };
 }
 
@@ -88,9 +94,10 @@ export async function discoverMcpTools(
   apiKey: string,
   headers?: Record<string, string>,
   onProgress?: (message: string) => void,
+  parentSignal?: AbortSignal,
 ): Promise<LiteLLMMcpTool[]> {
   onProgress?.("Discovering MCP tools from server...");
-  const { signal, cancel } = withTimeout(LIST_TIMEOUT_MS);
+  const { signal, cancel } = withTimeout(LIST_TIMEOUT_MS, parentSignal);
   try {
     onProgress?.("Querying MCP tools/list endpoint...");
     const response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/list`, {
@@ -103,7 +110,7 @@ export async function discoverMcpTools(
     });
     if (!response.ok) {
       onProgress?.(`MCP tools discovery failed with status ${response.status}`);
-      return [];
+      throw new Error(`HTTP ${response.status}`);
     }
     const body = (await response.json()) as unknown;
     const bodyRecord = asRecord(body);
@@ -112,9 +119,9 @@ export async function discoverMcpTools(
     const tools = rawTools.map(normalizeMcpTool).filter((tool): tool is LiteLLMMcpTool => tool !== undefined);
     onProgress?.(`Successfully discovered ${tools.length} MCP tools`);
     return tools;
-  } catch {
+  } catch (error) {
     onProgress?.("MCP tools discovery encountered an error");
-    return [];
+    throw error;
   } finally {
     cancel();
   }
@@ -216,9 +223,10 @@ export async function createMcpToolDefinitions(
   getApiKey: () => Promise<string>,
   headers?: Record<string, string>,
   onProgress?: (message: string) => void,
+  signal?: AbortSignal,
 ): Promise<ToolDefinition[]> {
   const discoveryApiKey = await getApiKey();
-  const tools = await discoverMcpTools(baseUrl, discoveryApiKey, headers, onProgress);
+  const tools = await discoverMcpTools(baseUrl, discoveryApiKey, headers, onProgress, signal);
 
   return tools.map((mcpTool) => {
     const safeServer = sanitizeName(mcpTool.server_name);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -32,6 +32,7 @@ type TestProviderConfig = {
   models?: unknown[];
   refreshModels?: (context: {
     allowNetwork: boolean;
+    force?: boolean;
     signal?: AbortSignal;
     credential?:
       | { type: "api_key"; key?: string }
@@ -265,6 +266,36 @@ describe("extension startup", () => {
     await vi.waitFor(() => {
       expect((pi.providers.at(-1)?.config.models as Array<{ id: string }> | undefined)?.[0]?.id).toBe("fresh-model");
     });
+  });
+
+  it("does not repeat a fresh session refresh unless forced", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "fresh-model", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await startSession(pi);
+    fetchMock.mockClear();
+
+    const config = pi.providers.at(-1)?.config;
+    const models = await config?.refreshModels?.({ allowNetwork: true });
+    expect(models).toEqual([expect.objectContaining({ id: "fresh-model" })]);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await config?.refreshModels?.({ allowNetwork: true, force: true });
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/model\/info$/), expect.anything());
   });
 
   it("delivers session refresh progress through the TUI", async () => {
@@ -775,7 +806,7 @@ describe("extension startup", () => {
     const pi = createPi();
     await extension(pi);
 
-    const models = await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+    const models = await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true, force: true });
     expect(models).toEqual([expect.objectContaining({ id: "refreshed-model" })]);
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -288,15 +288,60 @@ describe("extension startup", () => {
 
     await startSession(pi);
     const config = pi.providers.at(-1)?.config;
-    await config?.refreshModels?.({ allowNetwork: true });
+    const credential = { type: "api_key" as const, key: "env-key" };
+    await config?.refreshModels?.({ allowNetwork: true, credential });
     fetchMock.mockClear();
 
-    const models = await config?.refreshModels?.({ allowNetwork: true });
+    const models = await config?.refreshModels?.({ allowNetwork: true, credential });
     expect(models).toEqual([expect.objectContaining({ id: "fresh-model" })]);
     expect(fetchMock).not.toHaveBeenCalled();
 
-    await config?.refreshModels?.({ allowNetwork: true, force: true });
+    await config?.refreshModels?.({ allowNetwork: true, force: true, credential });
     expect(fetchMock).toHaveBeenCalledWith(expect.stringMatching(/\/model\/info$/), expect.anything());
+  });
+
+  it("registers MCP tools without repeating fresh-cache model discovery", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fingerprint("env-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    const requestedUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.endsWith("/mcp-rest/tools/list")) {
+        return jsonResponse(200, {
+          tools: [
+            {
+              name: "search",
+              description: "Search the web",
+              inputSchema: { type: "object", properties: {} },
+              mcp_info: { server_name: "brave", server_id: "brave-api" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const models = await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+
+    expect(models).toEqual(cachedModels);
+    expect(requestedUrls).toEqual(["https://litellm.example.com/mcp-rest/tools/list"]);
+    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
   });
 
   it("delivers session refresh progress through the TUI", async () => {
@@ -841,11 +886,12 @@ describe("extension startup", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("uses Pi's resolved credential for provider refresh", async () => {
+  it("uses Pi's resolved credential for provider refresh despite a fresh cache", async () => {
     const agentDir = await makeAgentDir();
     const helperPath = await writeHelper(agentDir, ["helper-key"]);
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY_HELPER = helperPath;
+    await writeModelCache(agentDir, helperPath);
     const seenAuthHeaders: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
@@ -860,18 +906,23 @@ describe("extension startup", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({ litellm: { type: "api_key", key: "new-key" } }),
+      "utf8",
+    );
 
     await pi.providers[0]?.config.refreshModels?.({
       allowNetwork: true,
-      credential: { type: "api_key", key: "resolved-key" },
+      credential: { type: "api_key", key: "new-key" },
     });
 
-    expect(seenAuthHeaders).toEqual(["Bearer resolved-key", "Bearer resolved-key"]);
+    expect(seenAuthHeaders).toEqual(["Bearer new-key", "Bearer new-key"]);
     expect(await readHelperCount(agentDir)).toBe(0);
     const cache = JSON.parse(await readFile(join(agentDir, "litellm-models.json"), "utf8")) as {
       apiKeyFingerprint: string;
     };
-    expect(cache.apiKeyFingerprint).toBe(fingerprint(`!${helperPath}`));
+    expect(cache.apiKeyFingerprint).toBe(fingerprint("new-key"));
   });
 
   it("cancels provider refresh with Pi's signal", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -287,9 +287,10 @@ describe("extension startup", () => {
     await extension(pi);
 
     await startSession(pi);
+    const config = pi.providers.at(-1)?.config;
+    await config?.refreshModels?.({ allowNetwork: true });
     fetchMock.mockClear();
 
-    const config = pi.providers.at(-1)?.config;
     const models = await config?.refreshModels?.({ allowNetwork: true });
     expect(models).toEqual([expect.objectContaining({ id: "fresh-model" })]);
     expect(fetchMock).not.toHaveBeenCalled();

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1824,6 +1824,8 @@ describe("multi-provider hardening", () => {
 
   it("does not execute an alias key command when a stored auth entry wins", async () => {
     const agentDir = await makeAgentDir();
+    delete process.env.LITELLM_BASE_URL;
+    delete process.env.LITELLM_API_KEY;
     const countingHelper = await writeHelper(agentDir, ["alias-command-key"]);
     await writeFile(
       join(agentDir, "auth.json"),

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -12,6 +12,7 @@ const ENV_KEYS = [
   "LITELLM_API_KEY_HELPER",
   "LITELLM_HEADERS",
   "LITELLM_OFFLINE",
+  "LITELLM_VERBOSE_DISCOVERY",
   "LITELLM_ANTHROPIC_API_KEY",
   "LITELLM_ANTHROPIC_HEADERS",
   "LITELLM_DISCOVERY_TIMEOUT_MS",
@@ -270,6 +271,7 @@ describe("extension startup", () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "new-key";
+    process.env.LITELLM_VERBOSE_DISCOVERY = "1";
     await writeFile(
       join(agentDir, "litellm-models.json"),
       JSON.stringify({
@@ -302,12 +304,14 @@ describe("extension startup", () => {
     await vi.waitFor(() =>
       expect(notify).toHaveBeenCalledWith("LiteLLM MCP: Discovering MCP tools from server...", "info"),
     );
+    delete process.env.LITELLM_VERBOSE_DISCOVERY;
   });
 
   it("keeps concurrent extension progress bound to the initiating session", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "new-key";
+    process.env.LITELLM_VERBOSE_DISCOVERY = "1";
     await writeFile(
       join(agentDir, "litellm-models.json"),
       JSON.stringify({
@@ -363,6 +367,7 @@ describe("extension startup", () => {
     const fallbackMessage = "LiteLLM: /model/info unavailable, trying /v1/models...";
     expect(firstNotify.mock.calls.filter(([message]) => message === fallbackMessage)).toHaveLength(1);
     expect(secondNotify.mock.calls.filter(([message]) => message === fallbackMessage)).toHaveLength(1);
+    delete process.env.LITELLM_VERBOSE_DISCOVERY;
   });
 
   it("registers the API key as an explicit environment reference", async () => {
@@ -1101,6 +1106,7 @@ describe("extension startup", () => {
   it("prompts during login and caches discovered models", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_VERBOSE_DISCOVERY = "1";
     const seenRequests: Array<{ url: string; authorization: string }> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
@@ -1148,6 +1154,7 @@ describe("extension startup", () => {
     };
     expect(cache.models.map((model) => model.id)).toEqual(["vidaimock-openai"]);
     expect(progress).toHaveBeenCalledWith("LiteLLM: 1 models discovered (source: model_info)");
+    delete process.env.LITELLM_VERBOSE_DISCOVERY;
   });
 
   it("re-registers models discovered during login", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -344,6 +344,192 @@ describe("extension startup", () => {
     expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
   });
 
+  it("retries MCP discovery after a cached-path failure", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fingerprint("env-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(
+        jsonResponse(200, {
+          tools: [
+            {
+              name: "search",
+              description: "Search the web",
+              inputSchema: { type: "object", properties: {} },
+              mcp_info: { server_name: "brave", server_id: "brave-api" },
+            },
+          ],
+        }),
+      );
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+    await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
+  });
+
+  it("retries MCP discovery after a forced-refresh failure", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fingerprint("env-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    let mcpAttempts = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, { data: [{ model_name: "refreshed-model", model_info: { mode: "chat" } }] });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) {
+        mcpAttempts += 1;
+        if (mcpAttempts === 2) throw new Error("offline");
+        return jsonResponse(200, { tools: [] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+    await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true, force: true });
+    await pi.providers.at(-1)?.config.refreshModels?.({ allowNetwork: true });
+
+    expect(mcpAttempts).toBe(3);
+  });
+
+  it("shares cached MCP registration across concurrent refreshes", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fingerprint("env-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    const requestedUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      requestedUrls.push(String(input));
+      return jsonResponse(200, {
+        tools: [
+          {
+            name: "search",
+            description: "Search the web",
+            inputSchema: { type: "object", properties: {} },
+            mcp_info: { server_name: "brave", server_id: "brave-api" },
+          },
+        ],
+      });
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await Promise.all([
+      pi.providers[0]?.config.refreshModels?.({ allowNetwork: true }),
+      pi.providers[0]?.config.refreshModels?.({ allowNetwork: true }),
+    ]);
+
+    expect(requestedUrls).toEqual(["https://litellm.example.com/mcp-rest/tools/list"]);
+    expect(pi.tools.filter((tool) => tool.name === "mcp_brave_search")).toHaveLength(1);
+  });
+
+  it("keeps cached models when the MCP credential helper fails", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeFailingHelper(agentDir);
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY_HELPER = helperPath;
+    await writeModelCache(agentDir, helperPath);
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const models = await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+
+    expect(models).toEqual(cachedModels);
+    expect(await readHelperCount(agentDir)).toBe(1);
+  });
+
+  it("cancels cached MCP discovery without registering tools", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "env-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://litellm.example.com",
+        apiKeyFingerprint: fingerprint("env-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    let resolveDiscovery: ((response: Response) => void) | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      (_input, init) =>
+        new Promise<Response>((resolve, reject) => {
+          resolveDiscovery = resolve;
+          init?.signal?.addEventListener("abort", () => reject(init.signal?.reason), { once: true });
+        }),
+    );
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const controller = new AbortController();
+
+    const refresh = pi.providers[0]?.config.refreshModels?.({ allowNetwork: true, signal: controller.signal });
+    await vi.waitFor(() => expect(resolveDiscovery).toBeDefined());
+    controller.abort(new Error("refresh cancelled"));
+    resolveDiscovery?.(
+      jsonResponse(200, {
+        tools: [
+          {
+            name: "search",
+            description: "Search the web",
+            inputSchema: { type: "object", properties: {} },
+            mcp_info: { server_name: "brave", server_id: "brave-api" },
+          },
+        ],
+      }),
+    );
+
+    await expect(refresh).rejects.toThrow("refresh cancelled");
+    expect(pi.tools.map((tool) => tool.name)).not.toContain("mcp_brave_search");
+  });
+
   it("delivers session refresh progress through the TUI", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
@@ -1268,6 +1454,60 @@ describe("extension startup", () => {
     expect(pi.providers).toHaveLength(2);
     expect(pi.providers[1]?.config.baseUrl).toBe("http://127.0.0.1:4000/v1");
     expect(registeredModels?.map((model) => model.id)).toEqual(["vidaimock-openai"]);
+  });
+
+  it("discovers MCP tools again after login changes credentials", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://old.example.com";
+    process.env.LITELLM_API_KEY = "old-key";
+    await writeFile(
+      join(agentDir, "litellm-models.json"),
+      JSON.stringify({
+        baseUrl: "https://old.example.com",
+        apiKeyFingerprint: fingerprint("old-key"),
+        fetchedAt: Date.now(),
+        source: "model_info",
+        models: cachedModels,
+      }),
+      "utf8",
+    );
+    const requestedUrls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url === "https://new.example.com/model/info") {
+        return jsonResponse(200, { data: [{ model_name: "new-model", model_info: { mode: "chat" } }] });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) {
+        const server = url.startsWith("https://new.example.com") ? "new" : "old";
+        return jsonResponse(200, {
+          tools: [
+            {
+              name: "search",
+              description: "Search the web",
+              inputSchema: { type: "object", properties: {} },
+              mcp_info: { server_name: server, server_id: `${server}-api` },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    await pi.providers[0]?.config.refreshModels?.({ allowNetwork: true });
+
+    const credential = await pi.providers[0]?.config.oauth?.login({
+      onPrompt: async (options) => (options.placeholder ? "https://new.example.com" : "new-key"),
+      signal: new AbortController().signal,
+    });
+    const storedCredential = { type: "oauth" as const, ...credential! };
+    await writeFile(join(agentDir, "auth.json"), JSON.stringify({ litellm: storedCredential }), "utf8");
+    await pi.providers.at(-1)?.config.refreshModels?.({ allowNetwork: true, credential: storedCredential });
+
+    expect(requestedUrls).toContain("https://new.example.com/mcp-rest/tools/list");
+    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_new_search");
   });
 
   it("leaves /login litellm to Pi's registered OAuth provider", async () => {

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -80,10 +80,10 @@ describe("discoverMcpTools", () => {
     );
   });
 
-  it("returns an empty list when discovery fails", async () => {
+  it("rejects when discovery fails", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
 
-    await expect(discoverMcpTools("https://litellm.example.com", "sk-test")).resolves.toEqual([]);
+    await expect(discoverMcpTools("https://litellm.example.com", "sk-test")).rejects.toThrow("offline");
   });
 });
 

--- a/tests/terminal-smoke.test.ts
+++ b/tests/terminal-smoke.test.ts
@@ -48,15 +48,19 @@ async function withPi(run: (session: Session) => Promise<void>): Promise<void> {
   }
 }
 
-async function submit(session: Session, text: string): Promise<void> {
+async function submit(session: Session, text: string, autocompleteText?: string): Promise<void> {
   await session.keyboard.type(text);
   if (text.startsWith("/")) {
     await session.screen.waitForText(text, { timeoutMs: waitTimeoutMs });
   }
+  if (autocompleteText) {
+    await session.screen.waitForText(autocompleteText, { timeoutMs: waitTimeoutMs });
+    await session.keyboard.press("Escape");
+  }
   await session.keyboard.press("Enter");
 }
 
-it("waits for command echo without inspecting form values", async () => {
+it("dismisses command autocomplete without inspecting form values", async () => {
   const calls: unknown[] = [];
   const session = {
     keyboard: {
@@ -69,10 +73,18 @@ it("waits for command echo without inspecting form values", async () => {
     },
   } as unknown as Session;
 
-  await submit(session, "/login litellm");
+  await submit(session, "/login litellm", "LiteLLM · subscription/API key");
   await submit(session, "sk-ci-litellm-smoke");
 
-  expect(calls).toEqual(["type", ["waitForText", "/login litellm", { timeoutMs: 90_000 }], "Enter", "type", "Enter"]);
+  expect(calls).toEqual([
+    "type",
+    ["waitForText", "/login litellm", { timeoutMs: 90_000 }],
+    ["waitForText", "LiteLLM · subscription/API key", { timeoutMs: 90_000 }],
+    "Escape",
+    "Enter",
+    "type",
+    "Enter",
+  ]);
 });
 
 async function waitForInitialModel(session: Session): Promise<void> {
@@ -99,7 +111,7 @@ describe.skipIf(!enabled)("interactive Pi terminal smoke", () => {
       await withPi(async (session) => {
         await waitForInitialModel(session);
 
-        await submit(session, "/login litellm");
+        await submit(session, "/login litellm", "LiteLLM · subscription/API key");
         await session.screen.waitForText("Select authentication method for LiteLLM", { timeoutMs: waitTimeoutMs });
         await session.keyboard.press("Enter");
         await session.screen.waitForText("Enter LiteLLM proxy URL", { timeoutMs: waitTimeoutMs });

--- a/tests/terminal-smoke.test.ts
+++ b/tests/terminal-smoke.test.ts
@@ -5,7 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { type Session, TerminalControl } from "@kitlangton/terminal-control";
-import { afterAll, beforeAll, describe, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const piPath = resolve(repoRoot, "node_modules/.bin/pi");
@@ -50,8 +50,30 @@ async function withPi(run: (session: Session) => Promise<void>): Promise<void> {
 
 async function submit(session: Session, text: string): Promise<void> {
   await session.keyboard.type(text);
+  if (text.startsWith("/")) {
+    await session.screen.waitForText(text, { timeoutMs: waitTimeoutMs });
+  }
   await session.keyboard.press("Enter");
 }
+
+it("waits for command echo without inspecting form values", async () => {
+  const calls: unknown[] = [];
+  const session = {
+    keyboard: {
+      press: async (key: string) => void calls.push(key),
+      type: async () => void calls.push("type"),
+    },
+    screen: {
+      waitForText: async (text: string | RegExp, options?: { timeoutMs?: number }) =>
+        void calls.push(["waitForText", text, options]),
+    },
+  } as unknown as Session;
+
+  await submit(session, "/login litellm");
+  await submit(session, "sk-ci-litellm-smoke");
+
+  expect(calls).toEqual(["type", ["waitForText", "/login litellm", { timeoutMs: 90_000 }], "Enter", "type", "Enter"]);
+});
 
 async function waitForInitialModel(session: Session): Promise<void> {
   try {


### PR DESCRIPTION
Discovery progress messages (TUI notifications and stderr output) are now
silent by default. Set `LITELLM_VERBOSE_DISCOVERY=1` to opt back in during:
- Model discovery (startup, `/litellm-refresh`, login)
- MCP tool discovery

Changes:
- Add `silent` option to `discoverModels()` and `discoverFromHealth()` to
  suppress `onProgress` callbacks at the source
- Gate all progress callbacks with `isVerboseDiscovery()` check in index.ts
- Update existing tests to set `LITELLM_VERBOSE_DISCOVERY=1` where progress
  notifications are asserted
- Document `LITELLM_VERBOSE_DISCOVERY` in README env var table
- Fix test isolation in alias-key test (clear inherited env vars)

Written with AI.

----
Superseeds and closes #92
Fixes #88 