### PR TITLE
chore: release v2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump `pi-provider-litellm` from 2.0.4 to 2.0.5
- publish the stale cached metadata fixes from #124
- publish the secure Pi dependency and optional peer-install fixes from #125

## User impact

Cached model metadata is refreshed more reliably, and installing the extension no longer pulls Pi host packages while retaining the dependency security updates.

## Validation

- clean-copy `npm ci`
- clean-copy `npm run prepublishOnly`
- clean-copy `npm pack --dry-run --json`
- 241 tests passed, 1 skipped
- signed release commit