### PR TITLE
fix: normalize tool messages for strict OpenAI schema validation (Moonshot/Kimi compatibility)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -651,29 +651,51 @@ function isReasoningItem(item: unknown): boolean {
   return typeof item === "object" && item !== null && (item as { type?: unknown }).type === "reasoning";
 }
 
-// Returns the original message reference when no normalization is needed.
-function normalizeStrictToolMessage(message: any): any {
-  if (
-    message.role === "assistant" &&
-    Array.isArray(message.tool_calls) &&
-    message.tool_calls.length > 0 &&
-    message.content == null
-  ) {
-    return { ...message, content: "" };
-  }
-  if (message.role === "tool" && Array.isArray(message.content)) {
-    return {
-      ...message,
-      content: message.content
+// Returns the original array reference when no normalization is needed.
+function normalizeStrictToolMessages(messages: any[]): any[] {
+  const normalized: any[] = [];
+  let imageParts: any[] = [];
+  let changed = false;
+  const flushImages = (): void => {
+    if (imageParts.length === 0) return;
+    normalized.push({
+      role: "user",
+      content: [{ type: "text", text: "Attached image(s) from tool result:" }, ...imageParts],
+    });
+    imageParts = [];
+  };
+
+  for (const message of messages) {
+    if (message.role !== "tool") flushImages();
+    if (
+      message.role === "assistant" &&
+      Array.isArray(message.tool_calls) &&
+      message.tool_calls.length > 0 &&
+      message.content == null
+    ) {
+      normalized.push({ ...message, content: "" });
+      changed = true;
+    } else if (message.role === "tool" && Array.isArray(message.content)) {
+      const previousImageCount = imageParts.length;
+      const content = message.content
         .map((part: any) => {
           if (typeof part === "string") return part;
-          if (part && part.type === "text") return part.text || "";
+          if (part?.type === "text") return part.text || "";
+          if (part?.type === "image_url") imageParts.push(part);
           return "";
         })
-        .join(""),
-    };
+        .join("");
+      normalized.push({
+        ...message,
+        content: content || (imageParts.length > previousImageCount ? "(see attached image)" : "(no tool output)"),
+      });
+      changed = true;
+    } else {
+      normalized.push(message);
+    }
   }
-  return message;
+  flushImages();
+  return changed ? normalized : messages;
 }
 
 // Reasoning fields LiteLLM forwards to chat-completions providers. The Moonshot
@@ -740,8 +762,8 @@ function prepareLiteLLMRequestPayload(
   if (modelId && isMoonshotModel(modelId)) {
     const messages = (next ?? payload).messages;
     if (Array.isArray(messages)) {
-      const normalized = messages.map(normalizeStrictToolMessage);
-      if (normalized.some((message, index) => message !== messages[index])) {
+      const normalized = normalizeStrictToolMessages(messages);
+      if (normalized !== messages) {
         next ??= { ...payload };
         next.messages = normalized;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,13 @@ import type {
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { setupLiteLLMCostTracking } from "./cost.js";
-import { discoverModels, isGpt55Model, normalizeBaseUrl, shouldSuppressReasoningContent } from "./discover.js";
+import {
+  discoverModels,
+  isGpt55Model,
+  isMoonshotModel,
+  normalizeBaseUrl,
+  shouldSuppressReasoningContent,
+} from "./discover.js";
 import {
   getGcloudToken,
   getGcloudTokenCacheKey,
@@ -645,6 +651,31 @@ function isReasoningItem(item: unknown): boolean {
   return typeof item === "object" && item !== null && (item as { type?: unknown }).type === "reasoning";
 }
 
+// Returns the original message reference when no normalization is needed.
+function normalizeStrictToolMessage(message: any): any {
+  if (
+    message.role === "assistant" &&
+    Array.isArray(message.tool_calls) &&
+    message.tool_calls.length > 0 &&
+    message.content == null
+  ) {
+    return { ...message, content: "" };
+  }
+  if (message.role === "tool" && Array.isArray(message.content)) {
+    return {
+      ...message,
+      content: message.content
+        .map((part: any) => {
+          if (typeof part === "string") return part;
+          if (part && part.type === "text") return part.text || "";
+          return "";
+        })
+        .join(""),
+    };
+  }
+  return message;
+}
+
 // Reasoning fields LiteLLM forwards to chat-completions providers. The Moonshot
 // path defaults them off; the gpt-5.5 tool path strips them entirely.
 const REASONING_SUPPRESSION_DEFAULTS: Record<string, unknown> = {
@@ -701,6 +732,19 @@ function prepareLiteLLMRequestPayload(
     if (Array.isArray(input) && input.some(isReasoningItem)) {
       next ??= { ...payload };
       next.input = input.filter((item) => !isReasoningItem(item));
+    }
+  }
+
+  // Moonshot/Kimi applies strict OpenAI schema validation: assistant tool calls
+  // must carry string content, and tool results must be plain text.
+  if (modelId && isMoonshotModel(modelId)) {
+    const messages = (next ?? payload).messages;
+    if (Array.isArray(messages)) {
+      const normalized = messages.map(normalizeStrictToolMessage);
+      if (normalized.some((message, index) => message !== messages[index])) {
+        next ??= { ...payload };
+        next.messages = normalized;
+      }
     }
   }
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -760,7 +760,7 @@ describe("feature parity", () => {
     });
   });
 
-  it("flattens array tool result content for Kimi requests", async () => {
+  it("preserves image blocks after Kimi tool results", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
@@ -779,12 +779,14 @@ describe("feature parity", () => {
             {
               role: "tool",
               tool_call_id: "call_1",
-              content: [
-                "plain ",
-                { type: "text", text: "text part" },
-                { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
-              ],
+              content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } }],
             },
+            {
+              role: "tool",
+              tool_call_id: "call_2",
+              content: [{ type: "text", text: "second output" }],
+            },
+            { role: "tool", tool_call_id: "call_3", content: [] },
           ],
         },
       },
@@ -792,7 +794,18 @@ describe("feature parity", () => {
     );
 
     expect(updated).toEqual({
-      messages: [{ role: "tool", tool_call_id: "call_1", content: "plain text part" }],
+      messages: [
+        { role: "tool", tool_call_id: "call_1", content: "(see attached image)" },
+        { role: "tool", tool_call_id: "call_2", content: "second output" },
+        { role: "tool", tool_call_id: "call_3", content: "(no tool output)" },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Attached image(s) from tool result:" },
+            { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+          ],
+        },
+      ],
       include_reasoning: false,
       reasoning_content: false,
       merge_reasoning_content_in_choices: true,

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -715,6 +715,146 @@ describe("feature parity", () => {
     expect(updated).toBeUndefined();
   });
 
+  it("fills empty assistant content on Kimi tool calls", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      {
+        payload: {
+          messages: [
+            { role: "user", content: "hi" },
+            {
+              role: "assistant",
+              content: null,
+              tool_calls: [{ id: "call_1", type: "function", function: { name: "noop", arguments: "{}" } }],
+            },
+            { role: "tool", tool_call_id: "call_1", content: "tool output" },
+          ],
+        },
+      },
+      { model: { provider: "litellm", id: "kimi-k3" } },
+    );
+
+    expect(updated).toEqual({
+      messages: [
+        { role: "user", content: "hi" },
+        {
+          role: "assistant",
+          content: "",
+          tool_calls: [{ id: "call_1", type: "function", function: { name: "noop", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "tool output" },
+      ],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+    });
+  });
+
+  it("flattens array tool result content for Kimi requests", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      {
+        payload: {
+          messages: [
+            {
+              role: "tool",
+              tool_call_id: "call_1",
+              content: [
+                "plain ",
+                { type: "text", text: "text part" },
+                { type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } },
+              ],
+            },
+          ],
+        },
+      },
+      { model: { provider: "litellm", id: "kimi-k3" } },
+    );
+
+    expect(updated).toEqual({
+      messages: [{ role: "tool", tool_call_id: "call_1", content: "plain text part" }],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+    });
+  });
+
+  it("leaves well-formed Kimi tool messages untouched", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const messages = [
+      {
+        role: "assistant",
+        content: "calling the tool",
+        tool_calls: [{ id: "call_1", type: "function", function: { name: "noop", arguments: "{}" } }],
+      },
+      { role: "tool", tool_call_id: "call_1", content: "tool output" },
+    ];
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.({ payload: { messages } }, { model: { provider: "litellm", id: "kimi-k3" } });
+
+    expect(updated?.messages).toBe(messages);
+  });
+
+  it("leaves strict-schema tool messages untouched for non-Moonshot models", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      {
+        payload: {
+          messages: [
+            {
+              role: "assistant",
+              content: null,
+              tool_calls: [{ id: "call_1", type: "function", function: { name: "noop", arguments: "{}" } }],
+            },
+            { role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: "tool output" }] },
+          ],
+        },
+      },
+      { model: { provider: "litellm", id: "anthropic/claude-3-5-sonnet" } },
+    );
+
+    expect(updated).toBeUndefined();
+  });
+
   it("drops reasoning fields for llm-gateway/gpt-5.5 tool requests", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -321,7 +321,11 @@ describe("extension startup", () => {
       "https://litellm.example.com/model/info",
       "https://litellm.example.com/mcp-rest/tools/list",
     ]);
-    expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
+    // MCP registration runs in the background so a hanging /mcp-rest endpoint
+    // cannot block model refresh; wait for it to finish before asserting.
+    await vi.waitFor(() => {
+      expect(pi.tools.map((tool) => tool.name)).toContain("mcp_brave_search");
+    });
     expect(pi.providers[0]?.getModels()).toEqual([stored]);
   });
 


### PR DESCRIPTION
This PR adds payload normalization for `kimi-*` models to comply with their strict API schema validation requirements, specifically when using function calling (tools).

**Context:**
The Moonshot (Kimi) API enforces stricter schema checks than the standard OpenAI API:
1. **Assistant tool calls:** When an assistant message contains `tool_calls`, standard OpenAI models accept `content: null` or an omitted `content` field. Moonshot API strictly requires `content: ""` and throws a 400 Bad Request error otherwise.
2. **Tool result arrays:** When a `tool` role message returns content as an array of content blocks (e.g. `[{"type": "text", "text": "..."}]`), Moonshot API rejects it with a 400 error, expecting a plain string. 

**Changes:**
- Before sending the payload to the proxy, this patch checks if the model ID starts with `kimi-`.
- Maps the messages array to ensure `msg.content = ""` on assistant tool calls if it is null or undefined.
- Flattens array-based `msg.content` structures into joined text strings for `tool` responses.

This prevents the `400: The request was invalid.` errors when using the `pi` agent with Kimi models.