### PR TITLE
chore: release v2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump package metadata to 2.0.3
- prepare the next patch release

## Verification

- `npm ci`
- `npm run prepublishOnly`
- `npm pack --dry-run --json`

All release checks were run from a clean copy excluding `.git`, `.worktrees`, `node_modules`, and `dist`.