### PR TITLE
fix: keep MCP discovery from blocking login

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -946,7 +946,9 @@ export default async function (pi: ExtensionAPI): Promise<void> {
         ) {
           const auth = await authForCredential(definition, context.credential);
           defaultRuntimeAuth = auth;
-          await registerMcpTools(auth, context.signal);
+          const registration = registerMcpTools(auth, context.signal);
+          if (context.signal) await registration;
+          else void registration.catch(() => undefined);
         }
       }
     };

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -150,6 +150,7 @@ describe("feature parity", () => {
     process.env.LITELLM_API_KEY = "second-token";
     process.env.LITELLM_HEADERS = '{"x-tenant":"second"}';
     await refreshProvider(pi);
+    await vi.waitFor(() => expect(pi.tools.map((tool) => tool.name)).toContain("mcp_second_second"));
 
     expect(fetchMock).toHaveBeenCalledWith(
       "https://first.example.com/mcp-rest/tools/list",
@@ -163,7 +164,6 @@ describe("feature parity", () => {
         headers: expect.objectContaining({ Authorization: "Bearer second-token", "x-tenant": "second" }),
       }),
     );
-    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_second_second");
   });
 
   it("shares in-flight MCP discovery between default-provider refreshes", async () => {
@@ -334,6 +334,7 @@ describe("feature parity", () => {
     const pi = createPi();
     await extension(pi);
     await refreshProvider(pi);
+    await vi.waitFor(() => expect(pi.tools.map((candidate) => candidate.name)).toContain("mcp_brave_search"));
     const tool = pi.tools.find((candidate) => candidate.name === "mcp_brave_search");
 
     await tool?.execute?.("call-1", { query: "Pi" }, undefined, undefined, {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -325,6 +325,62 @@ describe("extension startup", () => {
     expect(pi.providers[0]?.getModels()).toEqual([stored]);
   });
 
+  it("does not block model refresh on MCP discovery", async () => {
+    process.env.LITELLM_MODELS_DEV = "0";
+    let mcpStarted!: () => void;
+    let releaseMcp!: (response: Response) => void;
+    const started = new Promise<void>((resolve) => {
+      mcpStarted = resolve;
+    });
+    const pendingMcp = new Promise<Response>((resolve) => {
+      releaseMcp = resolve;
+    });
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, { data: [{ model_name: "fresh-model", model_info: { mode: "chat" } }] });
+      }
+      if (url.endsWith("/mcp-rest/tools/list")) {
+        mcpStarted();
+        return pendingMcp;
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(await makeAgentDir());
+    const pi = createPi();
+    await extension(pi);
+
+    let refreshed = false;
+    const refresh = refreshProvider(pi.providers[0]!, {
+      allowNetwork: true,
+      credential: {
+        type: "api_key",
+        key: "sk-test",
+        env: { LITELLM_BASE_URL: "https://litellm.example.com" },
+      },
+    }).then(() => {
+      refreshed = true;
+    });
+    await started;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(refreshed).toBe(true);
+    releaseMcp(
+      jsonResponse(200, {
+        tools: [
+          {
+            name: "search",
+            description: "Search",
+            inputSchema: { type: "object", properties: {} },
+            mcp_info: { server_name: "brave" },
+          },
+        ],
+      }),
+    );
+    await refresh;
+    await vi.waitFor(() => expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search"));
+  });
+
   it("retains Pi-managed models when discovery fails", async () => {
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));


### PR DESCRIPTION
## Summary

- keep no-signal model refreshes from awaiting MCP tool discovery
- preserve signal-aware MCP discovery and cancellation behavior
- add regression coverage for returning before MCP discovery completes and registering tools afterward

## Root cause

Pi 0.82.1 performs a no-signal network refresh before `/login` returns. The provider synchronously awaited MCP tool discovery during that refresh, so an unavailable MCP endpoint could freeze the login flow.

## Verification

- `NPM_CONFIG_CACHE=/private/tmp/pi-provider-litellm-npm-cache npm run check`
- 27 test files passed; 230 tests passed; 1 skipped

Fixes #109