### PR TITLE
fix: keep Skills prompt enrichment best-effort on auth failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1264,14 +1264,24 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     );
   });
 
+  // Skills enrichment is best-effort: an expired credential or an unreachable proxy must not
+  // report an extension error on every turn. The failing model request states the real problem.
   pi.on("before_agent_start", async (event, ctx) => {
     defaultRuntimeAuth = undefined;
     if (!skillsEnabled || discoveryDisabledReason()) return;
-    const auth = await getRuntimeAuth(ctx);
-    if (!auth) return;
-    defaultRuntimeAuth = auth;
-    const skills = await listSkills(defaultRuntimeAuth.baseUrl, defaultRuntimeAuth.apiKey, defaultRuntimeAuth.headers);
-    const section = createSkillsPromptSection(skills);
+    let section: string | undefined;
+    try {
+      const auth = await getRuntimeAuth(ctx);
+      if (!auth) return;
+      defaultRuntimeAuth = auth;
+      const skills = await listSkills(auth.baseUrl, auth.apiKey, auth.headers);
+      section = createSkillsPromptSection(skills);
+    } catch (error) {
+      if (isVerboseDiscovery()) {
+        process.stderr.write(`LiteLLM: skipping Skills (${error instanceof Error ? error.message : String(error)}).\n`);
+      }
+      return;
+    }
     if (!section) return;
     return { systemPrompt: `${event.systemPrompt}\n\n${section}` };
   });

--- a/tests/skills-hook-errors.test.ts
+++ b/tests/skills-hook-errors.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPi, loadExtension } from "./test-helpers.js";
+
+vi.unmock("@earendil-works/pi-coding-agent");
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+  delete process.env.LITELLM_BASE_URL;
+  delete process.env.LITELLM_API_KEY;
+  delete process.env.LITELLM_VERBOSE_DISCOVERY;
+});
+
+async function startHook() {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-skills-"));
+  process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+  process.env.LITELLM_API_KEY = "sk-test";
+  const pi = createPi();
+  await (await loadExtension(agentDir))(pi);
+  return pi.handlers.get("before_agent_start")?.[0];
+}
+
+describe("before_agent_start skills hook", () => {
+  // An expired LiteLLM SSO credential makes Pi's getProviderAuth throw. The hook must not
+  // turn that into a per-turn `Extension "..." error:` report.
+  it("survives an unrefreshable OAuth credential", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, []));
+    const beforeAgentStart = await startHook();
+
+    await expect(
+      beforeAgentStart?.(
+        { systemPrompt: "Base prompt" },
+        {
+          modelRegistry: {
+            getProviderAuth: async () => {
+              throw new Error("OAuth refresh failed for litellm: LiteLLM credential cannot be refreshed");
+            },
+            getProvider: () => undefined,
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("survives a failing skills catalog request", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connect ECONNREFUSED"));
+    const beforeAgentStart = await startHook();
+
+    await expect(
+      beforeAgentStart?.(
+        { systemPrompt: "Base prompt" },
+        {
+          modelRegistry: {
+            getProviderAuth: async () => ({
+              auth: { apiKey: "sk-test", baseUrl: "https://litellm.example.com/v1" },
+            }),
+            getProvider: () => undefined,
+          },
+        },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("reports the reason on stderr under LITELLM_VERBOSE_DISCOVERY", async () => {
+    process.env.LITELLM_VERBOSE_DISCOVERY = "1";
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, []));
+    const stderr = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const beforeAgentStart = await startHook();
+
+    await beforeAgentStart?.(
+      { systemPrompt: "Base prompt" },
+      {
+        modelRegistry: {
+          getProviderAuth: async () => {
+            throw new Error("LiteLLM credential cannot be refreshed");
+          },
+          getProvider: () => undefined,
+        },
+      },
+    );
+
+    expect(stderr.mock.calls.map(([line]) => String(line)).join("")).toContain("cannot be refreshed");
+  });
+});


### PR DESCRIPTION
## Problem

When a LiteLLM SSO credential expires, every turn prints a red extension crash report with a stack trace:

```
Extension "…/pi-provider-litellm/dist/index.js" error: OAuth refresh failed for litellm:
LiteLLM credential cannot be refreshed; run /login litellm again
  at credentials.modify.signal.signal (…/pi-ai/dist/auth/resolve.js:90:27)
  at async …/pi-coding-agent/dist/core/auth-storage.js:384:26
  …
```

The expiry itself is correct behaviour. LiteLLM's CLI SSO issues no refresh token, so `refreshLiteLLM` (`src/index.ts:658`) rightly throws once the token is dead — verified against a real proxy, the stored token returns HTTP 401 on both `/v1/models` and `/key/info`, and `/login litellm` is the correct recovery.

The bug is where that error escapes. The `before_agent_start` hook calls `getRuntimeAuth(ctx)` → `ctx.modelRegistry.getProviderAuth()`, which throws. `extensions/runner.js` catches a throwing handler and routes it to `emitError` → `showExtensionError`, so a routine expired session is presented as an extension crash — repeatedly, once per turn, burying the one line that says what to do.

Skills prompt injection is an optional enhancement. It should never be able to do that.

## Fix

The hook is now best-effort: on failure it skips enrichment and returns undefined, reporting the reason only under `LITELLM_VERBOSE_DISCOVERY=1`. The failing model request still surfaces the real auth error through Pi's own UI, which is where it belongs. This matches how the MCP discovery path already behaves.

## Tests

`tests/skills-hook-errors.test.ts` — 3 cases:

- an unrefreshable OAuth credential (reproduces the reported error string; fails on `main`)
- a failing skills catalog request
- the verbose-mode stderr report (fails on `main`)

The catalog-failure case already passed before this change — `listSkills` handles its own network errors, only auth resolution was exposed.

## Verification

Against the locked dependencies (`npm ci`, pi-ai 0.84.2):

|  | `main` | this branch |
|---|---|---|
| Tests | 249 passed, 1 skipped | **252 passed**, 1 skipped |
| Typecheck | 0 errors | 0 errors |
| `biome check src tests` | clean | clean |

## Related, not fixed here

From `pi-ai/dist/auth/resolve.js`: *"A stored credential owns the provider: ambient/env is consulted only when nothing is stored. No silent env fallback after a failed refresh."* So while a dead credential sits in `auth.json`, setting `LITELLM_BASE_URL`/`LITELLM_API_KEY` will not rescue the session — `/logout litellm` is the escape hatch. That is the host's deliberate design; worth a README note separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
