### PR TITLE
chore: release v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Release v2.0.1 with the extension-loading fix from #102.

## User impact

Pi-managed installations on Pi 0.81.1 and 0.82.0 can load the LiteLLM extension again without the invalid `compat.js/api/...` module path reported in #93 and #101.

## Validation

- clean `npm ci`
- `npm run prepublishOnly`
- `npm pack --dry-run --json`
- signed release commit