### PR TITLE
fix: enrich bare Fable 5 model aliases

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -139,6 +139,7 @@ function catalogLookupIds(id: string): string[] {
   const anthropicAlias = unprefixed.toLowerCase().replaceAll(".", "-");
   const match = /^(?:claude-)?(opus|sonnet|haiku)-(\d+)-(\d+)$/.exec(anthropicAlias);
   if (match) lookupIds.add(`claude-${match[1]}-${match[2]}-${match[3]}`);
+  if (anthropicAlias === "fable-5") lookupIds.add("claude-fable-5");
 
   return [...lookupIds];
 }

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -895,6 +895,33 @@ describe("discoverModels fallback to /v1/models", () => {
     });
   });
 
+  it("enriches a bare Fable 5 fallback model from the Pi catalog", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = input instanceof URL ? input.toString() : String(input);
+      if (url.endsWith("/model/info")) return new Response(null, { status: 403 });
+      if (url.endsWith("/v1/models")) {
+        return jsonResponse(200, {
+          data: [{ id: "fable-5", object: "model", owned_by: "openai" }],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", { modelsDev: false });
+
+    expect(result).toMatchObject({
+      source: "models_list",
+      models: [
+        {
+          id: "fable-5",
+          name: "Claude Fable 5",
+          reasoning: true,
+          thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        },
+      ],
+    });
+  });
+
   it("uses models.dev metadata when LiteLLM returns provider ownership", async () => {
     const urls: string[] = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {


### PR DESCRIPTION
## Summary

- enrich the bare `fable-5` LiteLLM alias from Pi's canonical Claude Fable 5 catalog entry
- expose reasoning and native thinking levels when discovery falls back to `/v1/models`
- add regression coverage for the live `403` fallback shape

## Root cause

The deployment exposes `fable-5` with `owned_by: "openai"`. Existing alias normalization covered Opus, Sonnet, and Haiku, but not Fable, so catalog enrichment missed `claude-fable-5` and defaulted `reasoning` to `false`.

## Validation

- `npm run check` (231 passed, 1 skipped)
- `npm run clean`
- `npm run build`
- independent review: approved with no findings