### PR TITLE
fix: load Pi API factories through compat alias

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,6 +1,5 @@
 import { type Credential, createProvider, type Model, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
-import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
-import { openAIResponsesApi } from "@earendil-works/pi-ai/api/openai-responses.lazy";
+import { openAICompletionsApi, openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import type { DiscoveredModel, DiscoveryResult, LiteLLMApi } from "./types.js";
 
 export type LiteLLMProviderOptions = {

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -1,5 +1,10 @@
-import { readFile } from "node:fs/promises";
+import { cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("package gallery metadata", () => {
   it("uses the gallery image URL expected by pi.dev", async () => {
@@ -20,6 +25,26 @@ describe("package gallery metadata", () => {
 });
 
 describe("pi package compatibility", () => {
+  it("loads outside the repository without Pi peer dependencies", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-package-"));
+    try {
+      const source = join(fixture, "src");
+      await cp(join(repoRoot, "src"), source, { recursive: true });
+      const loaderUrl = pathToFileURL(
+        resolve(repoRoot, "node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/loader.js"),
+      ).href;
+      const { loadExtensions } = (await import(loaderUrl)) as {
+        loadExtensions(paths: string[], cwd: string): Promise<{ errors: unknown[] }>;
+      };
+
+      const result = await loadExtensions([join(source, "index.ts")], fixture);
+
+      expect(result.errors).toEqual([]);
+    } finally {
+      await rm(fixture, { force: true, recursive: true });
+    }
+  }, 15_000);
+
   it("requires the native Provider extension API", async () => {
     const { default: manifest } = await import("../package.json", {
       with: { type: "json" },

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -11,10 +11,8 @@ import { createLiteLLMProvider, toNativeModels } from "../src/provider.js";
 import type { DiscoveryResult } from "../src/types.js";
 
 const apiSpies = vi.hoisted(() => ({ completions: vi.fn(), responses: vi.fn() }));
-vi.mock("@earendil-works/pi-ai/api/openai-completions.lazy", () => ({
+vi.mock("@earendil-works/pi-ai/compat", () => ({
   openAICompletionsApi: () => ({ stream: apiSpies.completions, streamSimple: apiSpies.completions }),
-}));
-vi.mock("@earendil-works/pi-ai/api/openai-responses.lazy", () => ({
   openAIResponsesApi: () => ({ stream: apiSpies.responses, streamSimple: apiSpies.responses }),
 }));
 


### PR DESCRIPTION
## Summary

- load the OpenAI API factories through Pi's supported `pi-ai/compat` alias
- add regression coverage that loads the extension outside the repository without peer dependencies

## Root cause

Pi-managed extension installs omit host-provided peer dependencies. Pi's Jiti loader then rewrote the unsupported `@earendil-works/pi-ai/api/*.lazy` imports beneath `compat.js`, producing an invalid `compat.js/api/...` path in Pi 0.81.1 and 0.82.0.

## Validation

- `npm run check` in a clean copy: 227 passed, 1 skipped
- `npm run clean && npm run build`
- rebuilt packaged extension loaded successfully with Pi 0.82.0's isolated extension loader

Fixes #93