### PR TITLE
fix: map LiteLLM reasoning effort capabilities

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -420,6 +420,26 @@ function mapModelsDevMetadata(model: ModelsDevModel | undefined): Partial<Discov
   return metadata;
 }
 
+function mapReasoningEfforts(
+  info: NonNullable<ModelInfoEntry["model_info"]>,
+): NonNullable<DiscoveredModel["thinkingLevelMap"]> | undefined {
+  const flags = [
+    ["off", "none", info.supports_none_reasoning_effort],
+    ["minimal", "minimal", info.supports_minimal_reasoning_effort],
+    ["low", "low", info.supports_low_reasoning_effort],
+    ["medium", "medium", info.supports_medium_reasoning_effort],
+    ["high", "high", info.supports_high_reasoning_effort],
+    ["xhigh", "xhigh", info.supports_xhigh_reasoning_effort],
+    ["max", "max", info.supports_max_reasoning_effort],
+  ] as const;
+  const map = Object.fromEntries(
+    flags
+      .filter(([, , supported]) => supported !== undefined)
+      .map(([level, value, supported]) => [level, supported ? value : null]),
+  ) as NonNullable<DiscoveredModel["thinkingLevelMap"]>;
+  return Object.keys(map).length > 0 ? map : undefined;
+}
+
 function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
   const id = entry.model_name;
   if (!id) return undefined;
@@ -427,11 +447,16 @@ function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
   if (!isChatStyleMode(info.mode)) return undefined;
   const responsesMode = isResponsesMode(info.mode);
   const catalogModel = findCatalogModel(id);
+  const reasoningEffortMap = mapReasoningEfforts(info);
+  const thinkingLevelMap =
+    catalogModel?.thinkingLevelMap || reasoningEffortMap
+      ? { ...catalogModel?.thinkingLevelMap, ...reasoningEffortMap }
+      : undefined;
   return {
     id,
     name: id,
     reasoning: info.supports_reasoning ?? false,
-    ...(catalogModel?.thinkingLevelMap ? { thinkingLevelMap: catalogModel.thinkingLevelMap } : {}),
+    ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
     input: info.supports_vision ? ["text", "image"] : ["text"],
     cost: mapModelInfoCost(info, catalogModel?.cost),
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,13 @@ export interface ModelInfoEntry {
     max_input_tokens?: number;
     max_output_tokens?: number;
     supports_reasoning?: boolean;
+    supports_none_reasoning_effort?: boolean;
+    supports_minimal_reasoning_effort?: boolean;
+    supports_low_reasoning_effort?: boolean;
+    supports_medium_reasoning_effort?: boolean;
+    supports_high_reasoning_effort?: boolean;
+    supports_xhigh_reasoning_effort?: boolean;
+    supports_max_reasoning_effort?: boolean;
     supports_vision?: boolean;
   };
 }

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -221,6 +221,41 @@ describe("discoverModels via /model/info", () => {
     });
   });
 
+  it("maps LiteLLM reasoning effort capabilities", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "custom/reasoner",
+            model_info: {
+              mode: "chat",
+              supports_reasoning: true,
+              supports_none_reasoning_effort: true,
+              supports_minimal_reasoning_effort: false,
+              supports_low_reasoning_effort: false,
+              supports_medium_reasoning_effort: false,
+              supports_high_reasoning_effort: true,
+              supports_xhigh_reasoning_effort: false,
+              supports_max_reasoning_effort: true,
+            },
+          },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.thinkingLevelMap).toEqual({
+      off: "none",
+      minimal: null,
+      low: null,
+      medium: null,
+      high: "high",
+      xhigh: null,
+      max: "max",
+    });
+  });
+
   it("uses catalog costs when /model/info omits costs for Anthropic aliases", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = input instanceof URL ? input.toString() : String(input);
@@ -262,6 +297,23 @@ describe("discoverModels via /model/info", () => {
     const result = await discoverModels("https://litellm.example.com", "sk-test", {});
 
     expect(result.models[0]?.thinkingLevelMap).toMatchObject({ off: "none", xhigh: "xhigh", max: "max" });
+  });
+
+  it("merges partial reasoning effort capabilities over catalog metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "openai/gpt-5.6-luna",
+            model_info: { mode: "chat", supports_reasoning: true, supports_xhigh_reasoning_effort: false },
+          },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.thinkingLevelMap).toMatchObject({ off: "none", xhigh: null, max: "max" });
   });
 
   it("preserves richer metadata from later duplicate model ids", async () => {


### PR DESCRIPTION
## Summary

- map LiteLLM reasoning-effort capability flags into Pi thinking levels
- let explicit server capabilities override catalog metadata while preserving omitted values
- cover the reported payload and sparse catalog merging

## Testing

- npm run check
- npm run clean
- npm run build

Fixes #128