### PR TITLE
fix: support explicit insecure HTTP providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Provider fields:
 | `headers` | `$LITELLM_HEADERS` for `litellm`; unset for aliases | JSON string env reference or inline object of request headers |
 | `displayName` | provider name | Label shown in Pi UI |
 | `enabled` | `true` | Set `false` to skip an alias |
+| `allowInsecureHttp` | `false` | Set `true` to permit plaintext HTTP for this provider, for example `http://host.docker.internal`. Credentials and request data will not be encrypted. Loopback HTTP works without this setting. |
 
 `/login litellm` and Google ADC token auth remain scoped to the default `litellm` provider. Aliases use their configured `apiKey` or manually stored auth entries matching the alias name.
 

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -18,12 +18,12 @@ const DEFAULT_CONTEXT_WINDOW = 128_000;
 const DEFAULT_MAX_TOKENS = 16_384;
 const KNOWN_PROVIDER_SET = new Set<string>(getProviders());
 
-export function normalizeBaseUrl(input: string): string {
+export function normalizeBaseUrl(input: string, allowInsecureHttp = false): string {
   const url = new URL(input);
   const hostname = url.hostname.toLowerCase();
   const loopback =
     hostname === "localhost" || hostname === "[::1]" || (isIP(hostname) === 4 && hostname.startsWith("127."));
-  if (url.protocol !== "https:" && !(url.protocol === "http:" && loopback)) {
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && (loopback || allowInsecureHttp))) {
     throw new Error("LiteLLM base URL must use HTTPS except for loopback hosts");
   }
   return input.replace(/\/+$/, "").replace(/\/v1\/?$/i, "");
@@ -332,7 +332,7 @@ export async function discoverModels(
   apiKey: string,
   options: DiscoveryOptions & { onProgress?: (message: string) => void; silent?: boolean } = {},
 ): Promise<DiscoveryResult> {
-  const base = normalizeBaseUrl(baseUrl);
+  const base = normalizeBaseUrl(baseUrl, options.allowInsecureHttp);
   const progress = options.silent ? undefined : options.onProgress;
   progress?.("Querying /model/info endpoint...");
   const infoResult = await fetchJson<ModelInfoResponse>(`${base}/model/info`, apiKey, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ type RawProviderSettings = {
   apiKey?: unknown;
   headers?: unknown;
   enabled?: unknown;
+  allowInsecureHttp?: unknown;
 };
 
 type ProviderDefinition = {
@@ -72,6 +73,7 @@ type ProviderDefinition = {
   useDefaultEnv: boolean;
   useGcloudTokenAuth: boolean;
   enableOAuth: boolean;
+  allowInsecureHttp: boolean;
 };
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -390,7 +392,7 @@ async function resolveCredentials(
     apiKeyConfig = `$${ENV_API_KEY}`;
   }
   return {
-    baseUrl: configuredBase ? normalizeBaseUrl(configuredBase) : undefined,
+    baseUrl: configuredBase ? normalizeBaseUrl(configuredBase, definition.allowInsecureHttp) : undefined,
     apiKey: apiKey || undefined,
     apiKeyConfig,
   };
@@ -457,6 +459,7 @@ function getProviderDefinitions(settings: Record<string, unknown> | undefined): 
     useDefaultEnv: isDefault,
     useGcloudTokenAuth: isDefault,
     enableOAuth: isDefault,
+    allowInsecureHttp: raw?.allowInsecureHttp === true,
   });
 
   const definitions = [makeDefinition(PROVIDER_NAME, defaultSettings, true)];
@@ -469,7 +472,7 @@ function getProviderDefinitions(settings: Record<string, unknown> | undefined): 
   return definitions;
 }
 
-async function loginApiKey(interaction: AuthInteraction): Promise<ApiKeyCredential> {
+async function loginApiKey(interaction: AuthInteraction, allowInsecureHttp = false): Promise<ApiKeyCredential> {
   const rawBaseUrl = (
     await interaction.prompt({
       type: "text",
@@ -480,7 +483,7 @@ async function loginApiKey(interaction: AuthInteraction): Promise<ApiKeyCredenti
   if (!rawBaseUrl) throw new Error("Base URL is required");
   const key = (await interaction.prompt({ type: "secret", message: "Enter API key:" })).trim();
   if (!key) throw new Error("Both base URL and API key are required");
-  return { type: "api_key", key, env: { [ENV_BASE_URL]: normalizeBaseUrl(rawBaseUrl) } };
+  return { type: "api_key", key, env: { [ENV_BASE_URL]: normalizeBaseUrl(rawBaseUrl, allowInsecureHttp) } };
 }
 
 type CliSsoStart = { loginId: string; pollSecret: string; userCode: string; expiresInSeconds: number };
@@ -633,7 +636,11 @@ async function loginWithPastedToken(
   return { type: "oauth", access, refresh: "", expires, baseUrl };
 }
 
-async function loginOAuth(interaction: AuthInteraction, headers?: Record<string, string>): Promise<OAuthCredential> {
+async function loginOAuth(
+  interaction: AuthInteraction,
+  headers?: Record<string, string>,
+  allowInsecureHttp = false,
+): Promise<OAuthCredential> {
   const rawBaseUrl = (
     await interaction.prompt({
       type: "text",
@@ -642,7 +649,7 @@ async function loginOAuth(interaction: AuthInteraction, headers?: Record<string,
     })
   ).trim();
   if (!rawBaseUrl) throw new Error("Base URL is required");
-  const baseUrl = normalizeBaseUrl(rawBaseUrl);
+  const baseUrl = normalizeBaseUrl(rawBaseUrl, allowInsecureHttp);
   const cliSso = await startCliSso(baseUrl, interaction.signal, headers);
   if (!cliSso) return loginWithPastedToken(interaction, baseUrl, headers);
   interaction.notify({
@@ -692,7 +699,7 @@ async function resolveApiKeyAuth(
   if (stored) {
     source = "stored credential";
     creds = {
-      baseUrl: baseUrl ? normalizeBaseUrl(baseUrl) : undefined,
+      baseUrl: baseUrl ? normalizeBaseUrl(baseUrl, definition.allowInsecureHttp) : undefined,
       apiKey: stored,
     };
   } else {
@@ -728,7 +735,7 @@ async function resolveApiKeyAuth(
         }
       }
     }
-    if (!creds.baseUrl && baseUrl) creds.baseUrl = normalizeBaseUrl(baseUrl);
+    if (!creds.baseUrl && baseUrl) creds.baseUrl = normalizeBaseUrl(baseUrl, definition.allowInsecureHttp);
   }
   if (!creds.apiKey) return undefined;
   return {
@@ -737,7 +744,7 @@ async function resolveApiKeyAuth(
       baseUrl: creds.baseUrl ? `${creds.baseUrl}/v1` : undefined,
       headers: await resolveHeadersFromContext(definition, ctx.env),
     },
-    env: baseUrl ? { [ENV_BASE_URL]: normalizeBaseUrl(baseUrl) } : undefined,
+    env: baseUrl ? { [ENV_BASE_URL]: normalizeBaseUrl(baseUrl, definition.allowInsecureHttp) } : undefined,
     source: source ?? creds.apiKeyConfig ?? ENV_API_KEY,
   };
 }
@@ -746,7 +753,10 @@ function createProviderAuth(definition: ProviderDefinition): ProviderAuth {
   return {
     apiKey: {
       name: `${definition.displayName} API key`,
-      login: definition.name === PROVIDER_NAME ? loginApiKey : undefined,
+      login:
+        definition.name === PROVIDER_NAME
+          ? (interaction) => loginApiKey(interaction, definition.allowInsecureHttp)
+          : undefined,
       check: async ({ ctx, credential }) => {
         const baseUrl =
           credential?.env?.[ENV_BASE_URL] ??
@@ -784,14 +794,16 @@ function createProviderAuth(definition: ProviderDefinition): ProviderAuth {
       ? {
           name: "LiteLLM SSO",
           loginLabel: "Sign in with LiteLLM SSO",
-          login: (interaction) => loginOAuth(interaction, resolveHeaders(definition)),
+          login: (interaction) => loginOAuth(interaction, resolveHeaders(definition), definition.allowInsecureHttp),
           refresh: async (credential, signal) => ({
             ...(await refreshLiteLLM(credential, signal)),
             type: "oauth" as const,
           }),
           toAuth: async (credential) => ({
             apiKey: credential.access,
-            baseUrl: credential.baseUrl ? `${normalizeBaseUrl(String(credential.baseUrl))}/v1` : undefined,
+            baseUrl: credential.baseUrl
+              ? `${normalizeBaseUrl(String(credential.baseUrl), definition.allowInsecureHttp)}/v1`
+              : undefined,
             headers: resolveHeaders(definition),
           }),
         }
@@ -1037,16 +1049,21 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       cleanConfig(definition.baseUrl) ??
       (definition.useDefaultEnv ? cleanConfig(process.env[ENV_BASE_URL]) : undefined) ??
       "https://litellm.example.com";
-    return `${normalizeBaseUrl(baseUrl)}/v1`;
+    return `${normalizeBaseUrl(baseUrl, definition.allowInsecureHttp)}/v1`;
   }
 
   async function authForCredential(definition: ProviderDefinition, credential?: Credential, executeHelpers = true) {
     if (credential?.type === "oauth") {
       const baseUrl =
         typeof credential.baseUrl === "string"
-          ? normalizeBaseUrl(credential.baseUrl)
-          : normalizeBaseUrl(requestBaseUrl(definition));
-      return { baseUrl, apiKey: credential.access, headers: resolveHeaders(definition) };
+          ? normalizeBaseUrl(credential.baseUrl, definition.allowInsecureHttp)
+          : normalizeBaseUrl(requestBaseUrl(definition), definition.allowInsecureHttp);
+      return {
+        baseUrl,
+        apiKey: credential.access,
+        headers: resolveHeaders(definition),
+        allowInsecureHttp: definition.allowInsecureHttp,
+      };
     }
     const resolved = await resolveApiKeyAuth(
       definition,
@@ -1058,9 +1075,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       throw new Error(`no credentials for ${definition.name}. Run /login litellm or set env vars.`);
     }
     return {
-      baseUrl: normalizeBaseUrl(resolved.auth.baseUrl ?? requestBaseUrl(definition)),
+      baseUrl: normalizeBaseUrl(resolved.auth.baseUrl ?? requestBaseUrl(definition), definition.allowInsecureHttp),
       apiKey: resolved.auth.apiKey,
       headers: resolved.auth.headers,
+      allowInsecureHttp: definition.allowInsecureHttp,
     };
   }
 
@@ -1070,7 +1088,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   function mcpCatalogIdentity(auth: LiteLLMRuntimeAuth): string {
     return JSON.stringify({
-      baseUrl: normalizeBaseUrl(auth.baseUrl),
+      baseUrl: normalizeBaseUrl(auth.baseUrl, auth.allowInsecureHttp),
       apiKey: auth.apiKey,
       headers: Object.entries(auth.headers ?? {}).sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0)),
     });
@@ -1089,9 +1107,10 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       ),
     );
     return {
-      baseUrl: normalizeBaseUrl(baseUrl),
+      baseUrl: normalizeBaseUrl(baseUrl, definitions[0]?.allowInsecureHttp),
       apiKey,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
+      allowInsecureHttp: definitions[0]?.allowInsecureHttp,
     };
   }
 
@@ -1164,11 +1183,12 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       timeoutMs: getDiscoveryTimeoutMs(),
       signal,
       headers: auth.headers,
+      allowInsecureHttp: auth.allowInsecureHttp,
       silent: !isVerboseDiscovery(),
       onProgress: isVerboseDiscovery() ? (message) => process.stderr.write(`LiteLLM: ${message}\n`) : undefined,
     });
     signal?.throwIfAborted();
-    return { ...result, baseUrl: `${normalizeBaseUrl(auth.baseUrl)}/v1` };
+    return { ...result, baseUrl: `${normalizeBaseUrl(auth.baseUrl, auth.allowInsecureHttp)}/v1` };
   }
 
   // Pi's startup path only ever refreshes with allowNetwork:false, and it returns before the
@@ -1264,7 +1284,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
       const auth = await getRuntimeAuth(ctx);
       if (!auth) return;
       defaultRuntimeAuth = auth;
-      const skills = await listSkills(auth.baseUrl, auth.apiKey, auth.headers);
+      const skills = await listSkills(auth.baseUrl, auth.apiKey, auth.headers, auth.allowInsecureHttp);
       section = createSkillsPromptSection(skills);
     } catch (error) {
       if (isVerboseDiscovery()) {

--- a/src/mcp-tools.ts
+++ b/src/mcp-tools.ts
@@ -80,11 +80,12 @@ export async function discoverMcpTools(
   headers?: Record<string, string>,
   onProgress?: (message: string) => void,
   parentSignal?: AbortSignal,
+  allowInsecureHttp = false,
 ): Promise<LiteLLMMcpTool[]> {
   onProgress?.("Discovering MCP tools from server...");
   try {
     onProgress?.("Querying MCP tools/list endpoint...");
-    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/list`, {
+    const response = await fetch(`${normalizeBaseUrl(baseUrl, allowInsecureHttp)}/mcp-rest/tools/list`, {
       headers: {
         ...headers,
         Authorization: `Bearer ${apiKey}`,
@@ -118,9 +119,10 @@ export async function executeMcpTool(
   toolName: string,
   args: Record<string, unknown>,
   headers?: Record<string, string>,
+  allowInsecureHttp = false,
 ): Promise<string> {
   for (let attempt = 0; attempt <= MCP_RETRY_ATTEMPTS; attempt++) {
-    const result = await executeMcpToolOnce(baseUrl, apiKey, serverId, toolName, args, headers);
+    const result = await executeMcpToolOnce(baseUrl, apiKey, serverId, toolName, args, headers, allowInsecureHttp);
     if (attempt < MCP_RETRY_ATTEMPTS && result.retryable) {
       await sleep(MCP_RETRY_DELAY_MS);
       continue;
@@ -137,11 +139,12 @@ async function executeMcpToolOnce(
   toolName: string,
   args: Record<string, unknown>,
   headers?: Record<string, string>,
+  allowInsecureHttp = false,
 ): Promise<McpExecutionResult> {
   try {
     let response: Response;
     try {
-      response = await fetch(`${normalizeBaseUrl(baseUrl)}/mcp-rest/tools/call`, {
+      response = await fetch(`${normalizeBaseUrl(baseUrl, allowInsecureHttp)}/mcp-rest/tools/call`, {
         method: "POST",
         headers: {
           ...headers,
@@ -211,6 +214,7 @@ export async function createMcpToolDefinitions(
     discoveryAuth.headers,
     onProgress,
     signal,
+    discoveryAuth.allowInsecureHttp,
   );
 
   return tools.map((mcpTool) => {
@@ -239,6 +243,7 @@ export async function createMcpToolDefinitions(
           mcpTool.name,
           args,
           auth.headers,
+          auth.allowInsecureHttp,
         );
         return {
           content: [{ type: "text", text }],

--- a/src/skills.ts
+++ b/src/skills.ts
@@ -30,8 +30,9 @@ export async function listSkills(
   baseUrl: string,
   apiKey: string,
   headers?: Record<string, string>,
+  allowInsecureHttp = false,
 ): Promise<LiteLLMSkill[]> {
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, allowInsecureHttp);
   if (
     skillsCache &&
     skillsCache.baseUrl === normalizedBaseUrl &&
@@ -74,9 +75,10 @@ export async function createSkill(
     inputSchema?: Record<string, unknown>;
   },
   headers?: Record<string, string>,
+  allowInsecureHttp = false,
 ): Promise<unknown> {
   if (!input.source && !input.code) throw new Error("code is required when source is omitted");
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, allowInsecureHttp);
   let usedSkillHub = input.source !== undefined;
   const skillHubPayload = input.source
     ? {
@@ -139,8 +141,9 @@ export async function deleteSkill(
   apiKey: string,
   skillId: string,
   headers?: Record<string, string>,
+  allowInsecureHttp = false,
 ): Promise<void> {
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl, allowInsecureHttp);
   let skillHubError: unknown;
   const skillHubResponse = await fetch(`${normalizedBaseUrl}/claude-code/plugins/${encodeURIComponent(skillId)}`, {
     method: "DELETE",
@@ -222,7 +225,7 @@ export function createSkillToolDefinitions(
       parameters: Type.Object({}),
       async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
         const auth = await getAuth(ctx);
-        const skills = await listSkills(auth.baseUrl, auth.apiKey, auth.headers);
+        const skills = await listSkills(auth.baseUrl, auth.apiKey, auth.headers, auth.allowInsecureHttp);
         return { content: [{ type: "text", text: formatSkills(skills) }], details: { count: skills.length } };
       },
     }),
@@ -248,6 +251,7 @@ export function createSkillToolDefinitions(
             inputSchema,
           },
           auth.headers,
+          auth.allowInsecureHttp,
         );
         return { content: [{ type: "text", text: "LiteLLM skill created." }], details: { result } };
       },
@@ -259,7 +263,7 @@ export function createSkillToolDefinitions(
       parameters: DeleteSkillParams,
       async execute(_toolCallId, params: Static<typeof DeleteSkillParams>, _signal, _onUpdate, ctx) {
         const auth = await getAuth(ctx);
-        await deleteSkill(auth.baseUrl, auth.apiKey, params.skillId, auth.headers);
+        await deleteSkill(auth.baseUrl, auth.apiKey, params.skillId, auth.headers, auth.allowInsecureHttp);
         return { content: [{ type: "text", text: `LiteLLM skill deleted: ${params.skillId}` }], details: {} };
       },
     }),

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export type LiteLLMRuntimeAuth = {
   baseUrl: string;
   apiKey: string;
   headers?: Record<string, string>;
+  allowInsecureHttp?: boolean;
 };
 
 export type DiscoveredModel = Omit<Model<"openai-completions">, "provider" | "api" | "baseUrl"> & {
@@ -23,6 +24,7 @@ export interface DiscoveryOptions {
   timeoutMs?: number;
   signal?: AbortSignal;
   headers?: Record<string, string>;
+  allowInsecureHttp?: boolean;
 }
 
 export interface ModelInfoEntry {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -17,6 +17,14 @@ describe("normalizeBaseUrl", () => {
     expect(() => normalizeBaseUrl("http://litellm.example.com")).toThrow(/HTTPS/);
   });
 
+  it("allows an explicitly configured insecure endpoint", () => {
+    expect(normalizeBaseUrl("http://host.docker.internal/v1", true)).toBe("http://host.docker.internal");
+  });
+
+  it("does not allow other insecure protocols", () => {
+    expect(() => normalizeBaseUrl("ftp://host.docker.internal", true)).toThrow(/HTTPS/);
+  });
+
   it("strips trailing slashes", () => {
     expect(normalizeBaseUrl("https://x.example.com/")).toBe("https://x.example.com");
     expect(normalizeBaseUrl("https://x.example.com///")).toBe("https://x.example.com");

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -447,6 +447,37 @@ describe("extension startup", () => {
     expect(pi.providers[0]?.baseUrl).toBe("https://litellm.example.com/v1");
   });
 
+  it("uses explicitly allowed insecure HTTP for a provider", async () => {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "settings.json"),
+      JSON.stringify({
+        litellm: {
+          providers: {
+            litellm: {
+              baseUrl: "http://host.docker.internal",
+              apiKey: "sk-local",
+              allowInsecureHttp: true,
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+
+    await extension(pi);
+
+    await expect(resolveApiKey(pi.providers[0]!)).resolves.toMatchObject({
+      auth: {
+        apiKey: "sk-local",
+        baseUrl: "http://host.docker.internal/v1",
+      },
+    });
+  });
+
   it("applies LiteLLM request compatibility hooks to configured provider aliases", async () => {
     const agentDir = await makeAgentDir();
     await writeFile(

--- a/tests/mcp-tools.test.ts
+++ b/tests/mcp-tools.test.ts
@@ -15,6 +15,16 @@ afterEach(() => {
 });
 
 describe("discoverMcpTools", () => {
+  it("uses an explicitly allowed insecure endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { tools: [] }));
+
+    await expect(
+      discoverMcpTools("http://host.docker.internal", "sk-test", undefined, undefined, undefined, true),
+    ).resolves.toEqual([]);
+
+    expect(fetchMock).toHaveBeenCalledWith("http://host.docker.internal/mcp-rest/tools/list", expect.any(Object));
+  });
+
   it("returns tools from LiteLLM MCP REST discovery", async () => {
     const inputSchema = {
       type: "object",

--- a/tests/skills.test.ts
+++ b/tests/skills.test.ts
@@ -23,6 +23,17 @@ afterEach(() => {
 });
 
 describe("listSkills", () => {
+  it("uses an explicitly allowed insecure endpoint", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { plugins: [] }));
+
+    await expect(listSkills("http://host.docker.internal", "sk-test", undefined, true)).resolves.toEqual([]);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://host.docker.internal/claude-code/marketplace.json",
+      expect.any(Object),
+    );
+  });
+
   it("returns skills from the LiteLLM Skill Hub marketplace", async () => {
     const skills: LiteLLMSkill[] = [{ name: "terraform", description: "Terraform conventions", enabled: true }];
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { plugins: skills }));


### PR DESCRIPTION
## Summary

- add an explicit per-provider `allowInsecureHttp` opt-in
- preserve HTTPS enforcement and loopback HTTP defaults
- propagate the transport policy through auth, discovery, MCP, and Skills
- document the plaintext credential and request-data risk

Closes #144

## Verification

- `npx biome check --error-on-warnings` on changed files
- `npm run typecheck`
- `npm test -- --exclude '.worktrees/**'` (248 passed, 1 skipped)
- `npm run clean`
- `npm run build`
