### PR TITLE
fix: update vulnerable Pi dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,14 @@
       "peerDependencies": {
         "@earendil-works/pi-ai": ">=0.81.0",
         "@earendil-works/pi-coding-agent": ">=0.81.0"
+      },
+      "peerDependenciesMeta": {
+        "@earendil-works/pi-ai": {
+          "optional": true
+        },
+        "@earendil-works/pi-coding-agent": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/crc32": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -972,29 +972,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -1215,16 +1192,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
-      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22.19.0"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
       "version": "2.0.2",
@@ -2697,6 +2664,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2734,6 +2711,19 @@
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -3845,6 +3835,16 @@
       "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/undici-types": {
       "version": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   },
   "overrides": {
     "basic-ftp": "6.0.1",
-    "fast-xml-builder": "1.2.0",
-    "protobufjs": "8.7.1"
+    "protobufjs": "8.7.1",
+    "undici": "8.9.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,14 @@
     "@earendil-works/pi-ai": ">=0.81.0",
     "@earendil-works/pi-coding-agent": ">=0.81.0"
   },
+  "peerDependenciesMeta": {
+    "@earendil-works/pi-ai": {
+      "optional": true
+    },
+    "@earendil-works/pi-coding-agent": {
+      "optional": true
+    }
+  },
   "overrides": {
     "basic-ftp": "6.0.1",
     "protobufjs": "8.7.1",

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -52,6 +52,10 @@ describe("pi package compatibility", () => {
 
     expect(manifest.peerDependencies["@earendil-works/pi-ai"]).toBe(">=0.81.0");
     expect(manifest.peerDependencies["@earendil-works/pi-coding-agent"]).toBe(">=0.81.0");
+    expect(manifest.peerDependenciesMeta).toEqual({
+      "@earendil-works/pi-ai": { optional: true },
+      "@earendil-works/pi-coding-agent": { optional: true },
+    });
     expect(manifest.devDependencies["@earendil-works/pi-ai"]).toBe("^0.83.0");
     expect(manifest.devDependencies["@earendil-works/pi-coding-agent"]).toBe("^0.83.0");
   });

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -87,9 +87,8 @@ describe("dependency security overrides", () => {
 
     // basic-ftp left the dependency tree entirely; its override is vestigial.
     expect(Object.values(copiesOf("basic-ftp")).every((version) => version === "6.0.1")).toBe(true);
-    const fastXmlBuilderCopies = Object.values(copiesOf("fast-xml-builder"));
-    expect(fastXmlBuilderCopies).not.toHaveLength(0);
-    expect(fastXmlBuilderCopies.every((version) => version === "1.2.0")).toBe(true);
+    expect(Object.values(copiesOf("brace-expansion"))).toEqual(["5.0.9"]);
+    expect(Object.values(copiesOf("undici"))).toEqual(["8.9.0"]);
     // Pi 0.81.1 no longer ships a nested protobufjs copy.
     expect(copiesOf("protobufjs")).toEqual({
       "node_modules/protobufjs": "8.7.1",


### PR DESCRIPTION
## Summary

- keep Pi development dependencies on the supported 0.83 line
- override `undici` to 8.9.0 and resolve `brace-expansion` to 5.0.9
- mark Pi host peers optional so installing the extension does not auto-install Pi packages or surface their install-script warnings
- replace the obsolete `fast-xml-builder` lock assertion with checks for the remediated dependencies

## Root cause

`npm audit fix --force` selected the vulnerable Pi 0.75.3 line. Restoring 0.83.0 exposed newer transitive advisories, while npm's automatic peer installation also pulled host-provided Pi packages into standalone extension installs.

## User impact

The extension package now installs without pulling its Pi host peers. A clean tarball install adds only `pi-provider-litellm`, emits no `allowScripts` warning, and leaves Pi to provide its own runtime APIs.

## Validation

- `npm run prepublishOnly`
- `npm audit --json` (0 vulnerabilities)
- `npm pack --dry-run`
- clean tarball consumer install (only the extension installed)
- 241 tests passed, 1 skipped