### PR TITLE
feat: support LiteLLM CLI SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ You'll be prompted for the base URL and API key. Credentials are persisted to `~
 
 #### Enterprise SSO login
 
-If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments), you can authenticate via a browser SSO flow and optionally pair the resulting JWT with a stable virtual key:
+If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments), you can authenticate through LiteLLM's CLI SSO flow:
 
 1. Run `/login litellm` inside pi and select `Sign in with LiteLLM SSO`
 2. Enter the proxy URL
-3. Your default browser opens the LiteLLM SSO login URL (e.g. `https://litellm.your-domain.com/sso/key/generate`) automatically — the URL is also displayed in case it can't be opened. Authenticate via SSO
-4. Copy your token from the LiteLLM UI and paste it at the prompt (copying a full `Bearer ...` header value is fine — the prefix is stripped automatically)
-5. When prompted to generate a virtual key, press Enter to accept (recommended) or enter `n` to use the JWT directly
+3. Pi displays a verification code and opens the LiteLLM SSO login URL automatically
+4. Authenticate in the browser and confirm the displayed code
+5. If your account belongs to multiple teams, select the team for this session in Pi
 
-When you generate a virtual key, the resulting `sk-...` key is stored as your credential and used for all API requests. If the proxy's key policy attaches an expiry to the generated key, Pi will prompt you to re-authenticate when it nears expiry; otherwise the key is treated as permanent until revoked in LiteLLM.
+Pi polls the proxy until authentication completes and stores the returned short-lived CLI token. Newer proxies advertise the token lifetime; for older proxies, Pi uses `LITELLM_CLI_JWT_EXPIRATION_HOURS` or LiteLLM's 24-hour default. On LiteLLM versions that gate CLI SSO, start the proxy with `EXPERIMENTAL_UI_LOGIN=True`.
 
-When using a JWT directly, the extension reads its `exp` claim and Pi will prompt you to re-authenticate when the token nears expiry. Run `/login litellm` again to refresh.
+Older proxies without `/sso/cli/start` fall back to the legacy browser flow: copy the token from the LiteLLM UI, paste it into Pi, and optionally exchange it for a virtual key. Pi reads JWT expiry claims and prompts you to run `/login litellm` again when re-authentication is required.
 
 ### Option B — environment variables
 
@@ -155,6 +155,7 @@ Treat the configured LiteLLM proxy as trusted: Skills can add instructions to th
 | `GOOGLE_APPLICATION_CREDENTIALS` | Google default ADC path | Optional path to an ADC JSON file used by `LITELLM_GCLOUD_TOKEN_AUTH`. If unset, the extension checks the default gcloud ADC locations. |
 | `LITELLM_OFFLINE` | unset | If `1`, disable all model and MCP discovery, including post-login discovery; use cached models only |
 | `LITELLM_DISCOVERY_TIMEOUT_MS` | `5000` | Background and explicit discovery fetch timeout in ms; `0` disables automatic discovery |
+| `LITELLM_CLI_JWT_EXPIRATION_HOURS` | `24` | CLI SSO token lifetime fallback for older proxies whose poll response omits `expires_in`; mirror a non-default proxy setting locally |
 | `LITELLM_VERBOSE_DISCOVERY` | unset | If `1`, enable progress messages during model and MCP discovery (login, refresh, startup); discovery is silent by default |
 | `LITELLM_MODELS_DEV` | enabled | Set to `0` to disable models.dev metadata enrichment, including its cache and network request; `/v1/models` still uses Pi catalog metadata and defaults |
 
@@ -242,6 +243,8 @@ Opening `/model` refreshes configured provider catalogs in the background using 
 | Discovery times out | Increase `LITELLM_DISCOVERY_TIMEOUT_MS` or set `LITELLM_OFFLINE=1` to fall back on cached models |
 | `401 Token expired` | Set `LITELLM_API_KEY_HELPER`. |
 | No models with gcloud auth | Verify `gcloud auth application-default login` has been run or set `GOOGLE_APPLICATION_CREDENTIALS` to an `authorized_user` ADC file |
