### PR TITLE
fix: harden remote and release trust boundaries

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,0 +1,1 @@
+balcsida@gmail.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIcbnKfDVPJ9+k6+rwbQea3wYoxe5g6hNgTXXmYPLOKd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           node-version: '26.5.0'
           cache: 'npm'
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run prepublishOnly

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -35,7 +35,7 @@ jobs:
       LITELLM_MASTER_KEY: sk-ci-litellm-smoke
       LITELLM_LICENSE: ${{ github.event_name != 'pull_request' && secrets.LITELLM_LICENSE || '' }}
       LITELLM_DATABASE_URL: postgresql://litellm:litellm@host.docker.internal:5432/litellm
-      LITELLM_IMAGE: ${{ github.event_name != 'pull_request' && secrets.LITELLM_LICENSE != '' && 'docker.litellm.ai/berriai/litellm-database:main-latest' || 'docker.litellm.ai/berriai/litellm:main-latest' }}
+      LITELLM_IMAGE: ${{ github.event_name != 'pull_request' && secrets.LITELLM_LICENSE != '' && 'docker.litellm.ai/berriai/litellm-database@sha256:8b229a4b48fbe62d7f994b502106c3c1dbab958c07934fb446ac0e048a62745e' || 'docker.litellm.ai/berriai/litellm@sha256:f2dc9ba8a62cf2c51e3ed00e6975f4c70bb577b8ef0c2d7040e3228dc7d42b09' }}
       LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude
       LITELLM_SMOKE_EXPECT_SOURCE: model_info
       LITELLM_CLI_SMOKE_MODEL: vidaimock-openai
@@ -51,7 +51,7 @@ jobs:
           node-version: '26.5.0'
           cache: 'npm'
 
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npm run build
 
       - name: Install VidaiMock
@@ -107,7 +107,7 @@ jobs:
             -e POSTGRES_PASSWORD=litellm \
             -e POSTGRES_DB=litellm \
             -p 5432:5432 \
-            postgres:16-alpine
+            postgres:16-alpine@sha256:44c4ee9810eff91f7eab4d822642e01115b1a9eccce4bcbdde7604752d68eac6
 
       - name: Wait for LiteLLM smoke database
         if: ${{ env.LITELLM_LICENSE != '' }}

--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -42,6 +42,7 @@ jobs:
       LITELLM_CLI_SMOKE_MODEL_ANTHROPIC: anthropic/vidaimock-claude
       VIDAIMOCK_BASE_URL: http://127.0.0.1:8100
       VIDAIMOCK_VERSION: v0.2.7
+      VIDAIMOCK_SHA256: 3095dd2794b6bd3623057beb1c7def22ae366b85121acb72b3c92a54f79eb7fe
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -64,10 +65,7 @@ jobs:
           curl -fsSL \
             "https://github.com/vidaiUK/VidaiMock/releases/download/${VIDAIMOCK_VERSION}/${asset}" \
             -o ".tmp/${asset}"
-          curl -fsSL \
-            "https://github.com/vidaiUK/VidaiMock/releases/download/${VIDAIMOCK_VERSION}/${asset%.tar.gz}.sha256" \
-            -o ".tmp/${asset%.tar.gz}.sha256"
-          (cd .tmp && sha256sum -c "${asset%.tar.gz}.sha256")
+          (cd .tmp && printf '%s  %s\n' "$VIDAIMOCK_SHA256" "$asset" | sha256sum -c -)
           tar -xzf ".tmp/${asset}" -C .tmp
           install -m 0755 .tmp/vidaimock/vidaimock .tmp/bin/vidaimock
           .tmp/bin/vidaimock --version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '26.5.0'
           package-manager-cache: false
           registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
