### PR TITLE
feat: cache models.dev metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,11 @@ Setting `skills.enabled` to `false` disables the Skills Gateway management tools
 | `LITELLM_OFFLINE` | unset | If `1`, disable all model and MCP discovery, including `/litellm-refresh` and post-login MCP discovery; use cached models only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
 | `LITELLM_VERBOSE_DISCOVERY` | unset | If `1`, enable progress messages during model and MCP discovery (login, refresh, startup); discovery is silent by default |
+| `LITELLM_MODELS_DEV` | enabled | Set to `0` to disable models.dev metadata enrichment, including its cache and network request; `/v1/models` still uses Pi catalog metadata and defaults |
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` disables automatic and explicit refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
+
+Models.dev metadata is cached in `litellm-models-dev.json` under the Pi agent directory for 28 days. Fresh data avoids the public request; stale data is used immediately while one background refresh updates the cache. Set `LITELLM_MODELS_DEV=0` when your LiteLLM metadata is authoritative and no external enrichment is wanted.
 
 ### Google ADC token auth
 

--- a/docs/superpowers/plans/2026-07-21-models-dev-cache.md
+++ b/docs/superpowers/plans/2026-07-21-models-dev-cache.md
@@ -1,0 +1,750 @@
+# Models.dev Cache Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make models.dev enrichment optional and persist its catalog for 28 days with stale-while-revalidate refreshes.
+
+**Architecture:** Extend discovery options with an enable flag and one injected agent-directory cache path. Keep the catalog mapping in `src/discover.ts`, add a small validated `{ fetchedAt, catalog }` cache around the existing fetch, and reuse the atomic JSON writer in `src/cache.ts`. Extension call sites share one public catalog cache across provider aliases; direct discovery callers without a path retain process-local caching.
+
+**Tech Stack:** TypeScript ESM, Node.js `fs/promises`, Vitest, Biome, tsgo
+
+## Global Constraints
+
+- Node.js support remains `>=22.19.0`; add no dependency.
+- Models.dev enrichment remains enabled unless `LITELLM_MODELS_DEV=0`.
+- Disabling models.dev skips its memory cache, disk cache, and network request, but does not disable `/v1/models`.
+- The cache lifetime is exactly `28 * 24 * 60 * 60 * 1000` milliseconds and is not configurable.
+- Fresh cache data returns without network access; stale data returns immediately while one background refresh runs per cache path.
+- Initial cache misses may await one deduplicated models.dev fetch.
+- Failed reads, writes, initial fetches, and background refreshes remain non-fatal; stale data is never deleted on failure.
+- Models.dev remains limited to the successful `/v1/models` fallback path.
+- Use test-first development and signed, conventional, single-line commits no longer than 72 characters.
+- Keep the branch local unless the user explicitly authorizes a push.
+
+---
+
+### Task 1: Make Models.dev Enrichment Optional
+
+**Files:**
+- Modify: `src/types.ts:19-23`
+- Modify: `src/discover.ts:236-243,427-430`
+- Test: `tests/discover.test.ts:342-440`
+
+**Interfaces:**
+- Consumes: existing `discoverModels(baseUrl, apiKey, options)`.
+- Produces: `DiscoveryOptions.modelsDev?: boolean`; `false` skips models.dev and unset preserves enabled behavior.
+
+- [ ] **Step 1: Write the failing opt-out test**
+
+Add this case inside `describe("discoverModels fallback to /v1/models", ...)`:
+
+```ts
+it("skips models.dev enrichment when disabled", async () => {
+  const urls: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = input instanceof URL ? input.toString() : String(input);
+    urls.push(url);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, {
+        data: [{ id: "gpt-5.5", object: "model", owned_by: "openai" }],
+      });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  const result = await discoverModels("https://litellm.example.com", "sk-test", {
+    modelsDev: false,
+  });
+
+  expect(urls).not.toContain("https://models.dev/api.json");
+  expect(result.models[0]).toMatchObject({
+    id: "gpt-5.5",
+    name: "GPT-5.5",
+    contextWindow: 272000,
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+rtk npm test -- tests/discover.test.ts
+```
+
+Expected: FAIL because `DiscoveryOptions` has no `modelsDev` property or because discovery requests the unexpected models.dev URL.
+
+- [ ] **Step 3: Add the minimal option and guard**
+
+Extend `DiscoveryOptions` in `src/types.ts`:
+
+```ts
+export interface DiscoveryOptions {
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  headers?: Record<string, string>;
+  modelsDev?: boolean;
+}
+```
+
+Guard the catalog lookup in `src/discover.ts`, make the progress text accurate for
+cache hits, and leave mapping priority unchanged:
+
+```ts
+let modelsDev: ModelsDevResponse | undefined;
+if (options.modelsDev !== false) {
+  options.onProgress?.("Loading models.dev catalog for metadata enrichment...");
+  modelsDev = await getModelsDevCatalog(options);
+}
+```
+
+- [ ] **Step 4: Run the focused test to verify GREEN**
+
+Run:
+
+```bash
+rtk npm test -- tests/discover.test.ts
+```
+
+Expected: PASS, including the existing unavailable and successful models.dev enrichment cases.
+
+- [ ] **Step 5: Commit the optional enrichment behavior**
+
+```bash
+rtk git status --short
+rtk git add src/types.ts src/discover.ts tests/discover.test.ts
+rtk git commit -m "feat: make models.dev enrichment optional"
+```
+
+Expected: one signed commit containing only the option, guard, and regression test.
+
+---
+
+### Task 2: Persist Fresh Models.dev Metadata
+
+**Files:**
+- Modify: `src/cache.ts:1-51`
+- Modify: `src/types.ts:19-24`
+- Modify: `src/discover.ts:1-43,221-265`
+- Test: `tests/discover.test.ts:1-13,342-440`
+
+**Interfaces:**
+- Consumes: `DiscoveryOptions.modelsDev?: boolean` from Task 1 and the existing models.dev response mapping.
+- Produces: `DiscoveryOptions.modelsDevCachePath?: string`; `writeJsonAtomic(path: string, value: unknown): Promise<void>`; a private cache file shaped as `{ fetchedAt: number; catalog: ModelsDevResponse }`.
+
+- [ ] **Step 1: Write failing cache-miss, fresh-cache, and malformed-cache tests**
+
+Add imports to `tests/discover.test.ts`:
+
+```ts
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+```
+
+Add a local fixture:
+
+```ts
+const MODELS_DEV_CATALOG = {
+  openai: {
+    models: {
+      "gpt-5.5": {
+        name: "Models.dev GPT-5.5",
+        reasoning: true,
+        limit: { context: 1_050_000, output: 128_000 },
+        cost: { input: 5, output: 30, cache_read: 0.5 },
+      },
+    },
+  },
+};
+```
+
+Add three cases to the `/v1/models` describe block:
+
+```ts
+it("persists models.dev metadata after an initial cache miss", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+  const cachePath = join(dir, "litellm-models-dev.json");
+  vi.spyOn(Date, "now").mockReturnValue(1_000);
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    if (url === "https://models.dev/api.json") return jsonResponse(200, MODELS_DEV_CATALOG);
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  const result = await discoverModels("https://litellm.example.com", "sk-test", {
+    modelsDevCachePath: cachePath,
+  });
+
+  expect(result.models[0]?.contextWindow).toBe(1_050_000);
+  expect(JSON.parse(await readFile(cachePath, "utf8"))).toEqual({
+    fetchedAt: 1_000,
+    catalog: MODELS_DEV_CATALOG,
+  });
+});
+
+it("uses a fresh persistent models.dev cache without fetching", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+  const cachePath = join(dir, "litellm-models-dev.json");
+  await writeFile(cachePath, JSON.stringify({ fetchedAt: 1_000, catalog: MODELS_DEV_CATALOG }), "utf8");
+  vi.spyOn(Date, "now").mockReturnValue(2_000);
+  const urls: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    urls.push(url);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  const result = await discoverModels("https://litellm.example.com", "sk-test", {
+    modelsDevCachePath: cachePath,
+  });
+
+  expect(urls).not.toContain("https://models.dev/api.json");
+  expect(result.models[0]?.contextWindow).toBe(1_050_000);
+});
+
+it("replaces a malformed models.dev cache from the network", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+  const cachePath = join(dir, "litellm-models-dev.json");
+  await writeFile(cachePath, JSON.stringify({ fetchedAt: "invalid", catalog: [] }), "utf8");
+  const urls: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    urls.push(url);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    if (url === "https://models.dev/api.json") return jsonResponse(200, MODELS_DEV_CATALOG);
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  await discoverModels("https://litellm.example.com", "sk-test", { modelsDevCachePath: cachePath });
+
+  expect(urls).toContain("https://models.dev/api.json");
+  expect(JSON.parse(await readFile(cachePath, "utf8")).catalog).toEqual(MODELS_DEV_CATALOG);
+});
+```
+
+- [ ] **Step 2: Run the tests to verify RED**
+
+Run:
+
+```bash
+rtk npm test -- tests/discover.test.ts
+```
+
+Expected: FAIL because `modelsDevCachePath` and persistent cache behavior do not exist.
+
+- [ ] **Step 3: Reuse the atomic JSON writer**
+
+In `src/cache.ts`, extract the existing write body without changing `writeCache` callers:
+
+```ts
+export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, JSON.stringify(value, null, 2), "utf8");
+  await rename(tmp, path);
+}
+
+export async function writeCache(path: string, cache: CacheFile): Promise<void> {
+  await writeJsonAtomic(path, cache);
+}
+```
+
+- [ ] **Step 4: Add the cache path and validated persistent cache**
+
+Extend `DiscoveryOptions`:
+
+```ts
+modelsDevCachePath?: string;
+```
+
+In `src/discover.ts`, import `readFile` and the shared writer, then replace the singleton catalog with path-keyed state:
+
+```ts
+import { readFile } from "node:fs/promises";
+import { writeJsonAtomic } from "./cache.js";
+
+interface ModelsDevCacheFile {
+  fetchedAt: number;
+  catalog: ModelsDevResponse;
+}
+
+const modelsDevCaches = new Map<string, ModelsDevCacheFile>();
+```
+
+Add narrow cache validation and IO:
+
+```ts
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readModelsDevCache(path: string): Promise<ModelsDevCacheFile | undefined> {
+  try {
+    const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.fetchedAt !== "number" ||
+      !Number.isFinite(parsed.fetchedAt) ||
+      parsed.fetchedAt < 0 ||
+      !isRecord(parsed.catalog)
+    ) {
+      return undefined;
+    }
+    return { fetchedAt: parsed.fetchedAt, catalog: parsed.catalog as ModelsDevResponse };
+  } catch {
+    return undefined;
+  }
+}
+
+async function fetchAndStoreModelsDevCatalog(
+  key: string,
+  options: DiscoveryOptions,
+): Promise<ModelsDevResponse | undefined> {
+  try {
+    const catalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
+    const cache = { fetchedAt: Date.now(), catalog };
+    modelsDevCaches.set(key, cache);
+    if (options.modelsDevCachePath) {
+      await writeJsonAtomic(options.modelsDevCachePath, cache).catch(() => undefined);
+    }
+    return catalog;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
+  const key = options.modelsDevCachePath ?? MODELS_DEV_URL;
+  let cache = modelsDevCaches.get(key);
+  if (!cache && options.modelsDevCachePath) {
+    cache = await readModelsDevCache(options.modelsDevCachePath);
+    if (cache) modelsDevCaches.set(key, cache);
+  }
+  if (cache) return cache.catalog;
+  return fetchAndStoreModelsDevCatalog(key, options);
+}
+```
+
+The `modelsDev === false` guard from Task 1 must run before this function, so disabled discovery reads no cache.
+
+- [ ] **Step 5: Run focused discovery and existing cache tests**
+
+Run:
+
+```bash
+rtk npm test -- tests/discover.test.ts tests/cache.test.ts
+```
+
+Expected: PASS; existing LiteLLM model-cache round trips still use atomic writes.
+
+- [ ] **Step 6: Commit persistent caching**
+
+```bash
+rtk git status --short
+rtk git add src/cache.ts src/types.ts src/discover.ts tests/discover.test.ts
+rtk git commit -m "feat: persist models.dev metadata cache"
+```
+
+Expected: one signed commit with fresh-cache persistence and validation.
+
+---
+
+### Task 3: Refresh Stale Metadata in the Background
+
+**Files:**
+- Modify: `src/discover.ts:15-43,236-265`
+- Test: `tests/discover.test.ts:342-440`
+
+**Interfaces:**
+- Consumes: path-keyed `ModelsDevCacheFile` state and `fetchAndStoreModelsDevCatalog` from Task 2.
+- Produces: fixed `MODELS_DEV_CACHE_TTL_MS`; one `Promise` per cache key for initial-fetch and stale-refresh deduplication.
+
+- [ ] **Step 1: Write failing stale-while-revalidate tests**
+
+Add a small deferred helper to `tests/discover.test.ts`:
+
+```ts
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+```
+
+Add these cases to the `/v1/models` describe block. Use a stale fixture whose `fetchedAt` is more than 28 days behind mocked `Date.now()`:
+
+```ts
+it("returns stale metadata while refreshing it in the background", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+  const cachePath = join(dir, "litellm-models-dev.json");
+  const staleCatalog = {
+    openai: { models: { "gpt-5.5": { name: "Stale GPT", limit: { context: 200_000 } } } },
+  };
+  await writeFile(cachePath, JSON.stringify({ fetchedAt: 1, catalog: staleCatalog }), "utf8");
+  vi.spyOn(Date, "now").mockReturnValue(28 * 24 * 60 * 60 * 1000 + 2);
+  const refresh = deferred<Response>();
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    if (url === "https://models.dev/api.json") return refresh.promise;
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  const result = await discoverModels("https://litellm.example.com", "sk-test", {
+    modelsDevCachePath: cachePath,
+  });
+
+  expect(result.models[0]).toMatchObject({ name: "Stale GPT", contextWindow: 200_000 });
+  refresh.resolve(jsonResponse(200, MODELS_DEV_CATALOG));
+  await vi.waitFor(async () => {
+    const cache = JSON.parse(await readFile(cachePath, "utf8"));
+    expect(cache.catalog).toEqual(MODELS_DEV_CATALOG);
+  });
+});
+
+it("keeps stale metadata when background refresh fails", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+  const cachePath = join(dir, "litellm-models-dev.json");
+  const stale = { fetchedAt: 1, catalog: MODELS_DEV_CATALOG };
+  await writeFile(cachePath, JSON.stringify(stale), "utf8");
+  vi.spyOn(Date, "now").mockReturnValue(28 * 24 * 60 * 60 * 1000 + 2);
+  const modelsDevRequests: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    if (url === "https://models.dev/api.json") {
+      modelsDevRequests.push(url);
+      return new Response(null, { status: 503 });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  const result = await discoverModels("https://litellm.example.com", "sk-test", {
+    modelsDevCachePath: cachePath,
+  });
+
+  expect(result.models[0]?.contextWindow).toBe(1_050_000);
+  await vi.waitFor(() => expect(modelsDevRequests).toHaveLength(1));
+  expect(JSON.parse(await readFile(cachePath, "utf8"))).toEqual(stale);
+});
+
+it("deduplicates concurrent stale cache refreshes", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+  const cachePath = join(dir, "litellm-models-dev.json");
+  await writeFile(cachePath, JSON.stringify({ fetchedAt: 1, catalog: MODELS_DEV_CATALOG }), "utf8");
+  vi.spyOn(Date, "now").mockReturnValue(28 * 24 * 60 * 60 * 1000 + 2);
+  const refresh = deferred<Response>();
+  let refreshes = 0;
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    if (url === "https://models.dev/api.json") {
+      refreshes++;
+      return refresh.promise;
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+
+  await Promise.all([
+    discoverModels("https://one.example.com", "sk-test", { modelsDevCachePath: cachePath }),
+    discoverModels("https://two.example.com", "sk-test", { modelsDevCachePath: cachePath }),
+  ]);
+
+  expect(refreshes).toBe(1);
+  refresh.resolve(jsonResponse(200, MODELS_DEV_CATALOG));
+  await vi.waitFor(async () => {
+    expect(JSON.parse(await readFile(cachePath, "utf8")).fetchedAt).toBe(Date.now());
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify RED**
+
+Run:
+
+```bash
+rtk npm test -- tests/discover.test.ts
+```
+
+Expected: FAIL because stale cache currently returns without starting a refresh and concurrent refresh state is not tracked.
+
+- [ ] **Step 3: Add the fixed TTL and deduplicated refresh promise**
+
+In `src/discover.ts`, add:
+
+```ts
+const MODELS_DEV_CACHE_TTL_MS = 28 * 24 * 60 * 60 * 1000;
+const modelsDevRefreshes = new Map<string, Promise<ModelsDevResponse | undefined>>();
+```
+
+Replace `fetchAndStoreModelsDevCatalog` with a deduplicating version:
+
+```ts
+function refreshModelsDevCatalog(
+  key: string,
+  options: DiscoveryOptions,
+): Promise<ModelsDevResponse | undefined> {
+  const active = modelsDevRefreshes.get(key);
+  if (active) return active;
+  const refresh = (async () => {
+    try {
+      const catalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
+      const cache = { fetchedAt: Date.now(), catalog };
+      modelsDevCaches.set(key, cache);
+      if (options.modelsDevCachePath) {
+        await writeJsonAtomic(options.modelsDevCachePath, cache).catch(() => undefined);
+      }
+      return catalog;
+    } catch {
+      return undefined;
+    } finally {
+      modelsDevRefreshes.delete(key);
+    }
+  })();
+  modelsDevRefreshes.set(key, refresh);
+  return refresh;
+}
+```
+
+Update `getModelsDevCatalog`:
+
+```ts
+async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
+  const key = options.modelsDevCachePath ?? MODELS_DEV_URL;
+  let cache = modelsDevCaches.get(key);
+  if (!cache && options.modelsDevCachePath) {
+    cache = await readModelsDevCache(options.modelsDevCachePath);
+    if (cache) modelsDevCaches.set(key, cache);
+  }
+  if (!cache) return refreshModelsDevCatalog(key, options);
+  if (Date.now() - cache.fetchedAt < MODELS_DEV_CACHE_TTL_MS) return cache.catalog;
+  void refreshModelsDevCatalog(key, { ...options, signal: undefined });
+  return cache.catalog;
+}
+```
+
+Detaching only the stale background refresh from the caller signal lets revalidation finish after discovery returns; initial misses still honor cancellation and the existing timeout.
+
+- [ ] **Step 4: Run the focused tests to verify GREEN**
+
+Run:
+
+```bash
+rtk npm test -- tests/discover.test.ts tests/cache.test.ts
+```
+
+Expected: PASS with one models.dev request for concurrent stale callers.
+
+- [ ] **Step 5: Commit stale-while-revalidate**
+
+```bash
+rtk git status --short
+rtk git add src/discover.ts tests/discover.test.ts
+rtk git commit -m "perf: refresh stale models.dev cache in background"
+```
+
+Expected: one signed commit containing only TTL, background refresh, deduplication, and tests.
+
+---
+
+### Task 4: Wire the Shared Cache and Environment Control
+
+**Files:**
+- Modify: `src/index.ts:34-45,111-127,716-721,953-959,1044-1060,1141-1146`
+- Modify: `tests/index.test.ts:9-23,217-267`
+- Modify: `README.md:147-158`
+
+**Interfaces:**
+- Consumes: `DiscoveryOptions.modelsDev` and `DiscoveryOptions.modelsDevCachePath` from Tasks 1 and 2.
+- Produces: `getModelsDevDiscoveryOptions(): Pick<DiscoveryOptions, "modelsDev" | "modelsDevCachePath">`; shared `litellm-models-dev.json` path; documented `LITELLM_MODELS_DEV=0` behavior.
+
+- [ ] **Step 1: Write the failing extension-level environment test**
+
+Add `"LITELLM_MODELS_DEV"` to `ENV_KEYS`, then add this startup test:
+
+```ts
+it("disables models.dev enrichment with LITELLM_MODELS_DEV=0", async () => {
+  const agentDir = await makeAgentDir();
+  process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+  process.env.LITELLM_API_KEY = "sk-test";
+  process.env.LITELLM_MODELS_DEV = "0";
+  const urls: string[] = [];
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    urls.push(url);
+    if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+    if (url.endsWith("/v1/models")) {
+      return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+    }
+    if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+    throw new Error(`unexpected URL: ${url}`);
+  });
+  const extension = await loadExtension(agentDir);
+  const pi = createPi();
+
+  await extension(pi);
+  await startSession(pi);
+
+  expect(urls).not.toContain("https://models.dev/api.json");
+  expect((pi.providers.at(-1)?.config.models as Array<{ id: string }>)[0]?.id).toBe("gpt-5.5");
+});
+```
+
+- [ ] **Step 2: Run the extension test to verify RED**
+
+Run:
+
+```bash
+rtk npm test -- tests/index.test.ts
+```
+
+Expected: FAIL with an unexpected models.dev URL because the environment flag is not wired into extension discovery.
+
+- [ ] **Step 3: Add one shared extension option helper**
+
+In `src/index.ts`, add constants beside the existing discovery constants:
+
+```ts
+const ENV_MODELS_DEV = "LITELLM_MODELS_DEV";
+const MODELS_DEV_CACHE_FILENAME = "litellm-models-dev.json";
+```
+
+Add the shared options helper beside `getCachePath`:
+
+```ts
+function getModelsDevDiscoveryOptions(): Pick<DiscoveryOptions, "modelsDev" | "modelsDevCachePath"> {
+  return {
+    modelsDev: process.env[ENV_MODELS_DEV] !== "0",
+    modelsDevCachePath: join(getAgentDir(), MODELS_DEV_CACHE_FILENAME),
+  };
+}
+```
+
+Spread `...getModelsDevDiscoveryOptions()` into all three direct extension discovery flows:
+
+```ts
+await discoverModels(baseUrl, apiKey, {
+  ...getModelsDevDiscoveryOptions(),
+  timeoutMs: LOGIN_TIMEOUT_MS,
+  signal: callbacks.signal,
+  headers: options.headers,
+  onProgress: (message) => callbacks.onProgress?.(`LiteLLM: ${message}`),
+});
+```
+
+```ts
+await discoverWithFallback(creds.baseUrl, creds.apiKey, {
+  ...getModelsDevDiscoveryOptions(),
+  timeoutMs,
+  headers,
+  onProgress: (message) => process.stderr.write(`LiteLLM: ${message}\n`),
+});
+```
+
+```ts
+await discoverModels(fresh.baseUrl, fresh.apiKey, {
+  ...getModelsDevDiscoveryOptions(),
+  timeoutMs: getDiscoveryTimeoutMs(),
+  signal,
+  headers: state.headers,
+  onProgress: progress,
+});
+```
+
+- [ ] **Step 4: Document the cache contract**
+
+Add this row to the optional environment-variable table in `README.md`:
+
+```md
+| `LITELLM_MODELS_DEV` | enabled | Set to `0` to disable models.dev metadata enrichment, including its cache and network request; `/v1/models` still uses Pi catalog metadata and defaults |
+```
+
+Below the table, document the fixed cache behavior:
+
+```md
+Models.dev metadata is cached in `litellm-models-dev.json` under the Pi agent directory for 28 days. Fresh data avoids the public request; stale data is used immediately while one background refresh updates the cache. Set `LITELLM_MODELS_DEV=0` when your LiteLLM metadata is authoritative and no external enrichment is wanted.
+```
+
+- [ ] **Step 5: Run focused tests and typecheck**
+
+Run:
+
+```bash
+rtk npm test -- tests/index.test.ts tests/discover.test.ts tests/cache.test.ts
+rtk npm run typecheck
+```
+
+Expected: PASS; the env flag reaches session refresh and all three call sites typecheck with the shared options.
+
+- [ ] **Step 6: Commit extension wiring and documentation**
+
+```bash
+rtk git status --short
+rtk git add src/index.ts tests/index.test.ts README.md
+rtk git commit -m "feat: expose models.dev cache controls"
+```
+
+Expected: one signed commit containing only extension configuration, shared path wiring, README text, and its integration test.
+
+---
+
+### Task 5: Verify the Complete Branch
+
+**Files:**
+- Verify only; no planned modifications.
+
+**Interfaces:**
+- Consumes: all behavior from Tasks 1-4.
+- Produces: evidence that lint, types, tests, runtime build, diff hygiene, and signed history pass.
+
+- [ ] **Step 1: Run the repository gate**
+
+```bash
+rtk npm run check
+```
+
+Expected: Biome, typecheck, and the full Vitest suite PASS. If nested `.worktrees/**` contaminate root discovery, verify from a clean archive instead of changing unrelated files.
+
+- [ ] **Step 2: Rebuild runtime output**
+
+```bash
+rtk npm run clean
+rtk npm run build
+```
+
+Expected: both commands exit 0; generated `dist/` output is not edited by hand.
+
+- [ ] **Step 3: Check the final diff and signatures**
+
+```bash
+rtk git diff --check main...HEAD
+rtk git status --short --branch
+rtk git log --show-signature --format=fuller main..HEAD
+```
+
+Expected: no whitespace errors, no uncommitted source changes, and every feature-branch commit has a good signature.

--- a/docs/superpowers/specs/2026-07-21-models-dev-cache-design.md
+++ b/docs/superpowers/specs/2026-07-21-models-dev-cache-design.md
@@ -1,0 +1,65 @@
+# Models.dev Cache Design
+
+## Goal
+
+Keep models.dev metadata enrichment available without repeatedly delaying model
+discovery, while allowing operators to disable the external metadata source once
+their LiteLLM deployment provides trustworthy metadata.
+
+## Configuration
+
+Models.dev enrichment remains enabled by default. Setting
+`LITELLM_MODELS_DEV=0` skips both the persistent cache and the models.dev network
+request. It does not disable LiteLLM's `/v1/models` fallback; those models still
+use the bundled Pi catalog and existing conservative defaults.
+
+The cache lifetime is a fixed 28 days. No additional lifetime setting is added.
+
+## Cache
+
+The extension stores the public models.dev catalog and its fetch timestamp in
+`litellm-models-dev.json` under the Pi agent directory. The cache is shared by
+LiteLLM provider aliases because the catalog contains no deployment-specific or
+credential-specific data. Writes use the repository's existing atomic
+temporary-file-and-rename pattern. Missing, malformed, or incompatible cache
+files are treated as cache misses.
+
+The existing process-local cache remains, keyed by the persistent cache path so
+tests and alternate agent directories do not share state accidentally.
+
+## Discovery Flow
+
+Models.dev remains limited to successful `/v1/models` fallback discovery:
+
+1. With `LITELLM_MODELS_DEV=0`, skip models.dev and map models using the Pi
+   catalog and defaults.
+2. With a fresh cache, enrich models immediately without a network request.
+3. With a stale cache, enrich models immediately from stale data and start one
+   deduplicated background refresh. Discovery does not await that refresh.
+4. With no usable cache, fetch models.dev synchronously once because no stale
+   metadata exists to return.
+
+A successful refresh updates process memory and atomically replaces the disk
+cache. A failed background refresh leaves stale data intact. A failed initial
+fetch preserves the current Pi-catalog/default fallback. Cache read and write
+failures remain non-fatal.
+
+Direct `discoverModels` callers that do not supply an agent cache path retain
+the enabled, process-local behavior. Extension discovery paths supply the shared
+agent-directory cache path and the environment-controlled enabled flag.
+
+## Testing
+
+Focused discovery tests cover the opt-out, a fresh persistent cache, an initial
+cache miss, immediate stale-cache use, successful background replacement,
+failed refresh retention, and deduplication of concurrent stale refreshes. An
+extension-level test verifies that `LITELLM_MODELS_DEV=0` reaches discovery.
+
+Existing tests continue to cover models.dev metadata priority, Pi catalog
+fallback, discovery timeouts, and `/model/info` and `/health` paths.
+
+## Scope
+
+This change does not alter the LiteLLM model cache, expose a configurable cache
+lifetime, delete stale data, or couple behavior to a particular LiteLLM issue or
+version.

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -43,9 +43,13 @@ function isCacheFileShape(value: unknown): value is CacheFile {
   );
 }
 
-export async function writeCache(path: string, cache: CacheFile): Promise<void> {
+export async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
-  await writeFile(tmp, JSON.stringify(cache, null, 2), "utf8");
+  await writeFile(tmp, JSON.stringify(value, null, 2), "utf8");
   await rename(tmp, path);
+}
+
+export async function writeCache(path: string, cache: CacheFile): Promise<void> {
+  await writeJsonAtomic(path, cache);
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -191,6 +191,28 @@ function findModelsDevModel(
   return catalog?.[provider]?.models?.[modelId];
 }
 
+function awaitWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return promise;
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const cleanup = () => signal.removeEventListener("abort", onAbort);
+    const onAbort = () => {
+      cleanup();
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
 async function fetchJson<T>(
   url: string,
   apiKey: string,
@@ -271,7 +293,9 @@ async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDev
     cache = await readModelsDevCache(options.modelsDevCachePath);
     if (cache) modelsDevCaches.set(key, cache);
   }
-  if (!cache) return refreshModelsDevCatalog(key, options);
+  if (!cache) {
+    return awaitWithSignal(refreshModelsDevCatalog(key, { ...options, signal: undefined }), options.signal);
+  }
   if (Date.now() - cache.fetchedAt < MODELS_DEV_CACHE_TTL_MS) return cache.catalog;
   void refreshModelsDevCatalog(key, { ...options, signal: undefined });
   return cache.catalog;

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -246,6 +246,54 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeModelsDevCatalog(value: unknown): ModelsDevResponse | undefined {
+  if (!isRecord(value)) return undefined;
+  const catalog: ModelsDevResponse = {};
+  for (const [providerId, providerValue] of Object.entries(value)) {
+    if (!isRecord(providerValue) || !isRecord(providerValue.models)) continue;
+    const models: Record<string, ModelsDevModel> = {};
+    for (const [modelId, modelValue] of Object.entries(providerValue.models)) {
+      if (!isRecord(modelValue)) continue;
+      const model: ModelsDevModel = {};
+      if (typeof modelValue.name === "string") model.name = modelValue.name;
+      if (typeof modelValue.reasoning === "boolean") model.reasoning = modelValue.reasoning;
+      if (isRecord(modelValue.modalities) && Array.isArray(modelValue.modalities.input)) {
+        const input = modelValue.modalities.input.filter((entry): entry is string => typeof entry === "string");
+        if (input.length > 0) model.modalities = { input };
+      }
+      if (isRecord(modelValue.limit)) {
+        const limit: NonNullable<ModelsDevModel["limit"]> = {};
+        const context = finiteNumber(modelValue.limit.context);
+        const input = finiteNumber(modelValue.limit.input);
+        const output = finiteNumber(modelValue.limit.output);
+        if (context !== undefined) limit.context = context;
+        if (input !== undefined) limit.input = input;
+        if (output !== undefined) limit.output = output;
+        if (Object.keys(limit).length > 0) model.limit = limit;
+      }
+      if (isRecord(modelValue.cost)) {
+        const cost: NonNullable<ModelsDevModel["cost"]> = {};
+        const input = finiteNumber(modelValue.cost.input);
+        const output = finiteNumber(modelValue.cost.output);
+        const cacheRead = finiteNumber(modelValue.cost.cache_read);
+        const cacheWrite = finiteNumber(modelValue.cost.cache_write);
+        if (input !== undefined) cost.input = input;
+        if (output !== undefined) cost.output = output;
+        if (cacheRead !== undefined) cost.cache_read = cacheRead;
+        if (cacheWrite !== undefined) cost.cache_write = cacheWrite;
+        if (Object.keys(cost).length > 0) model.cost = cost;
+      }
+      models[modelId] = model;
+    }
+    catalog[providerId] = { models };
+  }
+  return catalog;
+}
+
 async function readModelsDevCache(path: string): Promise<ModelsDevCacheFile | undefined> {
   try {
     const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
@@ -254,12 +302,12 @@ async function readModelsDevCache(path: string): Promise<ModelsDevCacheFile | un
       typeof parsed.fetchedAt !== "number" ||
       !Number.isFinite(parsed.fetchedAt) ||
       parsed.fetchedAt < 0 ||
-      parsed.fetchedAt > Date.now() ||
-      !isRecord(parsed.catalog)
+      parsed.fetchedAt > Date.now()
     ) {
       return undefined;
     }
-    return { fetchedAt: parsed.fetchedAt, catalog: parsed.catalog as ModelsDevResponse };
+    const catalog = normalizeModelsDevCatalog(parsed.catalog);
+    return catalog ? { fetchedAt: parsed.fetchedAt, catalog } : undefined;
   } catch {
     return undefined;
   }
@@ -270,7 +318,8 @@ function refreshModelsDevCatalog(key: string, options: DiscoveryOptions): Promis
   if (active) return active;
   const refresh = (async () => {
     try {
-      const catalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
+      const catalog = normalizeModelsDevCatalog(await fetchPublicJson<unknown>(MODELS_DEV_URL, options));
+      if (!catalog) return undefined;
       const cache = { fetchedAt: Date.now(), catalog };
       modelsDevCaches.set(key, cache);
       if (options.modelsDevCachePath) {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -19,6 +19,7 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
 const MODELS_DEV_URL = "https://models.dev/api.json";
+const MODELS_DEV_CACHE_TTL_MS = 28 * 24 * 60 * 60 * 1000;
 
 interface ModelsDevModel {
   name?: string;
@@ -47,6 +48,7 @@ interface ModelsDevCacheFile {
 }
 
 const modelsDevCaches = new Map<string, ModelsDevCacheFile>();
+const modelsDevRefreshes = new Map<string, Promise<ModelsDevResponse | undefined>>();
 
 export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
@@ -240,21 +242,26 @@ async function readModelsDevCache(path: string): Promise<ModelsDevCacheFile | un
   }
 }
 
-async function fetchAndStoreModelsDevCatalog(
-  key: string,
-  options: DiscoveryOptions,
-): Promise<ModelsDevResponse | undefined> {
-  try {
-    const catalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
-    const cache = { fetchedAt: Date.now(), catalog };
-    modelsDevCaches.set(key, cache);
-    if (options.modelsDevCachePath) {
-      await writeJsonAtomic(options.modelsDevCachePath, cache).catch(() => undefined);
+function refreshModelsDevCatalog(key: string, options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
+  const active = modelsDevRefreshes.get(key);
+  if (active) return active;
+  const refresh = (async () => {
+    try {
+      const catalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
+      const cache = { fetchedAt: Date.now(), catalog };
+      modelsDevCaches.set(key, cache);
+      if (options.modelsDevCachePath) {
+        await writeJsonAtomic(options.modelsDevCachePath, cache).catch(() => undefined);
+      }
+      return catalog;
+    } catch {
+      return undefined;
+    } finally {
+      modelsDevRefreshes.delete(key);
     }
-    return catalog;
-  } catch {
-    return undefined;
-  }
+  })();
+  modelsDevRefreshes.set(key, refresh);
+  return refresh;
 }
 
 async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
@@ -264,8 +271,10 @@ async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDev
     cache = await readModelsDevCache(options.modelsDevCachePath);
     if (cache) modelsDevCaches.set(key, cache);
   }
-  if (cache) return cache.catalog;
-  return fetchAndStoreModelsDevCatalog(key, options);
+  if (!cache) return refreshModelsDevCatalog(key, options);
+  if (Date.now() - cache.fetchedAt < MODELS_DEV_CACHE_TTL_MS) return cache.catalog;
+  void refreshModelsDevCatalog(key, { ...options, signal: undefined });
+  return cache.catalog;
 }
 
 function mapModelsDevMetadata(model: ModelsDevModel | undefined): Partial<ProviderModelConfig> {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -188,7 +188,8 @@ function findModelsDevModel(
 ): ModelsDevModel | undefined {
   const { provider, modelId } = getFallbackProviderAndModel(id, ownedBy);
   if (!provider) return undefined;
-  return catalog?.[provider]?.models?.[modelId];
+  const models = catalog?.[provider]?.models;
+  return models && Object.hasOwn(models, modelId) ? models[modelId] : undefined;
 }
 
 function awaitWithSignal<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,7 +1,9 @@
+import { readFile } from "node:fs/promises";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
 import type { BuiltinProvider } from "@earendil-works/pi-ai/providers/all";
 import type { ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { writeJsonAtomic } from "./cache.js";
 import type {
   DiscoveryOptions,
   DiscoveryResult,
@@ -17,7 +19,6 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
 const MODELS_DEV_URL = "https://models.dev/api.json";
-let modelsDevCatalog: ModelsDevResponse | undefined;
 
 interface ModelsDevModel {
   name?: string;
@@ -39,6 +40,13 @@ interface ModelsDevModel {
 }
 
 type ModelsDevResponse = Record<string, { models?: Record<string, ModelsDevModel> }>;
+
+interface ModelsDevCacheFile {
+  fetchedAt: number;
+  catalog: ModelsDevResponse;
+}
+
+const modelsDevCaches = new Map<string, ModelsDevCacheFile>();
 
 export function normalizeBaseUrl(input: string): string {
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
@@ -210,14 +218,54 @@ async function fetchPublicJson<T>(url: string, options: DiscoveryOptions): Promi
   return (await response.json()) as T;
 }
 
-async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
-  if (modelsDevCatalog) return modelsDevCatalog;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function readModelsDevCache(path: string): Promise<ModelsDevCacheFile | undefined> {
   try {
-    modelsDevCatalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
-    return modelsDevCatalog;
+    const parsed: unknown = JSON.parse(await readFile(path, "utf8"));
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.fetchedAt !== "number" ||
+      !Number.isFinite(parsed.fetchedAt) ||
+      parsed.fetchedAt < 0 ||
+      !isRecord(parsed.catalog)
+    ) {
+      return undefined;
+    }
+    return { fetchedAt: parsed.fetchedAt, catalog: parsed.catalog as ModelsDevResponse };
   } catch {
     return undefined;
   }
+}
+
+async function fetchAndStoreModelsDevCatalog(
+  key: string,
+  options: DiscoveryOptions,
+): Promise<ModelsDevResponse | undefined> {
+  try {
+    const catalog = await fetchPublicJson<ModelsDevResponse>(MODELS_DEV_URL, options);
+    const cache = { fetchedAt: Date.now(), catalog };
+    modelsDevCaches.set(key, cache);
+    if (options.modelsDevCachePath) {
+      await writeJsonAtomic(options.modelsDevCachePath, cache).catch(() => undefined);
+    }
+    return catalog;
+  } catch {
+    return undefined;
+  }
+}
+
+async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
+  const key = options.modelsDevCachePath ?? MODELS_DEV_URL;
+  let cache = modelsDevCaches.get(key);
+  if (!cache && options.modelsDevCachePath) {
+    cache = await readModelsDevCache(options.modelsDevCachePath);
+    if (cache) modelsDevCaches.set(key, cache);
+  }
+  if (cache) return cache.catalog;
+  return fetchAndStoreModelsDevCatalog(key, options);
 }
 
 function mapModelsDevMetadata(model: ModelsDevModel | undefined): Partial<ProviderModelConfig> {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -390,8 +390,11 @@ export async function discoverModels(
     }
     throw new Error(`/v1/models returned ${listResult.status}`);
   }
-  progress?.("Fetching models.dev catalog for metadata enrichment...");
-  const modelsDev = await getModelsDevCatalog(options);
+  let modelsDev: ModelsDevResponse | undefined;
+  if (options.modelsDev !== false) {
+    progress?.("Loading models.dev catalog for metadata enrichment...");
+    modelsDev = await getModelsDevCatalog(options);
+  }
   const models = (listResult.data.data ?? [])
     .map((entry) => mapFromModelsList(entry, modelsDev))
     .filter((m): m is ProviderModelConfig => m !== undefined);

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -254,6 +254,7 @@ async function readModelsDevCache(path: string): Promise<ModelsDevCacheFile | un
       typeof parsed.fetchedAt !== "number" ||
       !Number.isFinite(parsed.fetchedAt) ||
       parsed.fetchedAt < 0 ||
+      parsed.fetchedAt > Date.now() ||
       !isRecord(parsed.catalog)
     ) {
       return undefined;

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -289,16 +289,21 @@ function refreshModelsDevCatalog(key: string, options: DiscoveryOptions): Promis
 
 async function getModelsDevCatalog(options: DiscoveryOptions): Promise<ModelsDevResponse | undefined> {
   const key = options.modelsDevCachePath ?? MODELS_DEV_URL;
+  const refreshOptions = { ...options, timeoutMs: DEFAULT_TIMEOUT_MS, signal: undefined };
   let cache = modelsDevCaches.get(key);
   if (!cache && options.modelsDevCachePath) {
     cache = await readModelsDevCache(options.modelsDevCachePath);
     if (cache) modelsDevCaches.set(key, cache);
   }
   if (!cache) {
-    return awaitWithSignal(refreshModelsDevCatalog(key, { ...options, signal: undefined }), options.signal);
+    const timeout = AbortSignal.timeout(options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    return awaitWithSignal(
+      refreshModelsDevCatalog(key, refreshOptions),
+      options.signal ? AbortSignal.any([options.signal, timeout]) : timeout,
+    );
   }
   if (Date.now() - cache.fetchedAt < MODELS_DEV_CACHE_TTL_MS) return cache.catalog;
-  void refreshModelsDevCatalog(key, { ...options, signal: undefined });
+  void refreshModelsDevCatalog(key, refreshOptions);
   return cache.catalog;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,11 @@ const ENV_HEADERS = "LITELLM_HEADERS";
 const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
 const ENV_OFFLINE = "LITELLM_OFFLINE";
 const ENV_VERBOSE_DISCOVERY = "LITELLM_VERBOSE_DISCOVERY";
+const ENV_MODELS_DEV = "LITELLM_MODELS_DEV";
 const DEFAULT_TIMEOUT_MS = 5000;
 const LOGIN_TIMEOUT_MS = 10_000;
 const CACHE_FILENAME = "litellm-models.json";
+const MODELS_DEV_CACHE_FILENAME = "litellm-models-dev.json";
 const CACHE_STALE_MS = 24 * 60 * 60 * 1000;
 const TOKEN_REFRESH_LEAD_MS = 5 * 60 * 1000;
 const PERMANENT_TOKEN_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
@@ -114,6 +116,12 @@ function getCachePath(providerName = PROVIDER_NAME): string {
   return join(getAgentDir(), `litellm-models-${sanitizeCacheSegment(providerName)}.json`);
 }
 
+function getModelsDevDiscoveryOptions(): Pick<DiscoveryOptions, "modelsDev" | "modelsDevCachePath"> {
+  return {
+    modelsDev: process.env[ENV_MODELS_DEV] !== "0",
+    modelsDevCachePath: join(getAgentDir(), MODELS_DEV_CACHE_FILENAME),
+  };
+}
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -566,6 +574,7 @@ async function loginLiteLLM(
   }
 
   const { models, source } = await discoverModels(baseUrl, apiKey, {
+    ...getModelsDevDiscoveryOptions(),
     timeoutMs: LOGIN_TIMEOUT_MS,
     signal: callbacks.signal,
     headers: options.headers,
@@ -808,6 +817,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     if (shouldFetch && !credentialWarning && creds.baseUrl && creds.apiKey && fp) {
       const timeoutMs = getDiscoveryTimeoutMs();
       const { result, warning } = await discoverWithFallback(creds.baseUrl, creds.apiKey, {
+        ...getModelsDevDiscoveryOptions(),
         timeoutMs,
         headers,
         silent: !isVerboseDiscovery(),
@@ -1028,6 +1038,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       ? (message: string) => onProgress(`LiteLLM: ${message}`)
       : (message: string) => process.stderr.write(`LiteLLM: ${message}\n`);
     const result = await discoverModels(fresh.baseUrl, fresh.apiKey, {
+      ...getModelsDevDiscoveryOptions(),
       timeoutMs: getDiscoveryTimeoutMs(),
       signal,
       headers: state.headers,

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface DiscoveryOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
   headers?: Record<string, string>;
+  modelsDev?: boolean;
 }
 
 export interface ModelInfoEntry {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface DiscoveryOptions {
   signal?: AbortSignal;
   headers?: Record<string, string>;
   modelsDev?: boolean;
+  modelsDevCachePath?: string;
 }
 
 export interface ModelInfoEntry {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -436,6 +436,54 @@ describe("discoverModels fallback to /v1/models", () => {
     });
   });
 
+  it("normalizes models.dev network metadata before caching it", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") {
+        return new Response(
+          '{"openai":{"models":{"gpt-5.5":{"name":"Remote GPT","reasoning":"yes","modalities":{"input":["text",7,"image"]},"limit":{"context":1050000,"input":"many","output":1e400},"cost":{"input":5,"output":"expensive","cache_read":0.5,"cache_write":1e400}}}}}',
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(result.models[0]).toMatchObject({
+      name: "Remote GPT",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 1_050_000,
+      maxTokens: 128_000,
+    });
+    expect(result.models[0]?.cost).toEqual({ input: 5, output: 0, cacheRead: 0.5, cacheWrite: 0 });
+    expect(JSON.parse(await readFile(cachePath, "utf8"))).toEqual({
+      fetchedAt: 1_000,
+      catalog: {
+        openai: {
+          models: {
+            "gpt-5.5": {
+              name: "Remote GPT",
+              modalities: { input: ["text", "image"] },
+              limit: { context: 1_050_000 },
+              cost: { input: 5, cache_read: 0.5 },
+            },
+          },
+        },
+      },
+    });
+  });
+
   it("lets initial cache-miss callers abort independently", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
     const cachePath = join(dir, "litellm-models-dev.json");
@@ -543,6 +591,56 @@ describe("discoverModels fallback to /v1/models", () => {
 
     expect(urls).not.toContain("https://models.dev/api.json");
     expect(result.models[0]?.contextWindow).toBe(1_050_000);
+  });
+
+  it("ignores malformed nested metadata in a fresh models.dev cache", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    await writeFile(
+      cachePath,
+      JSON.stringify({
+        fetchedAt: 1_000,
+        catalog: {
+          openai: {
+            models: {
+              "gpt-5.5": {
+                name: "Cached GPT",
+                reasoning: "yes",
+                modalities: { input: 42 },
+                limit: { context: "many", output: {} },
+                cost: { input: "expensive" },
+              },
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(urls).not.toContain("https://models.dev/api.json");
+    expect(result.models[0]).toMatchObject({
+      name: "Cached GPT",
+      reasoning: true,
+      input: ["text", "image"],
+      contextWindow: 272_000,
+      maxTokens: 128_000,
+    });
+    expect(result.models[0]?.cost.input).toBe(5);
   });
 
   it("returns stale metadata while refreshing it in the background", async () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -436,6 +436,50 @@ describe("discoverModels fallback to /v1/models", () => {
     });
   });
 
+  it("lets initial cache-miss callers abort independently", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    const first = new AbortController();
+    const later = new AbortController();
+    const third = new AbortController();
+    let modelsDevRequests = 0;
+    let resolveModelsDev!: (response: Response) => void;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") {
+        modelsDevRequests++;
+        return new Promise<Response>((resolve, reject) => {
+          resolveModelsDev = resolve;
+          const signal = (init as { signal?: AbortSignal } | undefined)?.signal;
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const discover = (signal: AbortSignal) =>
+      discoverModels("https://litellm.example.com", "sk-test", { modelsDevCachePath: cachePath, signal });
+    const firstResult = discover(first.signal);
+    const laterResult = discover(later.signal);
+    const thirdResult = discover(third.signal);
+
+    await vi.waitFor(() => expect(modelsDevRequests).toBe(1));
+    first.abort(new Error("first aborted"));
+    later.abort(new Error("later aborted"));
+    await expect(firstResult).rejects.toThrow("first aborted");
+    await expect(laterResult).rejects.toThrow("later aborted");
+    resolveModelsDev(jsonResponse(200, MODELS_DEV_CATALOG));
+
+    await expect(thirdResult).resolves.toMatchObject({
+      models: [{ id: "gpt-5.5", contextWindow: 1_050_000 }],
+    });
+    expect(modelsDevRequests).toBe(1);
+  });
+
   it("uses a fresh persistent models.dev cache without fetching", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
     const cachePath = join(dir, "litellm-models-dev.json");

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -361,6 +361,32 @@ describe("discoverModels fallback to /v1/models", () => {
     });
   }
 
+  it("skips models.dev enrichment when disabled", async () => {
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, {
+          data: [{ id: "gpt-5.5", object: "model", owned_by: "openai" }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDev: false,
+    });
+
+    expect(urls).not.toContain("https://models.dev/api.json");
+    expect(result.models[0]).toMatchObject({
+      id: "gpt-5.5",
+      name: "GPT-5.5",
+      contextWindow: 272000,
+    });
+  });
+
   it("uses Pi catalog metadata when models.dev is unavailable", async () => {
     const urls: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -480,6 +480,47 @@ describe("discoverModels fallback to /v1/models", () => {
     expect(modelsDevRequests).toBe(1);
   });
 
+  it("lets initial cache-miss callers time out independently", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    let modelsDevRequests = 0;
+    let resolveModelsDev!: (response: Response) => void;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") {
+        modelsDevRequests++;
+        return new Promise<Response>((resolve, reject) => {
+          resolveModelsDev = resolve;
+          const signal = (init as { signal?: AbortSignal } | undefined)?.signal;
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const short = discoverModels("https://short.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+      timeoutMs: 30,
+    });
+    const shortTimeout = expect(short).rejects.toBeDefined();
+    const long = discoverModels("https://long.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+      timeoutMs: 1_000,
+    });
+
+    await vi.waitFor(() => expect(modelsDevRequests).toBe(1));
+    await shortTimeout;
+    resolveModelsDev(jsonResponse(200, MODELS_DEV_CATALOG));
+    await expect(long).resolves.toMatchObject({
+      models: [{ id: "gpt-5.5", contextWindow: 1_050_000 }],
+    });
+    expect(modelsDevRequests).toBe(1);
+  });
+
   it("uses a fresh persistent models.dev cache without fetching", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
     const cachePath = join(dir, "litellm-models-dev.json");

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -11,6 +11,14 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
 const MODELS_DEV_CATALOG = {
   openai: {
     models: {
@@ -450,6 +458,98 @@ describe("discoverModels fallback to /v1/models", () => {
 
     expect(urls).not.toContain("https://models.dev/api.json");
     expect(result.models[0]?.contextWindow).toBe(1_050_000);
+  });
+
+  it("returns stale metadata while refreshing it in the background", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    const staleCatalog = {
+      openai: { models: { "gpt-5.5": { name: "Stale GPT", limit: { context: 200_000 } } } },
+    };
+    await writeFile(cachePath, JSON.stringify({ fetchedAt: 1, catalog: staleCatalog }), "utf8");
+    vi.spyOn(Date, "now").mockReturnValue(28 * 24 * 60 * 60 * 1000 + 2);
+    const refresh = deferred<Response>();
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") return refresh.promise;
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(result.models[0]).toMatchObject({ name: "Stale GPT", contextWindow: 200_000 });
+    refresh.resolve(jsonResponse(200, MODELS_DEV_CATALOG));
+    await vi.waitFor(async () => {
+      const cache = JSON.parse(await readFile(cachePath, "utf8"));
+      expect(cache.catalog).toEqual(MODELS_DEV_CATALOG);
+    });
+  });
+
+  it("keeps stale metadata when background refresh fails", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    const stale = { fetchedAt: 1, catalog: MODELS_DEV_CATALOG };
+    await writeFile(cachePath, JSON.stringify(stale), "utf8");
+    vi.spyOn(Date, "now").mockReturnValue(28 * 24 * 60 * 60 * 1000 + 2);
+    const modelsDevRequests: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") {
+        modelsDevRequests.push(url);
+        return new Response(null, { status: 503 });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(result.models[0]?.contextWindow).toBe(1_050_000);
+    await vi.waitFor(() => expect(modelsDevRequests).toHaveLength(1));
+    expect(JSON.parse(await readFile(cachePath, "utf8"))).toEqual(stale);
+  });
+
+  it("deduplicates concurrent stale cache refreshes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    await writeFile(cachePath, JSON.stringify({ fetchedAt: 1, catalog: MODELS_DEV_CATALOG }), "utf8");
+    vi.spyOn(Date, "now").mockReturnValue(28 * 24 * 60 * 60 * 1000 + 2);
+    const refresh = deferred<Response>();
+    let refreshes = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") {
+        refreshes++;
+        return refresh.promise;
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await Promise.all([
+      discoverModels("https://one.example.com", "sk-test", { modelsDevCachePath: cachePath }),
+      discoverModels("https://two.example.com", "sk-test", { modelsDevCachePath: cachePath }),
+    ]);
+
+    expect(refreshes).toBe(1);
+    refresh.resolve(jsonResponse(200, MODELS_DEV_CATALOG));
+    await vi.waitFor(async () => {
+      expect(JSON.parse(await readFile(cachePath, "utf8")).fetchedAt).toBe(Date.now());
+    });
   });
 
   it("replaces a malformed models.dev cache from the network", async () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -643,6 +643,27 @@ describe("discoverModels fallback to /v1/models", () => {
     expect(result.models[0]?.cost.input).toBe(5);
   });
 
+  it("ignores inherited model keys in a fresh models.dev cache", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    await writeFile(cachePath, JSON.stringify({ fetchedAt: 1_000, catalog: { openai: { models: {} } } }), "utf8");
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "constructor", owned_by: "openai" }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(result.models[0]?.name).toBe("constructor (no metadata)");
+  });
+
   it("returns stale metadata while refreshing it in the background", async () => {
     const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
     const cachePath = join(dir, "litellm-models-dev.json");

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -618,6 +618,29 @@ describe("discoverModels fallback to /v1/models", () => {
     expect(JSON.parse(await readFile(cachePath, "utf8")).catalog).toEqual(MODELS_DEV_CATALOG);
   });
 
+  it("replaces a future-dated models.dev cache from the network", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    await writeFile(cachePath, JSON.stringify({ fetchedAt: 2_000, catalog: MODELS_DEV_CATALOG }), "utf8");
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") return jsonResponse(200, MODELS_DEV_CATALOG);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await discoverModels("https://litellm.example.com", "sk-test", { modelsDevCachePath: cachePath });
+
+    expect(urls).toContain("https://models.dev/api.json");
+    expect(JSON.parse(await readFile(cachePath, "utf8")).fetchedAt).toBe(1_000);
+  });
+
   it("uses Pi catalog metadata when models.dev is unavailable", async () => {
     const urls: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildCompat, discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "../src/discover.js";
 
@@ -7,6 +10,19 @@ function jsonResponse(status: number, body: unknown): Response {
     headers: { "content-type": "application/json" },
   });
 }
+
+const MODELS_DEV_CATALOG = {
+  openai: {
+    models: {
+      "gpt-5.5": {
+        name: "Models.dev GPT-5.5",
+        reasoning: true,
+        limit: { context: 1_050_000, output: 128_000 },
+        cost: { input: 5, output: 30, cache_read: 0.5 },
+      },
+    },
+  },
+};
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -385,6 +401,77 @@ describe("discoverModels fallback to /v1/models", () => {
       name: "GPT-5.5",
       contextWindow: 272000,
     });
+  });
+
+  it("persists models.dev metadata after an initial cache miss", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    vi.spyOn(Date, "now").mockReturnValue(1_000);
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") return jsonResponse(200, MODELS_DEV_CATALOG);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(result.models[0]?.contextWindow).toBe(1_050_000);
+    expect(JSON.parse(await readFile(cachePath, "utf8"))).toEqual({
+      fetchedAt: 1_000,
+      catalog: MODELS_DEV_CATALOG,
+    });
+  });
+
+  it("uses a fresh persistent models.dev cache without fetching", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    await writeFile(cachePath, JSON.stringify({ fetchedAt: 1_000, catalog: MODELS_DEV_CATALOG }), "utf8");
+    vi.spyOn(Date, "now").mockReturnValue(2_000);
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {
+      modelsDevCachePath: cachePath,
+    });
+
+    expect(urls).not.toContain("https://models.dev/api.json");
+    expect(result.models[0]?.contextWindow).toBe(1_050_000);
+  });
+
+  it("replaces a malformed models.dev cache from the network", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pi-litellm-models-dev-"));
+    const cachePath = join(dir, "litellm-models-dev.json");
+    await writeFile(cachePath, JSON.stringify({ fetchedAt: "invalid", catalog: [] }), "utf8");
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url === "https://models.dev/api.json") return jsonResponse(200, MODELS_DEV_CATALOG);
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await discoverModels("https://litellm.example.com", "sk-test", { modelsDevCachePath: cachePath });
+
+    expect(urls).toContain("https://models.dev/api.json");
+    expect(JSON.parse(await readFile(cachePath, "utf8")).catalog).toEqual(MODELS_DEV_CATALOG);
   });
 
   it("uses Pi catalog metadata when models.dev is unavailable", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -146,7 +146,7 @@ describe("extension startup", () => {
     await startSession(pi);
 
     expect(urls).not.toContain("https://models.dev/api.json");
-    expect((pi.providers.at(-1)?.config.models as Array<{ id: string }>)[0]?.id).toBe("gpt-5.5");
+    expect((pi.providers.at(-1)?.config.models as Array<{ id: string }> | undefined)?.[0]?.id).toBe("gpt-5.5");
   });
 
   it("uses mismatched cached models until session-start refresh", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -16,6 +16,7 @@ const ENV_KEYS = [
   "LITELLM_ANTHROPIC_API_KEY",
   "LITELLM_ANTHROPIC_HEADERS",
   "LITELLM_DISCOVERY_TIMEOUT_MS",
+  "LITELLM_MODELS_DEV",
   "LITELLM_GCLOUD_TOKEN_AUTH",
   "GOOGLE_APPLICATION_CREDENTIALS",
   "STORED_LITELLM_KEY",
@@ -122,6 +123,32 @@ afterEach(() => {
 });
 
 describe("extension startup", () => {
+  it("disables models.dev enrichment with LITELLM_MODELS_DEV=0", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+    process.env.LITELLM_MODELS_DEV = "0";
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, { data: [{ id: "gpt-5.5", owned_by: "openai" }] });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) return jsonResponse(200, { tools: [] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+
+    await extension(pi);
+    await startSession(pi);
+
+    expect(urls).not.toContain("https://models.dev/api.json");
+    expect((pi.providers.at(-1)?.config.models as Array<{ id: string }>)[0]?.id).toBe("gpt-5.5");
+  });
+
   it("uses mismatched cached models until session-start refresh", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";


### PR DESCRIPTION
## Summary

- add `LITELLM_MODELS_DEV=0` to disable models.dev cache and network enrichment without disabling `/v1/models`
- persist the public models.dev catalog for 28 days and serve stale metadata while one background refresh runs
- deduplicate catalog fetches while keeping each caller's timeout and cancellation independent
- normalize cached and network metadata before use and persistence

## Why

Models.dev enrichment protects fallback discovery from stale LiteLLM metadata, including issues such as BerriAI/litellm#34134, but repeatedly fetching the public catalog can delay discovery. A long-lived stale-while-revalidate cache keeps the metadata correction while removing repeated loading latency; the opt-out supports deployments whose LiteLLM metadata is authoritative.

## Validation

- `npm run prepublishOnly` — 221 passed, 3 skipped; Biome, typecheck, build, and supply-chain guard passed
- `npm pack --dry-run`
- `git diff --check origin/main..HEAD`
- all 12 branch commits have good signatures