+| Enterprise SSO waits for token insertion | The proxy returned 404/405 for `/sso/cli/start`, so Pi used the legacy flow — upgrade LiteLLM or paste the UI token |
+| Enterprise CLI SSO start/poll fails | Check the proxy logs and verify `/sso/cli/start` and `/sso/cli/poll/{login_id}` are reachable; only 404/405 falls back to legacy login |
 | Enterprise SSO login shows "virtual key generation failed" | The LiteLLM instance may lack a database (`/key/generate` requires one), your user account may lack key-generation permission, or the request timed out; the JWT is used directly as a fallback |
 | Enterprise SSO token prompt fails with "SSO token is required" | The token field was left empty — paste the token copied from the LiteLLM UI |
 | MCP tools not showing | Verify the proxy exposes `/mcp-rest/tools/list` and open `/model` after fixing the proxy |

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -37,6 +37,18 @@ type SmokePi = {
   on: () => void;
 };
 
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const body = await response.text();
+    const redacted = body
+      .replace(/Bearer\s+[^\s",}]+/gi, "Bearer [redacted]")
+      .replace(/("(?:token|key|secret|access_token)"\s*:\s*")[^"]*/gi, "$1[redacted]");
+    return redacted ? `: ${redacted.slice(0, 500)}` : "";
+  } catch {
+    return "";
+  }
+}
+
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   return fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
 }
