### PR TITLE
chore: release v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "1.3.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `package.json` and `package-lock.json` to `2.0.0`
- prepare the first release of the Pi native custom Provider migration

## Why a major release

This release raises the minimum supported Pi version to 0.81.0, replaces extension-owned model/auth persistence with Pi's native provider lifecycle, removes `/litellm-refresh` in favor of `/model`, and tightens API-key helper execution to avoid shell interpretation.

## Validation

- Node `v26.5.0`
- `npm ci`
- `npm run prepublishOnly` — 27 test files passed; 226 tests passed and 1 gated test skipped; build and supply-chain guard passed
- `npm pack --dry-run --json` — 25 expected package files
- `git diff --check origin/main...HEAD`

The local gate ran from a clean temporary copy excluding nested `.worktrees`.