### PR TITLE
fix(discover): expand wildcard /model/info entries via /v1/models

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -515,7 +515,7 @@ export async function discoverModels(
     // /v1/models instead. When /model/info contains any wildcard id, also query
     // /v1/models and merge the expanded (non-wildcard) entries in, dropping the
     // raw wildcard row so it doesn't surface as a phantom model choice.
-    // Refs: github.com/BerriAI/litellm/issues/16178, docs.litellm.ai/docs/proxy/model_discovery
+    // Ref: docs.litellm.ai/docs/proxy/model_discovery
     if (models.some((m) => m.id.includes("*"))) {
       progress?.("/model/info has wildcard entries, expanding via /v1/models...");
       let modelsDev: ModelsDevResponse | undefined;

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -508,8 +508,31 @@ export async function discoverModels(
         model_info: { ...previous?.model_info, ...entry.model_info },
       });
     }
-    const models = [...entries.values()].map(mapFromModelInfo).filter((m): m is DiscoveredModel => m !== undefined);
-    return { source: "model_info", models };
+    let models = [...entries.values()].map(mapFromModelInfo).filter((m): m is DiscoveredModel => m !== undefined);
+    // LiteLLM's /model/info does NOT expand wildcard model_name entries (e.g.
+    // "lemonade/*" backed by model: openai/* + check_provider_endpoint: true)
+    // — it returns the literal wildcard only. The discovered ids live in
+    // /v1/models instead. When /model/info contains any wildcard id, also query
+    // /v1/models and merge the expanded (non-wildcard) entries in, dropping the
+    // raw wildcard row so it doesn't surface as a phantom model choice.
+    // Refs: github.com/BerriAI/litellm/issues/16178, docs.litellm.ai/docs/proxy/model_discovery
+    if (models.some((m) => m.id.includes("*"))) {
+      progress?.("/model/info has wildcard entries, expanding via /v1/models...");
+      let modelsDev: ModelsDevResponse | undefined;
+      if (options.modelsDev !== false) {
+        progress?.("Loading models.dev catalog for metadata enrichment...");
+        modelsDev = await getModelsDevCatalog(options);
+      }
+      const listResult = await fetchJson<ModelsListResponse>(`${base}/v1/models`, apiKey, options);
+      if (listResult.ok) {
+        const expanded = (listResult.data.data ?? [])
+          .map((entry) => mapFromModelsList(entry, modelsDev))
+          .filter((m): m is DiscoveredModel => m !== undefined && !m.id.includes("*"));
+        const seen = new Set<string>(models.map((m) => m.id));
+        models = [...models.filter((m) => !m.id.includes("*")), ...expanded.filter((m) => !seen.has(m.id))];
+      }
+    }
+    return { source: "model_info", models: deduplicateModels(models) };
   }
   if (![401, 403, 404].includes(infoResult.status)) {
     throw new Error(`/model/info returned ${infoResult.status}`);

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -296,6 +296,70 @@ describe("discoverModels via /model/info", () => {
   });
 });
 
