### PR TITLE
fix: re-enrich stale cached model metadata

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -132,7 +132,22 @@ function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined 
 }
 
 export function enrichCachedModel(model: Model<Api>): Model<Api> {
-  if (!model.name.endsWith(" (no metadata)")) return model;
+  if (
+    !model.name.endsWith(" (no metadata)") ||
+    model.reasoning ||
+    model.thinkingLevelMap !== undefined ||
+    model.input.length !== 1 ||
+    model.input[0] !== "text" ||
+    model.cost.input !== 0 ||
+    model.cost.output !== 0 ||
+    model.cost.cacheRead !== 0 ||
+    model.cost.cacheWrite !== 0 ||
+    model.cost.tiers !== undefined ||
+    model.contextWindow !== DEFAULT_CONTEXT_WINDOW ||
+    model.maxTokens !== DEFAULT_MAX_TOKENS
+  ) {
+    return model;
+  }
   const catalogModel = findCatalogModel(model.id);
   if (!catalogModel) return model;
   return {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -131,6 +131,22 @@ function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined 
   return undefined;
 }
 
+export function enrichCachedModel(model: Model<Api>): Model<Api> {
+  if (!model.name.endsWith(" (no metadata)")) return model;
+  const catalogModel = findCatalogModel(model.id);
+  if (!catalogModel) return model;
+  return {
+    ...model,
+    name: catalogModel.name,
+    reasoning: catalogModel.reasoning,
+    thinkingLevelMap: catalogModel.thinkingLevelMap,
+    input: catalogModel.input,
+    cost: catalogModel.cost,
+    contextWindow: catalogModel.contextWindow,
+    maxTokens: catalogModel.maxTokens,
+  };
+}
+
 function catalogLookupIds(id: string): string[] {
   const lookupIds = new Set([id]);
   const unprefixed = id.includes("/") ? id.slice(id.indexOf("/") + 1) : id;

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -132,6 +132,7 @@ function findCatalogModel(id: string, ownedBy?: string): Model<Api> | undefined 
 }
 
 export function enrichCachedModel(model: Model<Api>): Model<Api> {
+  // ponytail: legacy cache lacks field provenance; add per-field cache provenance if strict preservation becomes necessary.
   if (
     !model.name.endsWith(" (no metadata)") ||
     model.reasoning ||

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,5 +1,6 @@
 import { type Credential, createProvider, type Model, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
 import { openAICompletionsApi, openAIResponsesApi } from "@earendil-works/pi-ai/compat";
+import { enrichCachedModel } from "./discover.js";
 import type { DiscoveredModel, DiscoveryResult, LiteLLMApi } from "./types.js";
 
 export type LiteLLMProviderOptions = {
@@ -24,7 +25,7 @@ export function toNativeModels(
 }
 
 export function createLiteLLMProvider(options: LiteLLMProviderOptions): Provider<LiteLLMApi> {
-  return createProvider<LiteLLMApi>({
+  const provider = createProvider<LiteLLMApi>({
     id: options.id,
     name: options.name,
     baseUrl: options.baseUrl,
@@ -40,4 +41,20 @@ export function createLiteLLMProvider(options: LiteLLMProviderOptions): Provider
       "openai-responses": openAIResponsesApi(),
     },
   });
+  const refreshModels = provider.refreshModels;
+  if (!refreshModels) return provider;
+  return {
+    ...provider,
+    refreshModels: (context) =>
+      refreshModels({
+        ...context,
+        store: {
+          ...context.store,
+          async read() {
+            const entry = await context.store.read();
+            return entry && { ...entry, models: entry.models.map(enrichCachedModel) };
+          },
+        },
+      }),
+  };
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -49,11 +49,12 @@ export function createLiteLLMProvider(options: LiteLLMProviderOptions): Provider
       refreshModels({
         ...context,
         store: {
-          ...context.store,
           async read() {
             const entry = await context.store.read();
             return entry && { ...entry, models: entry.models.map(enrichCachedModel) };
           },
+          write: (entry) => context.store.write(entry),
+          delete: () => context.store.delete(),
         },
       }),
   };

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -124,6 +124,7 @@ describe("createLiteLLMProvider", () => {
             ...native("opus-5"),
             name: "opus-5 (no metadata)",
             reasoning: false,
+            maxTokens: 16_384,
           },
         ]),
         false,
@@ -142,6 +143,32 @@ describe("createLiteLLMProvider", () => {
       }),
     ]);
     expect(discover).not.toHaveBeenCalled();
+  });
+
+  it("keeps partially enriched stale cached aliases unchanged offline", async () => {
+    const legacyFallback: Model<Api> = {
+      ...native("opus-5"),
+      name: "opus-5 (no metadata)",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 16_384,
+    };
+    const partialCached: Model<Api>[] = [
+      { ...legacyFallback, reasoning: true },
+      { ...legacyFallback, input: ["text", "image"] },
+      { ...legacyFallback, cost: { input: 1, output: 0, cacheRead: 0, cacheWrite: 0 } },
+      { ...legacyFallback, contextWindow: 128_001 },
+      { ...legacyFallback, maxTokens: 16_385 },
+    ];
+    for (const cached of partialCached) {
+      const value = controller();
+
+      await value.refreshModels?.(context(store([cached]), false));
+
+      expect(value.getModels()).toEqual([cached]);
+    }
   });
 
   it("keeps unknown stale cached models unchanged offline", async () => {

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -11,7 +11,8 @@ import { createLiteLLMProvider, toNativeModels } from "../src/provider.js";
 import type { DiscoveryResult } from "../src/types.js";
 
 const apiSpies = vi.hoisted(() => ({ completions: vi.fn(), responses: vi.fn() }));
-vi.mock("@earendil-works/pi-ai/compat", () => ({
+vi.mock("@earendil-works/pi-ai/compat", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@earendil-works/pi-ai/compat")>()),
   openAICompletionsApi: () => ({ stream: apiSpies.completions, streamSimple: apiSpies.completions }),
   openAIResponsesApi: () => ({ stream: apiSpies.responses, streamSimple: apiSpies.responses }),
 }));
@@ -110,6 +111,47 @@ describe("createLiteLLMProvider", () => {
 
     expect(value.getModels()).toEqual([native("stored")]);
     expect(discover).not.toHaveBeenCalled();
+  });
+
+  it("re-enriches stale cached catalog aliases offline without discovery", async () => {
+    const discover = vi.fn(async () => discovered("fresh"));
+    const value = controller({ discover });
+
+    await value.refreshModels?.(
+      context(
+        store([
+          {
+            ...native("opus-5"),
+            name: "opus-5 (no metadata)",
+            reasoning: false,
+          },
+        ]),
+        false,
+      ),
+    );
+
+    expect(value.getModels()).toEqual([
+      expect.objectContaining({
+        id: "opus-5",
+        name: "Claude Opus 5",
+        reasoning: true,
+        thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+        provider: "litellm",
+        api: "openai-completions",
+        baseUrl: "https://proxy.example/v1",
+      }),
+    ]);
+    expect(discover).not.toHaveBeenCalled();
+  });
+
+  it("keeps unknown stale cached models unchanged offline", async () => {
+    const discover = vi.fn(async () => discovered("fresh"));
+    const cached = { ...native("unknown-model"), name: "unknown-model (no metadata)" };
+    const value = controller({ discover });
+
+    await value.refreshModels?.(context(store([cached]), false));
+
+    expect(value.getModels()).toEqual([cached]);
   });
 
   it("publishes and persists successful discovery", async () => {

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -55,6 +55,22 @@ function store(initial?: readonly Model<Api>[]) {
   return value;
 }
 
+class PrototypeStore implements ProviderModelsStore {
+  entry: Awaited<ReturnType<ProviderModelsStore["read"]>>;
+
+  async read() {
+    return this.entry;
+  }
+
+  async write(entry: Parameters<ProviderModelsStore["write"]>[0]) {
+    this.entry = entry;
+  }
+
+  async delete() {
+    this.entry = undefined;
+  }
+}
+
 function context(modelsStore: ProviderModelsStore, allowNetwork: boolean): RefreshModelsContext {
   return { store: modelsStore, allowNetwork, credential };
 }
@@ -190,6 +206,16 @@ describe("createLiteLLMProvider", () => {
     expect(value.getModels()).toEqual([native("fresh")]);
     expect(modelsStore.write).toHaveBeenCalledOnce();
     expect(modelsStore.write).toHaveBeenCalledWith(expect.objectContaining({ models: [native("fresh")] }));
+  });
+
+  it("persists online discovery through a prototype-backed store", async () => {
+    const modelsStore = new PrototypeStore();
+    const value = controller({ discover: vi.fn(async () => discovered("fresh")) });
+
+    await value.refreshModels?.(context(modelsStore, true));
+
+    expect(value.getModels()).toEqual([native("fresh")]);
+    expect(modelsStore.entry?.models).toEqual([native("fresh")]);
   });
 
   it("publishes discovered models with the credential URL", async () => {


### PR DESCRIPTION
## Summary

- re-enrich complete legacy fallback entries from the current Pi catalog during offline cache restoration
- preserve partial and unknown metadata plus LiteLLM routing fields
- delegate class-backed model store methods without losing receiver binding

## Compatibility note

Legacy caches have no per-field provenance. Entries matching the complete fallback shape migrate to catalog metadata by design; partial explicit metadata remains unchanged.

## Verification

- `npm run check` — 241 passed, 1 skipped
- `npm run clean`
- `npm run build`
- `git diff --check origin/main...HEAD`
- independent final review: ready to merge, no findings