+      - name: Validate signed release tag
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          ref=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$GITHUB_REF_NAME")
+          test "$(jq -r .object.type <<<"$ref")" = tag
+          tag=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$(jq -r .object.sha <<<"$ref")")
+          test "$(jq -r .verification.verified <<<"$tag")" = true
+          test "$(jq -r .object.sha <<<"$tag")" = "$GITHUB_SHA"
+          tagCommit=$(git rev-parse "$GITHUB_REF_NAME^{}")
+          test "$tagCommit" = "$GITHUB_SHA"
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+          packageVersion=$(node -p "require('./package.json').version")
+          test "${GITHUB_REF_NAME#v}" = "$packageVersion"
+          lockVersion=$(node -p "require('./package-lock.json').version")
+          test "$lockVersion" = "$packageVersion"
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - run: npm ci --ignore-scripts
       - name: Publish to npm
         run: npm publish --access public --provenance
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
           tag=$(gh api "repos/$GITHUB_REPOSITORY/git/tags/$(jq -r .object.sha <<<"$ref")")
           test "$(jq -r .verification.verified <<<"$tag")" = true
           test "$(jq -r .object.sha <<<"$tag")" = "$GITHUB_SHA"
+          git -c gpg.format=ssh -c gpg.ssh.allowedSignersFile=.github/release-allowed-signers verify-tag "$GITHUB_REF_NAME"
           tagCommit=$(git rev-parse "$GITHUB_REF_NAME^{}")
           test "$tagCommit" = "$GITHUB_SHA"
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ LiteLLM Skills and MCP integration are enabled by default. Disable either featur
 
 Setting `skills.enabled` to `false` disables the Skills Gateway management tools, skill fetching, and system-prompt injection. Setting `mcp.enabled` to `false` disables LiteLLM MCP discovery and tool registration. Restart Pi after changing these settings so previously registered tools are removed.
 
