### PR TITLE
chore(release): bump version to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump the package version to `2.2.1`
- prepare the patch release for the explicit insecure HTTP provider opt-in from #145

## Verification

- `npm ci --ignore-scripts`
- `npm run prepublishOnly` (248 passed, 1 skipped; 23 package files checked)
- `npm pack --dry-run --json`
