### PR TITLE
chore: release v2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Release

Prepare `pi-provider-litellm` v2.0.4 after restoring reasoning and native `xhigh`/`max` thinking levels for bare Opus 5 aliases.

## Changes

- Update `package.json` and `package-lock.json` to `2.0.4`.
- Preserve the Pi 0.81+ runtime compatibility floor.

## Validation

- `npm ci`
- `npm run prepublishOnly` (237 passed, 1 skipped; supply-chain guard passed)
- `npm pack --dry-run --json` (25 allowed files)
- `git diff --check`
- Signed release commit independently reviewed