### PR TITLE
fix: seed from the persisted catalog when startup discovery is unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { getAgentDir, readStoredCredential } from "@earendil-works/pi-coding-age
 import { setupLiteLLMCostTracking } from "./cost.js";
 import {
   discoverModels,
+  enrichCachedModel,
   isGpt55Model,
   isMoonshotModel,
   normalizeBaseUrl,
@@ -1191,11 +1192,35 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     return { ...result, baseUrl: `${normalizeBaseUrl(auth.baseUrl, auth.allowInsecureHttp)}/v1` };
   }
 
+  // A seed that returns [] leaves the provider registered with ZERO models, and an
+  // unattended session never recovers: Pi's startup refresh already ran with
+  // allowNetwork:false before this provider persisted anything, /model restores the
+  // cached catalog but the session's default model is never re-resolved, so every
+  // prompt fails with "No API key found for the selected model". Falling back to the
+  // persisted catalog keeps cold starts working exactly like the refresh restore
+  // path would — same store, same enrichment — just early enough for default-model
+  // resolution. Repro for the gap this closes: LITELLM_DISCOVERY_TIMEOUT_MS=1.
+  async function seedFromStore(definition: ProviderDefinition): Promise<Model<LiteLLMApi>[]> {
+    try {
+      const raw = await readFile(join(getAgentDir(), "models-store.json"), "utf8");
+      const entry = (JSON.parse(raw) as Record<string, { models?: Model<LiteLLMApi>[] } | undefined>)[definition.name];
+      const models = (entry?.models ?? []).filter((model) => model?.provider === definition.name);
+      if (models.length > 0 && isVerboseDiscovery()) {
+        process.stderr.write(
+          `LiteLLM (${definition.name}): startup discovery unavailable; seeded ${models.length} models from the persisted catalog.\n`,
+        );
+      }
+      return models.map((model) => enrichCachedModel(model) as Model<LiteLLMApi>);
+    } catch {
+      return [];
+    }
+  }
+
   // Pi's startup path only ever refreshes with allowNetwork:false, and it returns before the
   // network phase, so the provider would stay empty until the user opens /model. Discover here
   // instead, the way 1.x did, and hand the catalog over as the provider's baseline models.
   async function seedModels(definition: ProviderDefinition): Promise<Model<LiteLLMApi>[]> {
-    if (discoveryDisabledReason() || isHostOffline()) return [];
+    if (discoveryDisabledReason() || isHostOffline()) return seedFromStore(definition);
     try {
       const stored = readStoredCredential(definition.name, join(getAgentDir(), "auth.json"));
       // executeHelpers:false — activation must never run the user's key helper as a side effect,
@@ -1210,7 +1235,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
           `LiteLLM (${definition.name}): startup discovery skipped (${error instanceof Error ? error.message : String(error)}).\n`,
         );
       }
-      return [];
+      return seedFromStore(definition);
     }
   }
 

--- a/tests/cold-start-discovery.test.ts
+++ b/tests/cold-start-discovery.test.ts
@@ -159,4 +159,46 @@ describe("cold start discovery (issue #137)", () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it("falls back to the persisted models-store catalog when startup discovery is unavailable", async () => {
+    // A cold start whose discovery misses (slow daemon vs the seed budget, or a
+    // daemon that is briefly down) must not leave the provider empty when Pi's
+    // models-store.json still holds the last known catalog: an empty seed means
+    // the session's default model never resolves and never recovers unattended.
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-litellm-cold-store-"));
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({
+        litellm: { type: "api_key", key: "stored-key", env: { LITELLM_BASE_URL: "https://stored.example.com" } },
+      }),
+    );
+    const storedModel = {
+      id: "gpt-4o",
+      name: "gpt-4o (no metadata)",
+      api: "openai-completions",
+      provider: "litellm",
+      baseUrl: "https://stored.example.com/v1",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 8_192,
+    };
+    await writeFile(
+      join(agentDir, "models-store.json"),
+      JSON.stringify({
+        litellm: {
+          checkedAt: 0,
+          models: [storedModel, { ...storedModel, id: "foreign", provider: "someone-else" }],
+        },
+      }),
+    );
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      throw new Error("daemon unreachable");
+    });
+
+    const runtime = await startup(agentDir);
+
+    expect(runtime.getModels("litellm").map((model) => model.id)).toEqual(["gpt-4o"]);
+  });
 });


### PR DESCRIPTION
fixes: #147

# fix: seed from the persisted catalog when startup discovery is unavailable

## Problem

When the activation-time model seed cannot complete — the daemon answers
slower than the (deliberately hard-capped) 3s seed budget, is briefly down,
or `LITELLM_OFFLINE`/`PI_OFFLINE` is set — `seedModels` returns `[]` and the
provider registers with **zero models**, even when Pi's `models-store.json`
still holds the full catalog from the last successful discovery.

For an unattended session that state is permanent:

- Pi's startup refresh (the `allowNetwork:false` phase that would restore the
  stored catalog) has already run before this provider persisted anything.
- Opening `/model` restores the cached catalog ("Could not refresh litellm;
  showing cached models") — but the session's **default model is never
  re-resolved**, so without a human selecting in the picker, every prompt
  fails with `No API key found for the selected model`.

Deterministic repro: `LITELLM_DISCOVERY_TIMEOUT_MS=1 pi` (forces the seed
miss) with a populated `models-store.json` → "No models available", failing
prompts, catalog visible in `/model`.

This bites hardest in containers and headless/orchestrated sessions, where
nobody ever opens `/model`, and under concurrent cold starts (several
sessions hitting the proxy at once push discovery past the seed budget).

## Fix

`seedModels` falls back to the persisted catalog on both empty paths — the
offline gate and the seed-miss catch. The fallback reads
`models-store.json`, filters the entry to this provider's models, and
applies the same `enrichCachedModel` treatment the refresh restore path
uses. Because it runs before `registerProvider`, default-model resolution
succeeds and cold starts behave exactly like a successful (cached)
discovery. When discovery succeeds, nothing changes; when both discovery
and the store are unavailable, behavior is as before (empty seed).

## Testing

- New test in `tests/cold-start-discovery.test.ts`: a startup whose fetch
  fails seeds from a populated `models-store.json` (and filters out entries
  belonging to other providers).
- Full suite: 249 passed, 1 skipped; `npm run check` green.
- Field-tested against a real LiteLLM-compatible proxy: forced seed miss →
  `startup discovery unavailable; seeded 38 models from the persisted
  catalog` → session prompts work.