+describe("discoverModels wildcard expansion via /v1/models", () => {
+  it("expands a wildcard /model/info entry and drops the literal wildcard id", async () => {
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            { model_name: "lemonade/*", model_info: { mode: "chat" } },
+            { model_name: "lemonade/Qwen3.6-35B-A3B-MTP-GGUF-UD-IQ4_NL", model_info: { mode: "chat" } },
+          ],
+        });
+      }
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, {
+          data: [
+            { id: "lemonade/*", object: "model", owned_by: "openai" },
+            { id: "lemonade/Bonsai-1.7B-gguf", object: "model", owned_by: "openai" },
+            { id: "lemonade/Laguna-S-2.1-GGUF-UD-IQ4_NL", object: "model", owned_by: "openai" },
+            { id: "lemonade/Qwen3.6-35B-A3B-MTP-GGUF-UD-IQ4_NL", object: "model", owned_by: "openai" },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", { modelsDev: false });
+
+    expect(result.source).toBe("model_info");
+    expect(result.models.map((m) => m.id).sort()).toEqual([
+      "lemonade/Bonsai-1.7B-gguf",
+      "lemonade/Laguna-S-2.1-GGUF-UD-IQ4_NL",
+      "lemonade/Qwen3.6-35B-A3B-MTP-GGUF-UD-IQ4_NL",
+    ]);
+    // the raw wildcard id must NOT surface as a selectable model
+    expect(result.models.some((m) => m.id.includes("*"))).toBe(false);
+    // the concrete /model/info entry is not duplicated by /v1/models
+    expect(result.models.filter((m) => m.id === "lemonade/Qwen3.6-35B-A3B-MTP-GGUF-UD-IQ4_NL")).toHaveLength(1);
+    // /v1/models was actually queried (the expansion path ran)
+    expect(urls.some((u) => u.endsWith("/v1/models"))).toBe(true);
+  });
+
+  it("does not query /v1/models when /model/info has no wildcards", async () => {
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      urls.push(url);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "openai/gpt-4o", model_info: { mode: "chat" } }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", { modelsDev: false });
+
+    expect(result.source).toBe("model_info");
+    expect(result.models.map((m) => m.id)).toEqual(["openai/gpt-4o"]);
+    expect(urls.some((u) => u.endsWith("/v1/models"))).toBe(false);
+  });
+});
+
 describe("discoverModels response-mode models", () => {
   it("keeps /model/info response-mode models with a Responses API override", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {


### PR DESCRIPTION
## What & why

Fixes #107.

When a LiteLLM deployment uses a **wildcard** `model_name` (e.g. `lemonade/*` backed by `model: openai/*` with `litellm_settings.check_provider_endpoint: true`), `/model/info` returns only the literal wildcard — it does **not** expand it. The expanded ids live in `/v1/models` instead.

`discoverModels()` calls `/model/info` first and returns immediately on 200, only falling back to `/v1/models` on 401/403/404. So a wildcard-based campaign surfaces exactly one selectable "model" — `lemonade/*` — and the real downstream models never appear. Confirmed against a live LiteLLM 1.90.2 + lemonade-server setup:

```
GET /model/info → [{ model_name: "lemonade/*", ... }]                                   # wildcard only
GET /v1/models  → [ lemonade/*, lemonade/Bonsai-…, lemonade/Laguna-…, lemonade/Qwen3.6-… ] # expanded ✓
```

## Change

When `/model/info` returns 200 but contains any model id with `*`, also query `/v1/models` and merge the expanded (non-wildcard) entries in:

- drop the raw wildcard row(s) so they don't surface as phantom models;
- duplicate-protect against ids already present in the `/model/info` result (e.g. a concrete `lemonade/Qwen3.6-…` declared explicitly alongside the wildcard);
- reuse the existing `mapFromModelsList` + optional `models.dev` enrichment path (mirrors the existing `/v1/models` fallback), gated on the same `options.modelsDev !== false` check.

Non-wildcard `/model/info` deployments are unchanged — no extra `/v1/models` call is made.

## Tests

Added two cases in `tests/discover.test.ts` (`describe("discoverModels wildcard expansion via /v1/models")`):

1. `/model/info` with `lemonade/*` + a concrete `lemonade/Qwen3.6-…`, `/v1/models` returns the wildcard + 3 expanded ids → asserts `source === "model_info"`, the 3 concrete ids are the only ones present, no `*` id remains, the concrete entry isn't duplicated, and `/v1/models` was actually hit.
2. `/model/info` with no wildcards → asserts `/v1/models` is **not** queried (no regression / extra request for the common case).

Full suite: `229 passed | 1 skipped` (was 227 passed | 1 skipped), `npm run typecheck` and `npm run build` clean.

## Out of scope

Reasoning/thinking capability metadata is orthogonal — for OpenAI-compatible upstreams not listed on models.dev, `supports_reasoning` is `null` from `/model/info` and absent from `/v1/models`, so expanded models land with `reasoning: false` and "(no metadata)" display names. That's a provider-agnostic metadata gap (best addressed per-provider, e.g. via name heuristics like lemonade-server's own `isReasoningModel`), not part of this wildcard-expansion fix.

## Refs

- Issue: #107
- LiteLLM Model Discovery: https://docs.litellm.ai/docs/proxy/model_discovery