@@ -60,13 +72,13 @@ function isAuthFailure(status: number): boolean {
 
 async function expectAuthFailure(label: string, response: Response): Promise<void> {
   if (!isAuthFailure(response.status)) {
-    throw new Error(`${label} should reject auth, got ${response.status}`);
+    throw new Error(`${label} should reject auth, got ${response.status}${await readErrorBody(response)}`);
   }
 }
 
 async function expectOk(label: string, response: Response): Promise<void> {
   if (!response.ok) {
-    throw new Error(`${label} returned ${response.status}`);
+    throw new Error(`${label} returned ${response.status}${await readErrorBody(response)}`);
   }
 }
 
@@ -156,19 +168,30 @@ export async function runSsoLoginSmoke(
     if (!oauth) throw new Error("LiteLLM provider did not expose OAuth login");
 
     const authInfos: Array<{ url: string; instructions?: string }> = [];
-    const credential = await oauth.login({
-      prompt: async (prompt) => {
-        const { message } = prompt;
-        if ("placeholder" in prompt && prompt.placeholder) return baseUrl;
-        if (message.includes("SSO token")) return `Bearer ${options.masterKey}`;
-        if (message.includes("Generate a LiteLLM virtual key")) return "y";
-        return "";
-      },
-      notify: (event) => {
-        if (event.type === "auth_url") authInfos.push(event);
-      },
-      signal: new AbortController().signal,
-    });
+    const fetchImpl = globalThis.fetch;
+    // ponytail: the smoke proxy has no SSO IdP; protocol tests cover CLI SSO while this keeps legacy fallback live.
+    globalThis.fetch = (input, init) =>
+      String(input) === `${baseUrl}/sso/cli/start`
+        ? Promise.resolve(new Response(null, { status: 404 }))
+        : fetchImpl(input, init);
+    let credential: Awaited<ReturnType<typeof oauth.login>>;
+    try {
+      credential = await oauth.login({
+        prompt: async (prompt) => {
+          const { message } = prompt;
+          if ("placeholder" in prompt && prompt.placeholder) return baseUrl;
+          if (message.includes("SSO token")) return `Bearer ${options.masterKey}`;
+          if (message.includes("Generate a LiteLLM virtual key")) return "y";
+          return "";
+        },
+        notify: (event) => {
+          if (event.type === "auth_url") authInfos.push(event);
+        },
+        signal: new AbortController().signal,
+      });
+    } finally {
+      globalThis.fetch = fetchImpl;
+    }
 
     if (!authInfos.some((info) => info.url === `${baseUrl}/sso/key/generate`)) {
       throw new Error("SSO login did not request /sso/key/generate");

--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -37,18 +37,6 @@ type SmokePi = {
   on: () => void;
 };
 
-async function readErrorBody(response: Response): Promise<string> {
-  try {
-    const body = await response.text();
-    const redacted = body
-      .replace(/Bearer\s+[^\s",}]+/gi, "Bearer [redacted]")
-      .replace(/("(?:token|key|secret|access_token)"\s*:\s*")[^"]*/gi, "$1[redacted]");
-    return redacted ? `: ${redacted.slice(0, 500)}` : "";
-  } catch {
-    return "";
-  }
-}
-
 async function fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
   return fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
 }
@@ -72,13 +60,13 @@ function isAuthFailure(status: number): boolean {
 
 async function expectAuthFailure(label: string, response: Response): Promise<void> {
   if (!isAuthFailure(response.status)) {
-    throw new Error(`${label} should reject auth, got ${response.status}${await readErrorBody(response)}`);
+    throw new Error(`${label} should reject auth, got ${response.status}`);
   }
 }
 
 async function expectOk(label: string, response: Response): Promise<void> {
   if (!response.ok) {
-    throw new Error(`${label} returned ${response.status}${await readErrorBody(response)}`);
+    throw new Error(`${label} returned ${response.status}`);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 import type {
   Api,
   ApiKeyCredential,
@@ -40,11 +41,15 @@ const ENV_API_KEY = "LITELLM_API_KEY";
 const ENV_API_KEY_HELPER = "LITELLM_API_KEY_HELPER";
 const ENV_HEADERS = "LITELLM_HEADERS";
 const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
+const ENV_CLI_JWT_EXPIRATION_HOURS = "LITELLM_CLI_JWT_EXPIRATION_HOURS";
 const ENV_OFFLINE = "LITELLM_OFFLINE";
 const ENV_VERBOSE_DISCOVERY = "LITELLM_VERBOSE_DISCOVERY";
 const ENV_MODELS_DEV = "LITELLM_MODELS_DEV";
 const DEFAULT_TIMEOUT_MS = 5000;
 const LOGIN_TIMEOUT_MS = 10_000;
+const CLI_SSO_POLL_INTERVAL_MS = 2_000;
+const CLI_SSO_EXPIRES_IN_SECONDS = 600;
+const DEFAULT_CLI_JWT_EXPIRATION_HOURS = 24;
 const MODELS_DEV_CACHE_FILENAME = "litellm-models-dev.json";
 const TOKEN_REFRESH_LEAD_MS = 5 * 60 * 1000;
 const PERMANENT_TOKEN_EXPIRES_AT = Number.MAX_SAFE_INTEGER;
@@ -170,15 +175,24 @@ function tokenExpiresAt(apiKey: string, opaqueFallback = PERMANENT_TOKEN_EXPIRES
   }
 }
 
+function configuredCliJwtExpiresAt(): number {
+  const configured = Number(process.env[ENV_CLI_JWT_EXPIRATION_HOURS]);
+  const hours = Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_CLI_JWT_EXPIRATION_HOURS;
+  return Date.now() + hours * 60 * 60 * 1_000;
+}
+
+function boundedLoginSignal(signal?: AbortSignal): AbortSignal {
+  return signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(LOGIN_TIMEOUT_MS)])
+    : AbortSignal.timeout(LOGIN_TIMEOUT_MS);
+}
+
 async function generateVirtualKey(
   baseUrl: string,
   userToken: string,
   signal?: AbortSignal,
   headers?: Record<string, string>,
 ): Promise<{ key: string; expiresAt?: number }> {
-  const boundedSignal = signal
-    ? AbortSignal.any([signal, AbortSignal.timeout(LOGIN_TIMEOUT_MS)])
-    : AbortSignal.timeout(LOGIN_TIMEOUT_MS);
   const response = await fetch(`${baseUrl}/key/generate`, {
     method: "POST",
     headers: {
@@ -187,7 +201,7 @@ async function generateVirtualKey(
       "Content-Type": "application/json",
     },
     body: JSON.stringify({}),
-    signal: boundedSignal,
+    signal: boundedLoginSignal(signal),
   });
   if (!response.ok) {
     throw new Error(`Virtual key generation failed (${response.status})`);
@@ -461,16 +475,117 @@ async function loginApiKey(interaction: AuthInteraction): Promise<ApiKeyCredenti
   return { type: "api_key", key, env: { [ENV_BASE_URL]: normalizeBaseUrl(rawBaseUrl) } };
 }
 
-async function loginOAuth(interaction: AuthInteraction, headers?: Record<string, string>): Promise<OAuthCredential> {
-  const rawBaseUrl = (
-    await interaction.prompt({
-      type: "text",
-      message: "Enter LiteLLM proxy URL (no trailing /v1):",
-      placeholder: "https://litellm.example.com",
-    })
-  ).trim();
-  if (!rawBaseUrl) throw new Error("Base URL is required");
-  const baseUrl = normalizeBaseUrl(rawBaseUrl);
+type CliSsoStart = { loginId: string; pollSecret: string; userCode: string; expiresInSeconds: number };
+
+async function startCliSso(
+  baseUrl: string,
+  signal?: AbortSignal,
+  headers?: Record<string, string>,
+): Promise<CliSsoStart | undefined> {
+  const response = await fetch(`${baseUrl}/sso/cli/start`, {
+    method: "POST",
+    headers,
+    signal: boundedLoginSignal(signal),
+  });
+  if (response.status === 404 || response.status === 405) return undefined;
+  if (!response.ok) throw new Error(`LiteLLM CLI SSO start failed (HTTP ${response.status})`);
+  const data = (await response.json()) as Record<string, unknown>;
+  if (
+    typeof data.login_id !== "string" ||
+    !data.login_id ||
+    typeof data.poll_secret !== "string" ||
+    !data.poll_secret ||
+    typeof data.user_code !== "string" ||
+    !data.user_code
+  ) {
+    throw new Error("LiteLLM CLI SSO start returned an invalid response");
+  }
+  return {
+    loginId: data.login_id,
+    pollSecret: data.poll_secret,
+    userCode: data.user_code,
+    expiresInSeconds:
+      typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
+        ? data.expires_in
+        : CLI_SSO_EXPIRES_IN_SECONDS,
+  };
+}
+
+async function waitForNextCliSsoPoll(interaction: AuthInteraction): Promise<void> {
+  try {
+    await delay(CLI_SSO_POLL_INTERVAL_MS, undefined, interaction.signal ? { signal: interaction.signal } : undefined);
+  } catch (error) {
+    if (interaction.signal?.aborted) throw interaction.signal.reason;
+    throw error;
+  }
+}
+
+async function pollCliSso(
+  baseUrl: string,
+  start: CliSsoStart,
+  interaction: AuthInteraction,
+  headers?: Record<string, string>,
+): Promise<{ access: string; expiresInSeconds?: number }> {
+  const deadline = Date.now() + start.expiresInSeconds * 1_000;
+  const pollUrl = new URL(`${baseUrl}/sso/cli/poll/${encodeURIComponent(start.loginId)}`);
+  let teamId: string | undefined;
+  while (Date.now() < deadline) {
+    if (teamId) pollUrl.searchParams.set("team_id", teamId);
+    let response: Response;
+    try {
+      response = await fetch(pollUrl, {
+        headers: { ...headers, "x-litellm-cli-poll-secret": start.pollSecret },
+        signal: boundedLoginSignal(interaction.signal),
+      });
+    } catch {
+      if (interaction.signal?.aborted) throw interaction.signal.reason;
+      await waitForNextCliSsoPoll(interaction);
+      continue;
+    }
+    if (response.status === 429 || response.status >= 500) {
+      await waitForNextCliSsoPoll(interaction);
+      continue;
+    }
+    if (response.status === 400) throw new Error("LiteLLM CLI SSO login expired or is invalid");
+    if (!response.ok) throw new Error(`LiteLLM CLI SSO polling failed (HTTP ${response.status})`);
+    const data = (await response.json()) as Record<string, unknown>;
+    if (data.status === "ready" && typeof data.key === "string" && data.key) {
+      return {
+        access: data.key,
+        expiresInSeconds:
+          typeof data.expires_in === "number" && Number.isFinite(data.expires_in) && data.expires_in > 0
+            ? data.expires_in
+            : undefined,
+      };
+    }
+    if (data.status === "ready" && data.requires_team_selection === true && !teamId) {
+      const details = Array.isArray(data.team_details) ? data.team_details : [];
+      const teams = details.flatMap((team) => {
+        if (!team || typeof team !== "object") return [];
+        const record = team as Record<string, unknown>;
+        const id = typeof record.team_id === "string" ? record.team_id : record.id;
+        const alias = record.team_alias;
+        return typeof id === "string" && id ? [{ id, label: typeof alias === "string" && alias ? alias : id }] : [];
+      });
+      if (teams.length === 0 && Array.isArray(data.teams))
+        teams.push(...data.teams.flatMap((id) => (typeof id === "string" && id ? [{ id, label: id }] : [])));
+      if (teams.length === 0) throw new Error("LiteLLM CLI SSO requested team selection without any teams");
+      const selected = await interaction.prompt({ type: "select", message: "Select a LiteLLM team:", options: teams });
+      if (!teams.some((team) => team.id === selected)) throw new Error("Invalid LiteLLM team selection");
+      teamId = selected;
+      continue;
+    }
+    if (data.status !== "pending") throw new Error("LiteLLM CLI SSO polling returned an invalid response");
+    await waitForNextCliSsoPoll(interaction);
+  }
+  throw new Error("LiteLLM CLI SSO login expired");
+}
+
+async function loginWithPastedToken(
+  interaction: AuthInteraction,
+  baseUrl: string,
+  headers?: Record<string, string>,
+): Promise<OAuthCredential> {
   interaction.notify({
     type: "auth_url",
     url: `${baseUrl}/sso/key/generate`,
@@ -508,6 +623,36 @@ async function loginOAuth(interaction: AuthInteraction, headers?: Record<string,
     }
   }
   return { type: "oauth", access, refresh: "", expires, baseUrl };
+}
+
+async function loginOAuth(interaction: AuthInteraction, headers?: Record<string, string>): Promise<OAuthCredential> {
+  const rawBaseUrl = (
+    await interaction.prompt({
+      type: "text",
+      message: "Enter LiteLLM proxy URL (no trailing /v1):",
+      placeholder: "https://litellm.example.com",
+    })
+  ).trim();
+  if (!rawBaseUrl) throw new Error("Base URL is required");
+  const baseUrl = normalizeBaseUrl(rawBaseUrl);
+  const cliSso = await startCliSso(baseUrl, interaction.signal, headers);
+  if (!cliSso) return loginWithPastedToken(interaction, baseUrl, headers);
+  interaction.notify({
+    type: "device_code",
+    userCode: cliSso.userCode,
+    verificationUri: `${baseUrl}/sso/key/generate?${new URLSearchParams({ source: "litellm-cli", key: cliSso.loginId })}`,
+    expiresInSeconds: cliSso.expiresInSeconds,
+  });
+  const result = await pollCliSso(baseUrl, cliSso, interaction, headers);
+  return {
+    type: "oauth",
+    access: result.access,
+    refresh: "",
+    expires: result.expiresInSeconds
+      ? Date.now() + result.expiresInSeconds * 1_000
+      : tokenExpiresAt(result.access, configuredCliJwtExpiresAt()),
+    baseUrl,
+  };
 }
 
 async function refreshLiteLLM(credentials: OAuthCredentials, _signal?: AbortSignal): Promise<OAuthCredentials> {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -22,6 +22,7 @@ const ENV_KEYS = [
   "LITELLM_ANTHROPIC_API_KEY",
   "LITELLM_ANTHROPIC_HEADERS",
   "LITELLM_DISCOVERY_TIMEOUT_MS",
+  "LITELLM_CLI_JWT_EXPIRATION_HOURS",
   "LITELLM_MODELS_DEV",
   "LITELLM_GCLOUD_TOKEN_AUTH",
   "GOOGLE_APPLICATION_CREDENTIALS",
@@ -132,26 +133,45 @@ function interaction(
 async function loginOAuth(
   provider: Provider,
   callbacks: {
-    onPrompt: (prompt: { message: string; placeholder?: string }) => Promise<string>;
+    onPrompt: (prompt: {
+      type: string;
+      message: string;
+      placeholder?: string;
+      options?: readonly { id: string; label: string }[];
+    }) => Promise<string>;
     onAuth?: (event: { url: string; instructions?: string }) => void;
+    onDeviceCode?: (event: { userCode: string; verificationUri: string; expiresInSeconds?: number }) => void;
     onProgress?: (message: string) => void;
     signal?: AbortSignal;
   },
 ) {
-  return provider.auth.oauth?.login(
-    interaction(
-      (prompt) =>
-        callbacks.onPrompt({
-          message: prompt.message,
-          placeholder: "placeholder" in prompt ? prompt.placeholder : undefined,
-        }),
-      (event) => {
-        if (event.type === "auth_url") callbacks.onAuth?.(event);
-        if (event.type === "progress") callbacks.onProgress?.(event.message);
-      },
-      callbacks.signal ?? TEST_SIGNAL,
-    ),
-  );
+  const fetchImpl = globalThis.fetch;
+  if (!callbacks.onDeviceCode)
+    globalThis.fetch = (input, init) =>
+      String(input).endsWith("/sso/cli/start")
+        ? Promise.resolve(jsonResponse(404, { detail: "Not Found" }))
+        : fetchImpl(input, init);
+  try {
+    return await provider.auth.oauth?.login(
+      interaction(
+        (prompt) =>
+          callbacks.onPrompt({
+            type: prompt.type,
+            message: prompt.message,
+            placeholder: "placeholder" in prompt ? prompt.placeholder : undefined,
+            options: "options" in prompt ? prompt.options : undefined,
+          }),
+        (event) => {
+          if (event.type === "auth_url") callbacks.onAuth?.(event);
+          if (event.type === "device_code") callbacks.onDeviceCode?.(event);
+          if (event.type === "progress") callbacks.onProgress?.(event.message);
+        },
+        callbacks.signal ?? TEST_SIGNAL,
+      ),
+    );
+  } finally {
+    globalThis.fetch = fetchImpl;
+  }
 }
 
 afterEach(() => {
@@ -891,6 +911,64 @@ describe("extension startup", () => {
     expect(seenRequests.every(({ url }) => !url.endsWith("/model/info"))).toBe(true);
   });
 
+  it("completes CLI SSO with the server lifetime and selected team", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_MODELS_DEV = "0";
+    const urls: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      urls.push(url);
+      if (url.endsWith("/sso/cli/start"))
+        return jsonResponse(200, {
+          login_id: "cli-login",
+          poll_secret: "poll-secret",
+          user_code: "ABCD-EFGH",
+          expires_in: 600,
+        });
+      if (url.endsWith("/sso/cli/poll/cli-login"))
+        return jsonResponse(200, {
+          status: "ready",
+          requires_team_selection: true,
+          team_details: [{ id: "team-b", team_alias: "Beta" }],
+        });
+      if (url.endsWith("/sso/cli/poll/cli-login?team_id=team-b"))
+        return jsonResponse(200, { status: "ready", key: "opaque-cli-token", expires_in: 7200 });
+      throw new Error(`unexpected URL: ${url} (${String(init?.method ?? "GET")})`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const startedAt = Date.now();
+    const deviceCodes: Array<{ userCode: string; verificationUri: string }> = [];
+
+    const credential = await loginOAuth(pi.providers[0]!, {
+      onPrompt: async (prompt) => (prompt.placeholder ? "https://litellm.example.com" : "team-b"),
+      onDeviceCode: (event) => deviceCodes.push(event),
+      signal: new AbortController().signal,
+    });
+
+    expect(deviceCodes).toEqual([
+      {
+        type: "device_code",
+        userCode: "ABCD-EFGH",
+        verificationUri: "https://litellm.example.com/sso/key/generate?source=litellm-cli&key=cli-login",
+        expiresInSeconds: 600,
+      },
+    ]);
+    expect(credential).toMatchObject({
+      access: "opaque-cli-token",
+      refresh: "",
+      baseUrl: "https://litellm.example.com",
+    });
+    expect(credential?.expires).toBeGreaterThanOrEqual(startedAt + 7200 * 1000);
+    expect(urls).toEqual([
+      "https://litellm.example.com/sso/cli/start",
+      "https://litellm.example.com/sso/cli/poll/cli-login",
+      "https://litellm.example.com/sso/cli/poll/cli-login?team_id=team-b",
+    ]);
+  }, 15_000);
+
   it("enterprise SSO login strips Bearer prefix from pasted SSO token", async () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
@@ -960,6 +1038,7 @@ describe("extension startup", () => {
     const timeoutController = new AbortController();
     const nativeTimeout = AbortSignal.timeout.bind(AbortSignal);
     vi.spyOn(AbortSignal, "timeout")
+      .mockImplementationOnce(nativeTimeout)
       .mockImplementationOnce(() => timeoutController.signal)
       .mockImplementation(nativeTimeout);
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -915,10 +915,14 @@ describe("extension startup", () => {
     const agentDir = await makeAgentDir();
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
     process.env.LITELLM_MODELS_DEV = "0";
-    const urls: string[] = [];
+    const requests: Array<{ url: string; method: string; pollSecret: string | null }> = [];
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
-      urls.push(url);
+      requests.push({
+        url,
+        method: String(init?.method ?? "GET"),
+        pollSecret: new Headers(init?.headers).get("x-litellm-cli-poll-secret"),
+      });
       if (url.endsWith("/sso/cli/start"))
         return jsonResponse(200, {
           login_id: "cli-login",
@@ -962,11 +966,134 @@ describe("extension startup", () => {
       baseUrl: "https://litellm.example.com",
     });
     expect(credential?.expires).toBeGreaterThanOrEqual(startedAt + 7200 * 1000);
-    expect(urls).toEqual([
-      "https://litellm.example.com/sso/cli/start",
-      "https://litellm.example.com/sso/cli/poll/cli-login",
-      "https://litellm.example.com/sso/cli/poll/cli-login?team_id=team-b",
+    expect(requests).toEqual([
+      { url: "https://litellm.example.com/sso/cli/start", method: "POST", pollSecret: null },
+      { url: "https://litellm.example.com/sso/cli/poll/cli-login", method: "GET", pollSecret: "poll-secret" },
+      {
+        url: "https://litellm.example.com/sso/cli/poll/cli-login?team_id=team-b",
+        method: "GET",
+        pollSecret: "poll-secret",
+      },
     ]);
+  }, 15_000);
+
+  it("retries pending and transient CLI SSO polls", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_MODELS_DEV = "0";
+    let polls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/sso/cli/start"))
+        return jsonResponse(200, { login_id: "cli-login", poll_secret: "poll-secret", user_code: "ABCD-EFGH" });
+      if (url.endsWith("/sso/cli/poll/cli-login")) {
+        polls += 1;
+        if (polls === 1) return jsonResponse(200, { status: "pending" });
+        if (polls === 2) return jsonResponse(503, { detail: "unavailable" });
+        return jsonResponse(200, { status: "ready", key: "opaque-cli-token" });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    await expect(
+      loginOAuth(pi.providers[0]!, {
+        onPrompt: async (prompt) => (prompt.placeholder ? "https://litellm.example.com" : ""),
+        onDeviceCode: () => undefined,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toMatchObject({ access: "opaque-cli-token" });
+    expect(polls).toBe(3);
+  }, 15_000);
+
+  it("preserves cancellation while waiting for a CLI SSO poll", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_MODELS_DEV = "0";
+    let polled = false;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/sso/cli/start"))
+        return jsonResponse(200, { login_id: "cli-login", poll_secret: "poll-secret", user_code: "ABCD-EFGH" });
+      if (url.endsWith("/sso/cli/poll/cli-login")) {
+        polled = true;
+        return jsonResponse(200, { status: "pending" });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const controller = new AbortController();
+    const reason = new Error("caller cancelled login");
+    const login = loginOAuth(pi.providers[0]!, {
+      onPrompt: async (prompt) => (prompt.placeholder ? "https://litellm.example.com" : ""),
+      onDeviceCode: () => undefined,
+      signal: controller.signal,
+    });
+    await vi.waitFor(() => expect(polled).toBe(true));
+    controller.abort(reason);
+    await expect(login).rejects.toBe(reason);
+  }, 15_000);
+
+  it("uses legacy token paste only when CLI SSO start is unavailable", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_MODELS_DEV = "0";
+    let status = 404;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/sso/cli/start")) return jsonResponse(status, {});
+      if (url.endsWith("/key/generate")) return jsonResponse(200, { key: "sk-legacy" });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const login = () =>
+      loginOAuth(pi.providers[0]!, {
+        onPrompt: async (prompt) => (prompt.placeholder ? "https://litellm.example.com" : "Bearer legacy-token"),
+        onDeviceCode: () => undefined,
+        signal: new AbortController().signal,
+      });
+
+    await expect(login()).resolves.toMatchObject({ access: "sk-legacy" });
+    status = 500;
+    await expect(login()).rejects.toThrow("LiteLLM CLI SSO start failed (HTTP 500)");
+  }, 15_000);
+
+  it("uses configured and default CLI token lifetimes when poll expiry is absent", async () => {
+    const agentDir = await makeAgentDir();
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_MODELS_DEV = "0";
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/sso/cli/start"))
+        return jsonResponse(200, { login_id: "cli-login", poll_secret: "poll-secret", user_code: "ABCD-EFGH" });
+      if (url.endsWith("/sso/cli/poll/cli-login"))
+        return jsonResponse(200, { status: "ready", key: "opaque-cli-token" });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+    const login = () =>
+      loginOAuth(pi.providers[0]!, {
+        onPrompt: async (prompt) => (prompt.placeholder ? "https://litellm.example.com" : ""),
+        onDeviceCode: () => undefined,
+        signal: new AbortController().signal,
+      });
+
+    process.env.LITELLM_CLI_JWT_EXPIRATION_HOURS = "48";
+    const configuredAt = Date.now();
+    const configured = await login();
+    expect(configured?.expires).toBeGreaterThanOrEqual(configuredAt + 48 * 60 * 60 * 1000);
+    delete process.env.LITELLM_CLI_JWT_EXPIRATION_HOURS;
+    const defaultAt = Date.now();
+    const fallback = await login();
+    expect(fallback?.expires).toBeGreaterThanOrEqual(defaultAt + 24 * 60 * 60 * 1000);
   }, 15_000);
 
   it("enterprise SSO login strips Bearer prefix from pasted SSO token", async () => {

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -59,9 +59,9 @@ describe("runAuthSmoke", () => {
     ]);
   });
 
-  it("redacts credential-shaped values from auth failure bodies", async () => {
+  it("keeps auth failure errors limited to endpoint and status", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      Response.json({ error: "Bearer sk-master-secret", token: "plain-virtual-secret" }, { status: 500 }),
+      Response.json({ error: "upstream failure", credentials: "unrecognized-secret" }, { status: 500 }),
     );
 
     await expect(
@@ -73,9 +73,8 @@ describe("runAuthSmoke", () => {
         enterprise: false,
       }),
     ).rejects.toSatisfy((error: Error) => {
-      expect(error.message).not.toContain("sk-master-secret");
-      expect(error.message).not.toContain("plain-virtual-secret");
-      return error.message.length < 600;
+      expect(error.message).toBe("missing-token /v1/models should reject auth, got 500");
+      return true;
     });
   });
 


### PR DESCRIPTION
## Summary

- add LiteLLM CLI device-code SSO through `/sso/cli/start` and `/sso/cli/poll`
- retain token-paste login only when the CLI SSO start endpoint is unavailable
- synchronize stored credential expiry from the proxy, with a compatible local fallback
- keep smoke failures useful without logging untrusted authentication response bodies

## Verification

- `npm run check` — 249 passed, 1 skipped
- `npm run clean` and `npm run build`
- `npm run supply-chain:guard`
- `npm pack --dry-run`