+Treat the configured LiteLLM proxy as trusted: Skills can add instructions to the system prompt, and MCP can expose tools the agent may call. Disable these integrations when the proxy, its administrators, or its configured content are not fully trusted.
+
 ## Use
 
 ```
@@ -155,6 +157,8 @@ Setting `skills.enabled` to `false` disables the Skills Gateway management tools
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
 | `LITELLM_VERBOSE_DISCOVERY` | unset | If `1`, enable progress messages during model and MCP discovery (login, refresh, startup); discovery is silent by default |
 | `LITELLM_MODELS_DEV` | enabled | Set to `0` to disable models.dev metadata enrichment, including its cache and network request; `/v1/models` still uses Pi catalog metadata and defaults |
+
+Only use a trusted `LITELLM_API_KEY_HELPER` or `!command`. Prefer an absolute executable path, keep secrets out of command arguments, and print only the token to stdout without logging it to stderr.
 
 `LITELLM_DISCOVERY_TIMEOUT_MS=0` disables automatic and explicit refresh model discovery. It does not replace the base URL or API key settings required to send requests when you are not using `/login litellm`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4816,9 +4816,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   },
   "overrides": {
     "basic-ftp": "6.0.1",
+    "nanoid": "3.3.18",
     "protobufjs": "8.7.1",
     "undici": "8.9.0"
   },

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Provider } from "@earendil-works/pi-ai";
 import { normalizeBaseUrl } from "../src/discover.js";
-import { smokeChatCompletion } from "./smoke-runner.js";
+import { readErrorBody, smokeChatCompletion } from "./smoke-runner.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const BAD_SMOKE_KEY = "bad-smoke-key";
@@ -36,15 +36,6 @@ type SmokePi = {
   registerTool: () => void;
   on: () => void;
 };
-
-async function readErrorBody(response: Response): Promise<string> {
-  try {
-    const body = await response.text();
-    return body ? `: ${body.slice(0, 500)}` : "";
-  } catch {
-    return "";
-  }
-}
 
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   return fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -7,7 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Provider } from "@earendil-works/pi-ai";
 import { normalizeBaseUrl } from "../src/discover.js";
-import { readErrorBody, smokeChatCompletion } from "./smoke-runner.js";
+import { smokeChatCompletion } from "./smoke-runner.js";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 const BAD_SMOKE_KEY = "bad-smoke-key";
@@ -60,13 +60,13 @@ function isAuthFailure(status: number): boolean {
 
 async function expectAuthFailure(label: string, response: Response): Promise<void> {
   if (!isAuthFailure(response.status)) {
-    throw new Error(`${label} should reject auth, got ${response.status}${await readErrorBody(response)}`);
+    throw new Error(`${label} should reject auth, got ${response.status}`);
   }
 }
 
 async function expectOk(label: string, response: Response): Promise<void> {
   if (!response.ok) {
-    throw new Error(`${label} returned ${response.status}${await readErrorBody(response)}`);
+    throw new Error(`${label} returned ${response.status}`);
   }
 }
 

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -49,10 +49,21 @@ export function parseSmokeModels(raw: string | undefined): string[] {
     .filter((model) => model.length > 0);
 }
 
-async function readErrorBody(response: Response): Promise<string> {
+export function redactErrorBody(body: string): string {
+  return body
+    .replace(/(Bearer\s+)[^"',\s}\]]+/gi, "$1[REDACTED]")
+    .replace(/\b(?:sk|pk)-[A-Za-z0-9._-]+\b/g, "[REDACTED]")
+    .replace(
+      /(\b(?:authorization|(?:access|refresh|id)[_-]?token|token|api[_-]?key|secret|password)\b["']?\s*[:=]\s*["']?)[^"',&;\s}\]]+/gi,
+      "$1[REDACTED]",
+    )
+    .replace(/\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]");
+}
+
+export async function readErrorBody(response: Response): Promise<string> {
   try {
     const body = await response.text();
-    return body ? `: ${body.slice(0, 500)}` : "";
+    return body ? `: ${redactErrorBody(body.slice(0, 500))}` : "";
   } catch {
     return "";
   }

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -49,26 +49,6 @@ export function parseSmokeModels(raw: string | undefined): string[] {
     .filter((model) => model.length > 0);
 }
 
-export function redactErrorBody(body: string): string {
-  return body
-    .replace(/(Bearer\s+)[^"',\s}\]]+/gi, "$1[REDACTED]")
-    .replace(/\b(?:sk|pk)-[A-Za-z0-9._-]+\b/g, "[REDACTED]")
-    .replace(
-      /(\b(?:authorization|(?:access|refresh|id)[_-]?token|token|api[_-]?key|secret|password)\b["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^,&;\r\n}\]]+)/gi,
-      "$1[REDACTED]",
-    )
-    .replace(/\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]");
-}
-
-export async function readErrorBody(response: Response): Promise<string> {
-  try {
-    const body = await response.text();
-    return body ? `: ${redactErrorBody(body.slice(0, 500))}` : "";
-  } catch {
-    return "";
-  }
-}
-
 export async function smokeChatCompletion(
   baseUrl: string,
   apiKey: string,
@@ -91,7 +71,7 @@ export async function smokeChatCompletion(
     signal: AbortSignal.timeout(timeoutMs),
   });
   if (!response.ok) {
-    throw new Error(`/v1/chat/completions for ${modelId} returned ${response.status}${await readErrorBody(response)}`);
+    throw new Error(`/v1/chat/completions for ${modelId} returned ${response.status}`);
   }
   const data = (await response.json()) as ChatCompletionResponse;
   const content = data.choices?.[0]?.message?.content;

--- a/scripts/smoke-runner.ts
+++ b/scripts/smoke-runner.ts
@@ -54,7 +54,7 @@ export function redactErrorBody(body: string): string {
     .replace(/(Bearer\s+)[^"',\s}\]]+/gi, "$1[REDACTED]")
     .replace(/\b(?:sk|pk)-[A-Za-z0-9._-]+\b/g, "[REDACTED]")
     .replace(
-      /(\b(?:authorization|(?:access|refresh|id)[_-]?token|token|api[_-]?key|secret|password)\b["']?\s*[:=]\s*["']?)[^"',&;\s}\]]+/gi,
+      /(\b(?:authorization|(?:access|refresh|id)[_-]?token|token|api[_-]?key|secret|password)\b["']?\s*[:=]\s*)(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|[^,&;\r\n}\]]+)/gi,
       "$1[REDACTED]",
     )
     .replace(/\b[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g, "[REDACTED]");

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { isIP } from "node:net";
 import type { Api, Model } from "@earendil-works/pi-ai";
 import { getModels, getProviders } from "@earendil-works/pi-ai/compat";
 import type { BuiltinProvider } from "@earendil-works/pi-ai/providers/all";
@@ -51,6 +52,12 @@ const modelsDevCaches = new Map<string, ModelsDevCacheFile>();
 const modelsDevRefreshes = new Map<string, Promise<ModelsDevResponse | undefined>>();
 
 export function normalizeBaseUrl(input: string): string {
+  const url = new URL(input);
+  const hostname = url.hostname.toLowerCase();
+  const loopback = hostname === "localhost" || hostname === "[::1]" || (isIP(hostname) === 4 && hostname.startsWith("127."));
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+    throw new Error("LiteLLM base URL must use HTTPS except for loopback hosts");
+  }
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
 }
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -54,7 +54,8 @@ const modelsDevRefreshes = new Map<string, Promise<ModelsDevResponse | undefined
 export function normalizeBaseUrl(input: string): string {
   const url = new URL(input);
   const hostname = url.hostname.toLowerCase();
-  const loopback = hostname === "localhost" || hostname === "[::1]" || (isIP(hostname) === 4 && hostname.startsWith("127."));
+  const loopback =
+    hostname === "localhost" || hostname === "[::1]" || (isIP(hostname) === 4 && hostname.startsWith("127."));
   if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
     throw new Error("LiteLLM base URL must use HTTPS except for loopback hosts");
   }

--- a/src/gcloud-token.ts
+++ b/src/gcloud-token.ts
@@ -118,7 +118,7 @@ async function exchangeRefreshToken(credentials: AuthorizedUserCredentials): Pro
     });
 
     if (!response.ok) {
-      console.warn(`LiteLLM gcloud auth: Token exchange failed (${response.status}): ${await response.text()}`);
+      console.warn(`LiteLLM gcloud auth: Token exchange failed (${response.status})`);
       return null;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -190,8 +190,7 @@ async function generateVirtualKey(
     signal: boundedSignal,
   });
   if (!response.ok) {
-    const text = await response.text().catch(() => "");
-    throw new Error(`Virtual key generation failed (${response.status}): ${text}`);
+    throw new Error(`Virtual key generation failed (${response.status})`);
   }
   const data = (await response.json()) as { key?: unknown; expires?: unknown };
   if (typeof data.key !== "string" || !data.key) throw new Error("No key in response from /key/generate");

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -37,6 +37,10 @@ afterEach(() => {
 });
 
 describe("normalizeBaseUrl", () => {
+  it("rejects insecure non-loopback endpoints", () => {
+    expect(() => normalizeBaseUrl("http://litellm.example.com")).toThrow(/HTTPS/);
+  });
+
   it("strips trailing slashes", () => {
     expect(normalizeBaseUrl("https://x.example.com/")).toBe("https://x.example.com");
     expect(normalizeBaseUrl("https://x.example.com///")).toBe("https://x.example.com");

--- a/tests/gcloud-token.test.ts
+++ b/tests/gcloud-token.test.ts
@@ -134,11 +134,12 @@ describe("getGcloudToken", () => {
       client_secret: "client-secret",
       refresh_token: "refresh-token",
     });
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("invalid_grant", { status: 400 }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("invalid_grant: remote-secret", { status: 400 }));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     await expect(getGcloudToken()).resolves.toBeNull();
 
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Token exchange failed"));
+    expect(warnSpy.mock.calls.flat().join(" ")).not.toContain("remote-secret");
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1117,7 +1117,7 @@ describe("extension startup", () => {
     const progress = vi.fn();
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
-      if (url.endsWith("/key/generate")) return jsonResponse(403, { error: "forbidden" });
+      if (url.endsWith("/key/generate")) return jsonResponse(403, { error: "forbidden", token: "remote-secret" });
       if (url.endsWith("/model/info"))
         return jsonResponse(200, { data: [{ model_name: "gpt-4o", model_info: { mode: "chat" } }] });
       throw new Error(`unexpected URL: ${url}`);
@@ -1139,6 +1139,7 @@ describe("extension startup", () => {
 
     expect(credential).toMatchObject({ access: jwt, refresh: "" });
     expect(progress).toHaveBeenCalledWith(expect.stringContaining("virtual key generation failed"));
+    expect(progress.mock.calls.flat().join(" ")).not.toContain("remote-secret");
   });
 
   it("enterprise SSO login throws when SSO token is empty", async () => {

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -132,7 +132,9 @@ describe("LiteLLM smoke workflow", () => {
 
     expect(workflow).toMatch(/permissions:\n {2}contents: read/);
     expect(workflow).toMatch(/VIDAIMOCK_VERSION: v\d+\.\d+\.\d+$/m);
-    expect(workflow).toMatch(/sha256sum -c "\$\{asset%\.tar\.gz\}\.sha256"/);
+    expect(workflow).toContain("VIDAIMOCK_SHA256: 3095dd2794b6bd3623057beb1c7def22ae366b85121acb72b3c92a54f79eb7fe");
+    expect(workflow).toContain(`printf '%s  %s\\n' "$VIDAIMOCK_SHA256" "$asset" | sha256sum -c -`);
+    expect(workflow).not.toContain("$" + "{asset%.tar.gz}.sha256");
   });
 
   it("uses immutable container image references and script-free installs", () => {

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -146,6 +146,19 @@ describe("LiteLLM smoke workflow", () => {
     expect(ci).toContain("run: npm ci --ignore-scripts");
   });
 
+  it("validates release tag identity, signature, version, and main ancestry", () => {
+    const release = readReleaseWorkflow();
+
+    expect(release).toContain("run: npm ci --ignore-scripts");
+    expect(release).toContain("git fetch --no-tags origin main");
+    expect(release).toContain('gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$GITHUB_REF_NAME"');
+    expect(release).toContain('test "$(jq -r .verification.verified <<<"$tag")" = true');
+    expect(release).toContain('git rev-parse "$GITHUB_REF_NAME^{}"');
+    expect(release).toContain('git merge-base --is-ancestor "$GITHUB_SHA" origin/main');
+    expect(release).toContain('packageVersion=$(node -p "require(\'./package.json\').version")');
+    expect(release).toContain('test "${GITHUB_REF_NAME#v}" = "$packageVersion"');
+  });
+
   it("preserves the workflow environment in the terminal smoke", () => {
     expect(readTerminalSmoke()).toContain("inheritEnv: true");
   });

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -33,8 +33,8 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("Wait for VidaiMock");
     expect(workflow).toContain("VIDAIMOCK_BASE_URL: http://127.0.0.1:8100");
     expect(workflow).toContain("LITELLM_DATABASE_URL: postgresql://litellm:litellm@host.docker.internal:5432/litellm");
-    expect(workflow).toContain("docker.litellm.ai/berriai/litellm-database:main-latest");
-    expect(workflow).toContain("docker.litellm.ai/berriai/litellm:main-latest");
+    expect(workflow).toContain("docker.litellm.ai/berriai/litellm-database@sha256:");
+    expect(workflow).toContain("docker.litellm.ai/berriai/litellm@sha256:");
     expect(workflow).toContain("LITELLM_SMOKE_MODELS: vidaimock-openai anthropic/vidaimock-claude");
     expect(workflow).toContain("LITELLM_SMOKE_EXPECT_SOURCE: model_info");
     expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL: vidaimock-openai");
@@ -104,8 +104,8 @@ describe("LiteLLM smoke workflow", () => {
 
   it("selects the unlicensed image for pull requests", () => {
     expect(readWorkflow()).toContain(
-      "LITELLM_IMAGE: $" +
-        "{{ github.event_name != 'pull_request' && secrets.LITELLM_LICENSE != '' && 'docker.litellm.ai/berriai/litellm-database:main-latest' || 'docker.litellm.ai/berriai/litellm:main-latest' }}",
+        "LITELLM_IMAGE: $" +
+        "{{ github.event_name != 'pull_request' && secrets.LITELLM_LICENSE != '' && 'docker.litellm.ai/berriai/litellm-database@sha256:8b229a4b48fbe62d7f994b502106c3c1dbab958c07934fb446ac0e048a62745e' || 'docker.litellm.ai/berriai/litellm@sha256:f2dc9ba8a62cf2c51e3ed00e6975f4c70bb577b8ef0c2d7040e3228dc7d42b09' }}",
     );
   });
 
@@ -133,6 +133,17 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toMatch(/permissions:\n {2}contents: read/);
     expect(workflow).toMatch(/VIDAIMOCK_VERSION: v\d+\.\d+\.\d+$/m);
     expect(workflow).toMatch(/sha256sum -c "\$\{asset%\.tar\.gz\}\.sha256"/);
+  });
+
+  it("uses immutable container image references and script-free installs", () => {
+    const workflow = readWorkflow();
+    const ci = readCiWorkflow();
+
+    expect(workflow).toMatch(/docker\.litellm\.ai\/berriai\/litellm(?:-database)?@sha256:[a-f0-9]{64}/);
+    expect(workflow).toMatch(/postgres:[\w.-]+@sha256:[a-f0-9]{64}/);
+    expect(workflow).not.toContain("main-latest");
+    expect(workflow).not.toMatch(/postgres:[\w.-]+\s*$/m);
+    expect(ci).toContain("run: npm ci --ignore-scripts");
   });
 
   it("preserves the workflow environment in the terminal smoke", () => {

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -104,7 +104,7 @@ describe("LiteLLM smoke workflow", () => {
 
   it("selects the unlicensed image for pull requests", () => {
     expect(readWorkflow()).toContain(
-        "LITELLM_IMAGE: $" +
+      "LITELLM_IMAGE: $" +
         "{{ github.event_name != 'pull_request' && secrets.LITELLM_LICENSE != '' && 'docker.litellm.ai/berriai/litellm-database@sha256:8b229a4b48fbe62d7f994b502106c3c1dbab958c07934fb446ac0e048a62745e' || 'docker.litellm.ai/berriai/litellm@sha256:f2dc9ba8a62cf2c51e3ed00e6975f4c70bb577b8ef0c2d7040e3228dc7d42b09' }}",
     );
   });
@@ -155,8 +155,8 @@ describe("LiteLLM smoke workflow", () => {
     expect(release).toContain('test "$(jq -r .verification.verified <<<"$tag")" = true');
     expect(release).toContain('git rev-parse "$GITHUB_REF_NAME^{}"');
     expect(release).toContain('git merge-base --is-ancestor "$GITHUB_SHA" origin/main');
-    expect(release).toContain('packageVersion=$(node -p "require(\'./package.json\').version")');
-    expect(release).toContain('test "${GITHUB_REF_NAME#v}" = "$packageVersion"');
+    expect(release).toContain("packageVersion=$(node -p \"require('./package.json').version\")");
+    expect(release).toContain(`test "\${GITHUB_REF_NAME#v}" = "$packageVersion"`);
   });
 
   it("preserves the workflow environment in the terminal smoke", () => {

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -17,6 +17,10 @@ function readReleaseWorkflow(): string {
   return readFileSync(resolve(repoRoot, ".github/workflows/release.yml"), "utf8");
 }
 
+function readReleaseAllowedSigners(): string {
+  return readFileSync(resolve(repoRoot, ".github/release-allowed-signers"), "utf8");
+}
+
 function readReadme(): string {
   return readFileSync(resolve(repoRoot, "README.md"), "utf8");
 }
@@ -155,10 +159,12 @@ describe("LiteLLM smoke workflow", () => {
     expect(release).toContain("git fetch --no-tags origin main");
     expect(release).toContain('gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$GITHUB_REF_NAME"');
     expect(release).toContain('test "$(jq -r .verification.verified <<<"$tag")" = true');
+    expect(release).toContain("gpg.ssh.allowedSignersFile=.github/release-allowed-signers verify-tag");
     expect(release).toContain('git rev-parse "$GITHUB_REF_NAME^{}"');
     expect(release).toContain('git merge-base --is-ancestor "$GITHUB_SHA" origin/main');
     expect(release).toContain("packageVersion=$(node -p \"require('./package.json').version\")");
     expect(release).toContain(`test "\${GITHUB_REF_NAME#v}" = "$packageVersion"`);
+    expect(readReleaseAllowedSigners()).toMatch(/^balcsida@gmail\.com ssh-ed25519 [A-Za-z0-9+/=]+\n$/);
   });
 
   it("preserves the workflow environment in the terminal smoke", () => {

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -92,6 +92,7 @@ describe("dependency security overrides", () => {
     // basic-ftp left the dependency tree entirely; its override is vestigial.
     expect(Object.values(copiesOf("basic-ftp")).every((version) => version === "6.0.1")).toBe(true);
     expect(Object.values(copiesOf("brace-expansion"))).toEqual(["5.0.9"]);
+    expect(Object.values(copiesOf("nanoid"))).toEqual(["3.3.18"]);
     expect(Object.values(copiesOf("undici"))).toEqual(["8.9.0"]);
     // Pi 0.84.2 still ships a nested protobufjs 7.x copy.
     expect(copiesOf("protobufjs")).toEqual({

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -59,6 +59,26 @@ describe("runAuthSmoke", () => {
     ]);
   });
 
+  it("redacts credential-shaped values from auth failure bodies", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      Response.json({ error: "Bearer sk-master-secret", token: "plain-virtual-secret" }, { status: 500 }),
+    );
+
+    await expect(
+      runAuthSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        masterKey: "sk-master",
+        modelId: "vidaimock-openai",
+        timeoutMs: 1000,
+        enterprise: false,
+      }),
+    ).rejects.toSatisfy((error: Error) => {
+      expect(error.message).not.toContain("sk-master-secret");
+      expect(error.message).not.toContain("plain-virtual-secret");
+      return error.message.length < 600;
+    });
+  });
+
   it("checks virtual-key auth, enterprise admin-route enforcement, and SSO login", async () => {
     const requests: Array<{ url: string; body?: unknown; auth?: string }> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -35,10 +35,13 @@ describe("parseSmokeModels", () => {
 });
 
 it("redacts credential fields in JSON error bodies", () => {
-  const body = redactErrorBody('{"api_key":"plain-provider-secret","token":"plain-virtual-secret"}');
+  const body = redactErrorBody(
+    '{"api_key":"plain provider secret","token":"plain-virtual-secret","authorization":"Basic dXNlcjpwYXNz"}',
+  );
 
-  expect(body).not.toContain("plain-provider-secret");
+  expect(body).not.toContain("plain provider secret");
   expect(body).not.toContain("plain-virtual-secret");
+  expect(body).not.toContain("dXNlcjpwYXNz");
 });
 
 describe("smokeChatCompletion", () => {

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -1,11 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  parseSmokeModels,
-  redactErrorBody,
-  runSmoke,
-  runSmokeFromEnv,
-  smokeChatCompletion,
-} from "../scripts/smoke-runner.js";
+import { parseSmokeModels, runSmoke, runSmokeFromEnv, smokeChatCompletion } from "../scripts/smoke-runner.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -32,16 +26,6 @@ describe("parseSmokeModels", () => {
     expect(parseSmokeModels(undefined)).toEqual([]);
     expect(parseSmokeModels(" \n ,, \t ")).toEqual([]);
   });
-});
-
-it("redacts credential fields in JSON error bodies", () => {
-  const body = redactErrorBody(
-    '{"api_key":"plain provider secret","token":"plain-virtual-secret","authorization":"Basic dXNlcjpwYXNz"}',
-  );
-
-  expect(body).not.toContain("plain provider secret");
-  expect(body).not.toContain("plain-virtual-secret");
-  expect(body).not.toContain("dXNlcjpwYXNz");
 });
 
 describe("smokeChatCompletion", () => {
@@ -232,31 +216,7 @@ describe("runSmoke", () => {
     expect(requestedUrls).toEqual(["http://127.0.0.1:4000/model/info"]);
   });
 
-  it("truncates oversized provider error bodies in failures", async () => {
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.endsWith("/model/info")) {
-        return jsonResponse(200, {
-          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
-        });
-      }
-      if (url.endsWith("/v1/chat/completions")) {
-        return new Response("x".repeat(600), { status: 500 });
-      }
-      throw new Error(`unexpected URL: ${url}`);
-    });
-
-    await expect(
-      runSmoke({
-        baseUrl: "http://127.0.0.1:4000",
-        apiKey: "sk-smoke",
-        modelIds: ["github-models-openai"],
-        timeoutMs: 1000,
-      }),
-    ).rejects.toThrow(/returned 500: x{500}$/);
-  });
-
-  it("includes provider response bodies in chat completion failures", async () => {
+  it("omits provider response bodies from chat completion failures", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
       if (url.endsWith("/model/info")) {
@@ -277,10 +237,10 @@ describe("runSmoke", () => {
         modelIds: ["github-models-openai"],
         timeoutMs: 1000,
       }),
-    ).rejects.toThrow(/\/v1\/chat\/completions for github-models-openai returned 429.*rate limited/);
+    ).rejects.toThrow("/v1/chat/completions for github-models-openai returned 429");
   });
 
-  it("redacts credential-shaped values from provider response bodies", async () => {
+  it("omits credentials from provider response bodies", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);
       if (url.endsWith("/model/info")) {
@@ -293,6 +253,7 @@ describe("runSmoke", () => {
           {
             authorization: "Bearer sk-live-secret",
             api_key: "plain-provider-secret",
+            credentials: ["unknown-secret-one", "unknown-secret-two"],
             jwt: "eyJhbGciOiJub25l.eyJzdWIiOiIxMjMifQ.sig",
           },
           { status: 500 },
@@ -312,6 +273,7 @@ describe("runSmoke", () => {
       expect(error.message).toContain("returned 500");
       expect(error.message).not.toContain("sk-live-secret");
       expect(error.message).not.toContain("plain-provider-secret");
+      expect(error.message).not.toContain("unknown-secret-two");
       expect(error.message).not.toContain("eyJhbGciOiJub25l");
       return error.message.length < 600;
     });

--- a/tests/smoke-runner.test.ts
+++ b/tests/smoke-runner.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { parseSmokeModels, runSmoke, runSmokeFromEnv, smokeChatCompletion } from "../scripts/smoke-runner.js";
+import {
+  parseSmokeModels,
+  redactErrorBody,
+  runSmoke,
+  runSmokeFromEnv,
+  smokeChatCompletion,
+} from "../scripts/smoke-runner.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -26,6 +32,13 @@ describe("parseSmokeModels", () => {
     expect(parseSmokeModels(undefined)).toEqual([]);
     expect(parseSmokeModels(" \n ,, \t ")).toEqual([]);
   });
+});
+
+it("redacts credential fields in JSON error bodies", () => {
+  const body = redactErrorBody('{"api_key":"plain-provider-secret","token":"plain-virtual-secret"}');
+
+  expect(body).not.toContain("plain-provider-secret");
+  expect(body).not.toContain("plain-virtual-secret");
 });
 
 describe("smokeChatCompletion", () => {
@@ -262,6 +275,43 @@ describe("runSmoke", () => {
         timeoutMs: 1000,
       }),
     ).rejects.toThrow(/\/v1\/chat\/completions for github-models-openai returned 429.*rate limited/);
+  });
+
+  it("redacts credential-shaped values from provider response bodies", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [{ model_name: "github-models-openai", model_info: { mode: "chat" } }],
+        });
+      }
+      if (url.endsWith("/v1/chat/completions")) {
+        return Response.json(
+          {
+            authorization: "Bearer sk-live-secret",
+            api_key: "plain-provider-secret",
+            jwt: "eyJhbGciOiJub25l.eyJzdWIiOiIxMjMifQ.sig",
+          },
+          { status: 500 },
+        );
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await expect(
+      runSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        apiKey: "sk-smoke",
+        modelIds: ["github-models-openai"],
+        timeoutMs: 1000,
+      }),
+    ).rejects.toSatisfy((error: Error) => {
+      expect(error.message).toContain("returned 500");
+      expect(error.message).not.toContain("sk-live-secret");
+      expect(error.message).not.toContain("plain-provider-secret");
+      expect(error.message).not.toContain("eyJhbGciOiJub25l");
+      return error.message.length < 600;
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- require HTTPS for remote LiteLLM endpoints while preserving loopback development
- omit untrusted remote response bodies and document Skills, MCP, and key-helper trust boundaries
- remediate the nanoid advisory and harden CI, smoke assets, and signed release provenance

## Verification

- `npm run check` (242 passed, 1 skipped)
- `npm run prepublishOnly`
- `npm audit --json` (0 vulnerabilities)
- `npm pack --dry-run --json` (25 files)