### PR TITLE
chore(release): bump version to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.0.6",
+      "version": "2.1.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.0.6",
+  "version": "2.1.0",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package and lockfile version to 2.1.0
- prepare the merged LiteLLM CLI SSO support for release

## Verification

- npm ci --ignore-scripts
- npm run prepublishOnly
- npm pack --dry-run --json
- 249 tests passed, 1 skipped
- 25 package files checked