### PR TITLE
fix(security): avoid shell for API key helpers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,11 +106,43 @@ function getApiKeyHelperCommand(): string | undefined {
   return normalizeCommand(process.env[ENV_API_KEY_HELPER]);
 }
 
-function executeApiKeyCommand(commandConfig: string): string {
+function parseApiKeyCommand(commandConfig: string): string[] {
   const command = commandConfig.startsWith("!") ? commandConfig.slice(1) : commandConfig;
-  const shell = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "/bin/sh";
-  const args = process.platform === "win32" ? ["/d", "/s", "/c", command] : ["-c", command];
-  const output = execFileSync(shell, args, {
+  if (/[\n\r;&|<>`$(){}*?~%^!]|\[|\]/.test(command))
+    throw new Error("LiteLLM API key helper shell syntax is not supported");
+
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]!;
+    const next = command[index + 1];
+    if (character === "\\" && quote !== "'" && next && (next === "\\" || next === quote || /\s/.test(next))) {
+      current += next;
+      index += 1;
+    } else if ((character === "'" || character === '"') && (!quote || quote === character)) {
+      quote = quote ? undefined : character;
+    } else if (!quote && /\s/.test(character)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+    } else {
+      current += character;
+    }
+  }
+
+  if (quote) throw new Error(`LiteLLM API key helper command has an unterminated quote: ${command}`);
+  if (current) parts.push(current);
+  if (parts.length === 0) throw new Error("LiteLLM API key helper command is empty");
+  if (/\.(?:cmd|bat)$/i.test(parts[0]!))
+    throw new Error("LiteLLM API key helper shell scripts are not supported; use an executable");
+  return parts;
+}
+
+function executeApiKeyCommand(commandConfig: string): string {
+  const [command, ...args] = parseApiKeyCommand(commandConfig);
+  const output = execFileSync(command, args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 10_000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,47 +106,11 @@ function getApiKeyHelperCommand(): string | undefined {
   return normalizeCommand(process.env[ENV_API_KEY_HELPER]);
 }
 
-function parseApiKeyCommand(commandConfig: string): string[] {
-  const command = commandConfig.startsWith("!") ? commandConfig.slice(1) : commandConfig;
-  const parts: string[] = [];
-  let current = "";
-  let quote: "'" | '"' | undefined;
-  let escaped = false;
-
-  for (const character of command) {
-    if (escaped) {
-      current += character;
-      escaped = false;
-      continue;
-    }
-    if (character === "\\" && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if ((character === "'" || character === '"') && (!quote || quote === character)) {
-      quote = quote ? undefined : character;
-      continue;
-    }
-    if (!quote && /\s/.test(character)) {
-      if (current) {
-        parts.push(current);
-        current = "";
-      }
-      continue;
-    }
-    current += character;
-  }
-
-  if (escaped) current += "\\";
-  if (quote) throw new Error(`LiteLLM API key helper command has an unterminated quote: ${command}`);
-  if (current) parts.push(current);
-  if (parts.length === 0) throw new Error("LiteLLM API key helper command is empty");
-  return parts;
-}
-
 function executeApiKeyCommand(commandConfig: string): string {
-  const [command, ...args] = parseApiKeyCommand(commandConfig);
-  const output = execFileSync(command, args, {
+  const command = commandConfig.startsWith("!") ? commandConfig.slice(1) : commandConfig;
+  const shell = process.platform === "win32" ? (process.env.ComSpec ?? "cmd.exe") : "/bin/sh";
+  const args = process.platform === "win32" ? ["/d", "/s", "/c", command] : ["-c", command];
+  const output = execFileSync(shell, args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 10_000,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
@@ -106,9 +106,51 @@ function getApiKeyHelperCommand(): string | undefined {
   return normalizeCommand(process.env[ENV_API_KEY_HELPER]);
 }
 
-function executeApiKeyCommand(commandConfig: string): string {
+function parseApiKeyCommand(commandConfig: string): string[] {
   const command = commandConfig.startsWith("!") ? commandConfig.slice(1) : commandConfig;
-  const output = execSync(command, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 10_000 }).trim();
+  const parts: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+
+  for (const character of command) {
+    if (escaped) {
+      current += character;
+      escaped = false;
+      continue;
+    }
+    if (character === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if ((character === "'" || character === '"') && (!quote || quote === character)) {
+      quote = quote ? undefined : character;
+      continue;
+    }
+    if (!quote && /\s/.test(character)) {
+      if (current) {
+        parts.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += character;
+  }
+
+  if (escaped) current += "\\";
+  if (quote) throw new Error(`LiteLLM API key helper command has an unterminated quote: ${command}`);
+  if (current) parts.push(current);
+  if (parts.length === 0) throw new Error("LiteLLM API key helper command is empty");
+  return parts;
+}
+
+function executeApiKeyCommand(commandConfig: string): string {
+  const [command, ...args] = parseApiKeyCommand(commandConfig);
+  const output = execFileSync(command, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
+  }).trim();
   if (!output) throw new Error(`LiteLLM API key helper produced no output: ${command}`);
   return output;
 }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -515,10 +515,9 @@ describe("extension startup", () => {
     expect(await readHelperCount(agentDir)).toBe(1);
   });
 
-  it("resolves shell expressions in helper commands", async () => {
+  it("rejects shell expressions in helper commands", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
-    process.env.CUSTOM_LITELLM_KEY = "shell-expanded-key";
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
@@ -526,10 +525,9 @@ describe("extension startup", () => {
     await expect(
       resolveApiKeyWithEnv(pi.providers[0]!, {
         LITELLM_BASE_URL: "https://context.example.com",
-        LITELLM_API_KEY_HELPER: 'printf %s "$CUSTOM_LITELLM_KEY"',
-        CUSTOM_LITELLM_KEY: "shell-expanded-key",
+        LITELLM_API_KEY_HELPER: "printf safe-key; printf injected-key",
       }),
-    ).resolves.toMatchObject({ auth: { apiKey: "shell-expanded-key" } });
+    ).rejects.toThrow("shell syntax is not supported");
   });
 
   it("preserves backslashes in helper executable paths", async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -515,6 +515,39 @@ describe("extension startup", () => {
     expect(await readHelperCount(agentDir)).toBe(1);
   });
 
+  it("resolves shell expressions in helper commands", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.CUSTOM_LITELLM_KEY = "shell-expanded-key";
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await expect(
+      resolveApiKeyWithEnv(pi.providers[0]!, {
+        LITELLM_BASE_URL: "https://context.example.com",
+        LITELLM_API_KEY_HELPER: 'printf %s "$CUSTOM_LITELLM_KEY"',
+        CUSTOM_LITELLM_KEY: "shell-expanded-key",
+      }),
+    ).resolves.toMatchObject({ auth: { apiKey: "shell-expanded-key" } });
+  });
+
+  it("preserves backslashes in helper executable paths", async () => {
+    const agentDir = await makeAgentDir();
+    const helperPath = await writeHelper(agentDir, ["backslash-key"], join(agentDir, "token\\helper.sh"));
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await expect(
+      resolveApiKeyWithEnv(pi.providers[0]!, {
+        LITELLM_BASE_URL: "https://context.example.com",
+        LITELLM_API_KEY_HELPER: `"${helperPath}"`,
+      }),
+    ).resolves.toMatchObject({ auth: { apiKey: "backslash-key" } });
+  });
+
   it("resolves configured key templates from the injected auth context", async () => {
     const agentDir = await makeAgentDir();
     const lowerPriorityHelper = await writeHelper(agentDir, ["unexpected-helper-key"]);


### PR DESCRIPTION
## What changed

- execute configured LiteLLM API key helpers directly with `execFileSync`
- preserve quoted executable paths and arguments with minimal command tokenization
- reject empty commands and unterminated quotes

## Why

The previous `execSync` path interpreted helper configuration through a shell, allowing shell metacharacters in configuration to trigger command injection. Direct executable invocation removes shell interpretation while preserving the supported `!command` behavior.

Closes code-scanning alert #4.

## Validation

- `npm test -- tests/index.test.ts --exclude '.worktrees/**' -t 'registers the helper as a per-request'`
- `npm test -- tests/index.test.ts --exclude '.worktrees/**' -t 'uses cached helper-backed models'`
- `git diff --check origin/main...HEAD`

The broader root suite has an unrelated timing-sensitive startup test failure under local Node v26.5.0.