### PR TITLE
fix: re-enrich cached models through the provider models store

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,16 @@
-import { type Credential, createProvider, type Model, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
+import {
+  type Credential,
+  createProvider,
+  type Model,
+  type Provider,
+  type ProviderAuth,
+  type RefreshModelsContext,
+} from "@earendil-works/pi-ai";
 import { openAICompletionsApi, openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { enrichCachedModel } from "./discover.js";
 import type { DiscoveredModel, DiscoveryResult, LiteLLMApi } from "./types.js";
+
+type ModelStore = RefreshModelsContext["store"];
 
 export type LiteLLMProviderOptions = {
   id: string;
@@ -45,10 +54,18 @@ export function createLiteLLMProvider(options: LiteLLMProviderOptions): Provider
   if (!refreshModels) return provider;
   return {
     ...provider,
-    refreshModels: (context) =>
-      refreshModels({
-        ...context,
-        stored: context.stored && { ...context.stored, models: context.stored.models.map(enrichCachedModel) },
-      }),
+    refreshModels: (context) => refreshModels({ ...context, store: enrichingStore(context.store) }),
+  };
+}
+
+/** Re-enriches the cached catalog on read so stale entries gain metadata later releases know about. */
+function enrichingStore(store: ModelStore): ModelStore {
+  return {
+    read: async () => {
+      const entry = await store.read();
+      return entry && { ...entry, models: entry.models.map(enrichCachedModel) };
+    },
+    write: (entry) => store.write(entry),
+    delete: () => store.delete(),
   };
 }

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPi, loadExtension, type TestPi } from "./test-helpers.js";
+import { createModelStore, createPi, loadExtension, type TestPi } from "./test-helpers.js";
 
 vi.unmock("@earendil-works/pi-coding-agent");
 
@@ -16,8 +16,7 @@ function jsonResponse(status: number, body: unknown): Response {
 async function refreshProvider(pi: TestPi, allowNetwork = true, signal?: AbortSignal): Promise<void> {
   await pi.providers[0]?.refreshModels?.({
     allowNetwork,
-    stored: undefined,
-    publish: async () => true,
+    store: createModelStore(),
     credential: {
       type: "api_key",
       key: process.env.LITELLM_API_KEY ?? "sk-test",
@@ -64,7 +63,6 @@ describe("feature parity", () => {
     await expect(
       pi.providers[0]?.auth.apiKey?.check?.({
         ctx: { env: async (name) => process.env[name], fileExists: async () => false },
-        signal: new AbortController().signal,
       }),
     ).resolves.toEqual({ type: "api_key", source: "gcloud ADC" });
   });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,16 +1,9 @@
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type {
-  AuthInteraction,
-  Credential,
-  ModelsStore,
-  ModelsStoreEntry,
-  Provider,
-  RefreshModelsContext,
-} from "@earendil-works/pi-ai";
+import type { Api, AuthInteraction, Credential, Model, Provider, RefreshModelsContext } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPi, loadExtension } from "./test-helpers.js";
+import { createModelStore, createPi, loadExtension, type TestModelStore } from "./test-helpers.js";
 
 const ENV_KEYS = [
   "LITELLM_BASE_URL",
@@ -70,33 +63,13 @@ async function readHelperCount(agentDir: string): Promise<number> {
   }
 }
 
-function createModelsStore(models: readonly any[] = []): ModelsStore {
-  let entry: ModelsStoreEntry | undefined = models.length > 0 ? { models, checkedAt: Date.now() } : undefined;
-  return {
-    read: async () => entry,
-    write: async (_providerId, next) => {
-      entry = next;
-    },
-    delete: async () => {
-      entry = undefined;
-    },
-  };
-}
-
 async function refreshProvider(
   provider: Provider,
-  options: Omit<RefreshModelsContext, "publish" | "signal" | "stored"> & { store?: ModelsStore },
+  options: Omit<RefreshModelsContext, "signal" | "store"> & { store?: TestModelStore },
 ): Promise<readonly unknown[]> {
-  const store = options.store ?? createModelsStore();
   await provider.refreshModels?.({
     ...options,
-    stored: await store.read(provider.id),
-    publish: async ({ persist, update }) => {
-      if (persist === null) await store.delete(provider.id);
-      else if (persist) await store.write(provider.id, persist);
-      update?.();
-      return true;
-    },
+    store: options.store ?? createModelStore(),
     signal: new AbortController().signal,
   });
   return provider.getModels();
@@ -111,14 +84,12 @@ function resolveApiKey(provider: Provider, credential?: Extract<Credential, { ty
       env: async (name) => process.env[name],
       fileExists: async () => false,
     },
-    signal: TEST_SIGNAL,
   });
 }
 
 function resolveApiKeyWithEnv(provider: Provider, env: Record<string, string | undefined>) {
   return provider.auth.apiKey?.resolve({
     ctx: { env: async (name) => env[name], fileExists: async () => false },
-    signal: TEST_SIGNAL,
   });
 }
 
@@ -259,7 +230,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(await makeAgentDir());
     const pi = createPi();
     await extension(pi);
-    const stored = {
+    const stored: Model<Api> = {
       id: "stored-model",
       name: "Stored model",
       provider: "litellm",
@@ -275,7 +246,7 @@ describe("extension startup", () => {
     await refreshProvider(pi.providers[0]!, {
       allowNetwork: false,
       credential: { type: "api_key", key: "sk-test" },
-      store: createModelsStore([stored]),
+      store: createModelStore([stored]),
     });
 
     expect(pi.providers[0]?.getModels()).toEqual([stored]);
@@ -296,7 +267,7 @@ describe("extension startup", () => {
     await refreshProvider(pi.providers[0]!, {
       allowNetwork: false,
       credential: { type: "api_key", key: "sk-test" },
-      store: createModelsStore(),
+      store: createModelStore(),
     });
 
     expect(await readFile(cachePath, "utf8")).toBe(legacyCache);
@@ -327,7 +298,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(await makeAgentDir());
     const pi = createPi();
     await extension(pi);
-    const stored = {
+    const stored: Model<Api> = {
       id: "stored-model",
       name: "Stored model",
       provider: "litellm",
@@ -348,7 +319,7 @@ describe("extension startup", () => {
           key: "sk-test",
           env: { LITELLM_BASE_URL: "https://litellm.example.com" },
         },
-        store: createModelsStore([stored]),
+        store: createModelStore([stored]),
       }),
     ).rejects.toThrow("unexpected URL");
 
@@ -426,7 +397,7 @@ describe("extension startup", () => {
     const extension = await loadExtension(await makeAgentDir());
     const pi = createPi();
     await extension(pi);
-    const store = createModelsStore([
+    const store = createModelStore([
       {
         id: "stored-model",
         name: "Stored model",
@@ -560,7 +531,6 @@ describe("extension startup", () => {
 
     const result = await pi.providers[0]?.auth.apiKey?.check?.({
       ctx: { env: async (name) => process.env[name], fileExists: async () => false },
-      signal: TEST_SIGNAL,
     });
 
     expect(result).toEqual({ type: "api_key", source: "LITELLM_API_KEY_HELPER" });
@@ -1002,7 +972,6 @@ describe("extension startup", () => {
       loginOAuth(pi.providers[0]!, {
         onPrompt: async (prompt) => (prompt.placeholder ? "https://litellm.example.com" : ""),
         onDeviceCode: () => undefined,
-        signal: new AbortController().signal,
       }),
     ).resolves.toMatchObject({ access: "opaque-cli-token" });
     expect(polls).toBe(3);
@@ -1363,7 +1332,6 @@ describe("extension startup", () => {
           if (options.message.includes("Select login method")) return "2";
           return "";
         },
-        signal: new AbortController().signal,
       }),
     ).rejects.toThrow("SSO token is required");
   });

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -1,14 +1,8 @@
-import type {
-  Api,
-  Credential,
-  Model,
-  ModelsPublication,
-  ProviderAuth,
-  RefreshModelsContext,
-} from "@earendil-works/pi-ai";
+import type { Api, Credential, Model, ProviderAuth, RefreshModelsContext } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { createLiteLLMProvider, toNativeModels } from "../src/provider.js";
 import type { DiscoveryResult } from "../src/types.js";
+import { createModelStore, type TestModelStore } from "./test-helpers.js";
 
 const apiSpies = vi.hoisted(() => ({ completions: vi.fn(), responses: vi.fn() }));
 vi.mock("@earendil-works/pi-ai/compat", async (importOriginal) => ({
@@ -41,21 +35,14 @@ function native(id: string): Model<"openai-completions" | "openai-responses"> {
   return toNativeModels("litellm", "https://proxy.example/v1", discovered(id).models)[0];
 }
 
-type TestRefreshContext = RefreshModelsContext & { publications: ModelsPublication[] };
+type TestRefreshContext = RefreshModelsContext & { store: TestModelStore };
 
 function context(initial: readonly Model<Api>[] | undefined, allowNetwork: boolean): TestRefreshContext {
-  const publications: ModelsPublication[] = [];
   return {
-    stored: initial ? { models: initial, checkedAt: 1 } : undefined,
+    store: createModelStore(initial),
     allowNetwork,
     credential,
     signal: new AbortController().signal,
-    publish: vi.fn(async (publication) => {
-      publications.push(publication);
-      publication.update?.();
-      return true;
-    }),
-    publications,
   };
 }
 
@@ -179,7 +166,7 @@ describe("createLiteLLMProvider", () => {
     await value.refreshModels?.(refreshContext);
 
     expect(value.getModels()).toEqual([native("fresh")]);
-    expect(refreshContext.publications.at(-1)?.persist).toEqual({
+    expect(refreshContext.store.entry).toEqual({
       models: [native("fresh")],
       checkedAt: expect.any(Number),
     });
@@ -208,7 +195,7 @@ describe("createLiteLLMProvider", () => {
     await expect(value.refreshModels?.(refreshContext)).rejects.toThrow("rejected");
 
     expect(value.getModels()).toEqual([native("old")]);
-    expect(refreshContext.publications.every((publication) => publication.persist === undefined)).toBe(true);
+    expect(refreshContext.store.entry?.models).toEqual([native("old")]);
   });
 
   it("retains previous models when discovery is aborted", async () => {
@@ -223,7 +210,7 @@ describe("createLiteLLMProvider", () => {
     await value.refreshModels?.({ ...refreshContext, signal: abort.signal });
 
     expect(value.getModels()).toEqual([native("old")]);
-    expect(refreshContext.publications.every((publication) => publication.persist === undefined)).toBe(true);
+    expect(refreshContext.store.entry?.models).toEqual([native("old")]);
   });
 
   it("routes Responses models through the Responses API", async () => {

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1,6 +1,23 @@
 import { readFileSync } from "node:fs";
-import type { Provider } from "@earendil-works/pi-ai";
+import type { Api, Model, ModelsStoreEntry, Provider, RefreshModelsContext } from "@earendil-works/pi-ai";
 import { vi } from "vitest";
+
+/** In-memory ProviderModelsStore whose current entry stays readable for assertions. */
+export type TestModelStore = RefreshModelsContext["store"] & { entry: ModelsStoreEntry | undefined };
+
+export function createModelStore(models?: readonly Model<Api>[]): TestModelStore {
+  const store: TestModelStore = {
+    entry: models ? { models, checkedAt: 1 } : undefined,
+    read: async () => store.entry,
+    write: async (entry) => {
+      store.entry = entry;
+    },
+    delete: async () => {
+      store.entry = undefined;
+    },
+  };
+  return store;
+}
 
 type TestCommandContext = {
   ui: {


### PR DESCRIPTION
## Problem

`src/provider.ts` wrapped `refreshModels` to re-enrich the cached catalog by rewriting `context.stored`:

```ts
refreshModels({
  ...context,
  stored: context.stored && { ...context.stored, models: context.stored.models.map(enrichCachedModel) },
})
```

pi-ai removed `RefreshModelsContext.stored`. Since 0.84.x the provider reads its own cache through `context.store.read()` (`pi-ai/dist/models.js:337`), so the spread just set `stored: undefined` and **`enrichCachedModel` never ran**.

The failure is silent — no crash, no error. Cached models simply come back with whatever metadata was written at discovery time, so entries cached by an older release never pick up metadata that later releases know about (names, `reasoning`, `thinkingLevelMap`, context windows).

## Fix

Wrap the store instead, enriching on read:

```ts
refreshModels: (context) => refreshModels({ ...context, store: enrichingStore(context.store) })
```

`enrichingStore` delegates `read`/`write`/`delete` explicitly rather than spreading the store object, so a class-based `ProviderModelsStore` implementation keeps its `this` binding.

## Test suite

The suite was red on `main` — 22 failing tests and 22 typecheck errors — all from the same drift: the tests still modelled the removed `stored` + `publish`/`ModelsPublication` contract.

- Added one shared in-memory `createModelStore()` to `tests/test-helpers.ts` whose current `entry` stays readable, replacing the per-file shims in `index.test.ts`, `features.test.ts` and `provider.test.ts`.
- `publications.at(-1)?.persist` assertions become `store.entry`.
- Dropped `signal` from four `auth.apiKey.resolve/check` calls — same drift, the option no longer exists and nothing in `src/` reads it.

`provider.test.ts > re-enriches stale cached catalog aliases offline without discovery` is a direct regression test for the defect: it fails on `main`, passes here.

## Verification

|  | `main` | this branch |
|---|---|---|
| Tests | 22 failed | **0 failed** — 249 passed, 1 skipped |
| Typecheck | 22 errors | **0 errors** |
| `biome check src tests` | clean | clean |

## Note for the reviewer

`npm run check` still fails, for an unrelated reason: two git worktrees live inside the repo at `.worktrees/`, and biome refuses to run ("nested root configuration") while vitest picks up their copies of the suite. Worth adding `.worktrees` to `biome.json`'s ignore list and vitest's `exclude`, or moving those worktrees outside the repo — separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
