### PR TITLE
feat: offer the known LiteLLM proxy URL at login

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ To configure an API key, run `/login`, choose `Sign in with an API key`, then ch
 
 You'll be prompted for the base URL and API key. Credentials are persisted to `~/.pi/agent/auth.json`.
 
+If a proxy URL is already known — from `providers.<name>.baseUrl`, `LITELLM_BASE_URL`, or a previous login — pi offers it as the first option instead of asking you to retype it. Pick `Enter a different URL…` to point at another proxy.
+
 #### Enterprise SSO login
 
 If your LiteLLM proxy requires SSO/OAuth authentication (enterprise deployments), you can authenticate through LiteLLM's CLI SSO flow:
 
 1. Run `/login litellm` inside pi and select `Sign in with LiteLLM SSO`
-2. Enter the proxy URL
+2. Confirm the offered proxy URL, or enter one if this is the first login
 3. Pi displays a verification code and opens the LiteLLM SSO login URL automatically
 4. Authenticate in the browser and confirm the displayed code
 5. If your account belongs to multiple teams, select the team for this session in Pi

--- a/biome.json
+++ b/biome.json
@@ -23,9 +23,10 @@
   },
   "files": {
     "includes": [
-      "**/src/**/*.ts",
-      "**/tests/**/*.ts",
-      "**/scripts/**/*.ts",
+      "src/**/*.ts",
+      "tests/**/*.ts",
+      "scripts/**/*.ts",
+      "!**/.worktrees",
       "!**/node_modules",
       "!**/dist",
       "!**/coverage"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typecheck": "tsgo --noEmit",
     "lint": "biome check --error-on-warnings .",
     "format": "biome check --write .",
-    "test": "vitest --run",
+    "test": "vitest --run --dir tests",
     "supply-chain:guard": "tsx scripts/supply-chain-guard.ts",
     "check": "npm run lint && npm run typecheck && npm test",
     "prepublishOnly": "npm run check && npm run clean && npm run build && npm run supply-chain:guard"

--- a/src/index.ts
+++ b/src/index.ts
@@ -472,7 +472,50 @@ function getProviderDefinitions(settings: Record<string, unknown> | undefined): 
   return definitions;
 }
 
-async function loginApiKey(interaction: AuthInteraction, allowInsecureHttp = false): Promise<ApiKeyCredential> {
+const DIFFERENT_BASE_URL = "enter-a-different-url";
+
+/**
+ * The proxy URL is the one thing a user has to retype on every re-login, and an expired SSO token is
+ * the common reason to re-login. Offer whatever we already know: settings, env, or the credential the
+ * dead session was issued against.
+ */
+function knownBaseUrl(definition: ProviderDefinition): { url: string; source: string } | undefined {
+  const stored = readStoredCredential(definition.name, join(getAgentDir(), "auth.json"));
+  const candidates: [string | undefined, string][] = [
+    [cleanConfig(definition.baseUrl), "configured"],
+    [definition.useDefaultEnv ? cleanConfig(process.env[ENV_BASE_URL]) : undefined, `$${ENV_BASE_URL}`],
+    [
+      stored?.type === "oauth"
+        ? cleanConfig(typeof stored.baseUrl === "string" ? stored.baseUrl : undefined)
+        : cleanConfig(stored?.env?.[ENV_BASE_URL]),
+      "previous login",
+    ],
+  ];
+  for (const [candidate, source] of candidates) {
+    if (!candidate) continue;
+    try {
+      return { url: normalizeBaseUrl(candidate, definition.allowInsecureHttp), source };
+    } catch {
+      // A URL we could not use anyway is not worth offering; try the next candidate.
+    }
+  }
+  return undefined;
+}
+
+async function promptBaseUrl(interaction: AuthInteraction, definition: ProviderDefinition): Promise<string> {
+  const known = knownBaseUrl(definition);
+  if (known) {
+    const choice = await interaction.prompt({
+      type: "select",
+      message: "LiteLLM proxy URL:",
+      // Pi's login selector renders labels only, so the source has to ride along in the label.
+      options: [
+        { id: known.url, label: `${known.url} (${known.source})` },
+        { id: DIFFERENT_BASE_URL, label: "Enter a different URL…" },
+      ],
+    });
+    if (choice === known.url) return known.url;
+  }
   const rawBaseUrl = (
     await interaction.prompt({
       type: "text",
@@ -481,9 +524,14 @@ async function loginApiKey(interaction: AuthInteraction, allowInsecureHttp = fal
     })
   ).trim();
   if (!rawBaseUrl) throw new Error("Base URL is required");
+  return normalizeBaseUrl(rawBaseUrl, definition.allowInsecureHttp);
+}
+
+async function loginApiKey(interaction: AuthInteraction, definition: ProviderDefinition): Promise<ApiKeyCredential> {
+  const baseUrl = await promptBaseUrl(interaction, definition);
   const key = (await interaction.prompt({ type: "secret", message: "Enter API key:" })).trim();
   if (!key) throw new Error("Both base URL and API key are required");
-  return { type: "api_key", key, env: { [ENV_BASE_URL]: normalizeBaseUrl(rawBaseUrl, allowInsecureHttp) } };
+  return { type: "api_key", key, env: { [ENV_BASE_URL]: baseUrl } };
 }
 
 type CliSsoStart = { loginId: string; pollSecret: string; userCode: string; expiresInSeconds: number };
@@ -636,20 +684,9 @@ async function loginWithPastedToken(
   return { type: "oauth", access, refresh: "", expires, baseUrl };
 }
 
-async function loginOAuth(
-  interaction: AuthInteraction,
-  headers?: Record<string, string>,
-  allowInsecureHttp = false,
-): Promise<OAuthCredential> {
-  const rawBaseUrl = (
-    await interaction.prompt({
-      type: "text",
-      message: "Enter LiteLLM proxy URL (no trailing /v1):",
-      placeholder: "https://litellm.example.com",
-    })
-  ).trim();
-  if (!rawBaseUrl) throw new Error("Base URL is required");
-  const baseUrl = normalizeBaseUrl(rawBaseUrl, allowInsecureHttp);
+async function loginOAuth(interaction: AuthInteraction, definition: ProviderDefinition): Promise<OAuthCredential> {
+  const headers = resolveHeaders(definition);
+  const baseUrl = await promptBaseUrl(interaction, definition);
   const cliSso = await startCliSso(baseUrl, interaction.signal, headers);
   if (!cliSso) return loginWithPastedToken(interaction, baseUrl, headers);
   interaction.notify({
@@ -753,10 +790,7 @@ function createProviderAuth(definition: ProviderDefinition): ProviderAuth {
   return {
     apiKey: {
       name: `${definition.displayName} API key`,
-      login:
-        definition.name === PROVIDER_NAME
-          ? (interaction) => loginApiKey(interaction, definition.allowInsecureHttp)
-          : undefined,
+      login: definition.name === PROVIDER_NAME ? (interaction) => loginApiKey(interaction, definition) : undefined,
       check: async ({ ctx, credential }) => {
         const baseUrl =
           credential?.env?.[ENV_BASE_URL] ??
@@ -794,7 +828,7 @@ function createProviderAuth(definition: ProviderDefinition): ProviderAuth {
       ? {
           name: "LiteLLM SSO",
           loginLabel: "Sign in with LiteLLM SSO",
-          login: (interaction) => loginOAuth(interaction, resolveHeaders(definition), definition.allowInsecureHttp),
+          login: (interaction) => loginOAuth(interaction, definition),
           refresh: async (credential, signal) => ({
             ...(await refreshLiteLLM(credential, signal)),
             type: "oauth" as const,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1366,6 +1366,147 @@ describe("extension startup", () => {
   });
 });
 
+describe("login base URL reuse", () => {
+  const STORED_URL = "https://stored.example.com";
+
+  async function agentDirWithStoredOAuth(): Promise<string> {
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({
+        litellm: { type: "oauth", access: "expired-token", refresh: "", expires: 0, baseUrl: STORED_URL },
+      }),
+      "utf8",
+    );
+    return agentDir;
+  }
+
+  it("offers the stored credential's base URL instead of asking for it again", async () => {
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    delete process.env.LITELLM_BASE_URL;
+    const extension = await loadExtension(await agentDirWithStoredOAuth());
+    const pi = createPi();
+    await extension(pi);
+
+    const messages: string[] = [];
+    const credential = await loginOAuth(pi.providers[0]!, {
+      onPrompt: async (options) => {
+        messages.push(options.message);
+        if (options.options) return options.options.find((option) => option.id === STORED_URL)!.id;
+        return options.type === "secret" ? "sk-sso-token" : "n";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(credential?.baseUrl).toBe(STORED_URL);
+    expect(messages.some((message) => message.includes("Enter LiteLLM proxy URL"))).toBe(false);
+  });
+
+  it("names where the offered base URL came from", async () => {
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    delete process.env.LITELLM_BASE_URL;
+    const extension = await loadExtension(await agentDirWithStoredOAuth());
+    const pi = createPi();
+    await extension(pi);
+
+    let offered: readonly { id: string; label: string; description?: string }[] | undefined;
+    await loginOAuth(pi.providers[0]!, {
+      onPrompt: async (options) => {
+        if (options.options) {
+          offered = options.options;
+          return options.options.find((option) => option.id === STORED_URL)!.id;
+        }
+        return options.type === "secret" ? "sk-sso-token" : "n";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(offered?.map((option) => option.label)).toEqual([
+      `${STORED_URL} (previous login)`,
+      "Enter a different URL…",
+    ]);
+    expect(offered?.[0]?.id).toBe(STORED_URL);
+  });
+
+  it("still asks for a URL when the offered one is declined", async () => {
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    delete process.env.LITELLM_BASE_URL;
+    const extension = await loadExtension(await agentDirWithStoredOAuth());
+    const pi = createPi();
+    await extension(pi);
+
+    const types: string[] = [];
+    const credential = await loginOAuth(pi.providers[0]!, {
+      onPrompt: async (options) => {
+        types.push(options.type);
+        if (options.options) return options.options.find((option) => option.id !== STORED_URL)!.id;
+        if (options.placeholder) return "https://other.example.com";
+        return options.type === "secret" ? "sk-sso-token" : "n";
+      },
+      signal: new AbortController().signal,
+    });
+
+    expect(types.slice(0, 2)).toEqual(["select", "text"]);
+    expect(credential?.baseUrl).toBe("https://other.example.com");
+  });
+
+  it("offers LITELLM_BASE_URL to the API-key login", async () => {
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    process.env.LITELLM_BASE_URL = "https://env.example.com";
+    const extension = await loadExtension(await makeAgentDir());
+    const pi = createPi();
+    await extension(pi);
+
+    const prompt = vi.fn(async (options: Parameters<AuthInteraction["prompt"]>[0]) =>
+      "options" in options ? options.options.find((option) => option.id === "https://env.example.com")!.id : "sk-typed",
+    );
+    const credential = await pi.providers[0]?.auth.apiKey?.login?.(interaction(prompt));
+
+    expect(credential?.env?.LITELLM_BASE_URL).toBe("https://env.example.com");
+    expect(prompt.mock.calls.map(([options]) => options.type)).toEqual(["select", "secret"]);
+  });
+
+  it("ignores a stored base URL that is no longer usable", async () => {
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    delete process.env.LITELLM_BASE_URL;
+    const agentDir = await makeAgentDir();
+    await writeFile(
+      join(agentDir, "auth.json"),
+      JSON.stringify({
+        litellm: { type: "api_key", key: "sk-old", env: { LITELLM_BASE_URL: "http://insecure.example.com" } },
+      }),
+      "utf8",
+    );
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const prompt = vi.fn(async (options: Parameters<AuthInteraction["prompt"]>[0]) =>
+      "placeholder" in options && options.placeholder ? "https://typed.example.com" : "sk-typed",
+    );
+    const credential = await pi.providers[0]?.auth.apiKey?.login?.(interaction(prompt));
+
+    expect(prompt.mock.calls.map(([options]) => options.type)).toEqual(["text", "secret"]);
+    expect(credential?.env?.LITELLM_BASE_URL).toBe("https://typed.example.com");
+  });
+
+  it("asks for the proxy URL when nothing is configured yet", async () => {
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    delete process.env.LITELLM_BASE_URL;
+    const extension = await loadExtension(await makeAgentDir());
+    const pi = createPi();
+    await extension(pi);
+
+    const prompt = vi.fn(async (options: Parameters<AuthInteraction["prompt"]>[0]) =>
+      "placeholder" in options && options.placeholder ? "https://typed.example.com" : "sk-typed",
+    );
+    const credential = await pi.providers[0]?.auth.apiKey?.login?.(interaction(prompt));
+
+    expect(prompt.mock.calls.map(([options]) => options.type)).toEqual(["text", "secret"]);
+    expect(credential?.env?.LITELLM_BASE_URL).toBe("https://typed.example.com");
+  });
+});
+
 describe("multi-provider hardening", () => {
   it("does not register the default env key for an alias missing its apiKey", async () => {
     const agentDir = await makeAgentDir();

--- a/tests/terminal-smoke.test.ts
+++ b/tests/terminal-smoke.test.ts
@@ -9,6 +9,7 @@ const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const piPath = resolve(repoRoot, "node_modules/.bin/pi");
 const extensionPath = resolve(repoRoot, "dist/index.js");
 const enabled = process.env.LITELLM_TERMINAL_SMOKE === "1";
+const smokeBaseUrl = process.env.LITELLM_BASE_URL ?? "http://127.0.0.1:4000";
 const waitTimeoutMs = 90_000;
 const testTimeoutMs = 6 * waitTimeoutMs;
 let terminal: TerminalControl | undefined;
@@ -17,7 +18,8 @@ async function withPi(run: (session: Session) => Promise<void>): Promise<void> {
   const configuredAgentDir = process.env.PI_CODING_AGENT_DIR?.trim();
   const agentDir = configuredAgentDir || (await mkdtemp(join(tmpdir(), "pi-litellm-terminal-")));
   try {
-    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir };
+    // Pinned so login always reaches the "reuse the known URL" branch, whatever the shell exports.
+    const env = { ...process.env, PI_CODING_AGENT_DIR: agentDir, LITELLM_BASE_URL: smokeBaseUrl };
     await using session = await terminal?.launch({
       command: [piPath, "-e", extensionPath, "--no-tools", "--no-session"],
       cwd: repoRoot,
@@ -122,8 +124,10 @@ describe.skipIf(!enabled)("interactive Pi terminal smoke", () => {
         await session.screen.waitForIdle({ timeoutMs: waitTimeoutMs });
         await submit(session, "/login litellm", "LiteLLM · subscription/API key");
         await selectApiKeyAuthMethod(session);
-        await session.screen.waitForText("Enter LiteLLM proxy URL", { timeoutMs: waitTimeoutMs });
-        await submit(session, process.env.LITELLM_BASE_URL ?? "http://127.0.0.1:4000");
+        // The proxy URL is offered from LITELLM_BASE_URL, so signing in costs one keypress (#147).
+        await session.screen.waitForText("LiteLLM proxy URL", { timeoutMs: waitTimeoutMs });
+        await session.screen.waitForText(`${smokeBaseUrl} ($LITELLM_BASE_URL)`, { timeoutMs: waitTimeoutMs });
+        await session.keyboard.press("Enter");
         await session.screen.waitForText("Enter API key", { timeoutMs: waitTimeoutMs });
         await submit(session, process.env.LITELLM_API_KEY ?? "sk-ci-litellm-smoke");
 


### PR DESCRIPTION
## Problem

When an SSO token expires, `/login litellm` asks for the proxy URL again — a full URL to retype every time, even with a single LiteLLM provider configured:

```
✗ OAuth refresh failed for litellm: LiteLLM credential cannot be refreshed; run /login litellm again
```

The URL was already knowable at that point; nothing looked for it.

## Change

`knownBaseUrl(definition)` resolves the proxy URL from, in order:

1. `providers.<name>.baseUrl` in settings → `(configured)`
2. `LITELLM_BASE_URL` → `($LITELLM_BASE_URL)`
3. the stored credential's own base URL → `(previous login)`

Candidates that `normalizeBaseUrl` rejects are skipped rather than offered, so an unusable stored URL falls through to typing one instead of failing the login.

`promptBaseUrl()` then offers it as a select:

```
LiteLLM proxy URL:
> https://litellm.example.com (previous login)
  Enter a different URL…
```

Picking the first option is one keypress; `Enter a different URL…` falls through to the existing text prompt unchanged, as does the case where no URL is known. Both `loginApiKey` and `loginOAuth` route through the shared helper and now take `definition` instead of loose `allowInsecureHttp`/`headers` arguments.

Source 3 is what fixes the reported case: an SSO login typed by hand, with no settings entry and no env var, still has its URL in `auth.json` after the token dies.

Note that Pi's login selector renders option **labels only** and drops `description` (`interactive-mode.js`), so the source tag has to ride along inside the label.

## Tooling fixes

Two separate commits, unrelated to the feature but blocking `npm run check` in any clone with nested worktrees:

- `biome.json` used `**/src/**/*.ts`; the leading `**/` reached into `.worktrees/*/src/`. Dropped it to match `tsconfig.json`. Biome also discovers nested `biome.json` files by walking the tree regardless of `files.includes`, which produced `Found a nested root configuration` — `!**/.worktrees` stops the walk. Coverage is unchanged at 44 files.
- `npm test` was bare `vitest --run` and collected `.worktrees/*/tests/`. Now `--dir tests`. Every test lives under `tests/`, and the focused form in AGENTS.md (`npm test -- tests/<file>.test.ts`) still works.

## Testing

Six new specs in `tests/index.test.ts` cover the offered URL, its source label, declining it, the env-var source, an unusable stored URL, and the nothing-configured path. `npm run check` passes: lint, typecheck, 255 tests.

Verified by hand in a real Pi session (`pi -ne -e ./dist/index.js`) — the URL is offered and SSO re-auth completes.

`tests/terminal-smoke.test.ts` is updated to pin `LITELLM_BASE_URL` and press Enter rather than type the URL, but it only runs with `LITELLM_TERMINAL_SMOKE=1` against a live proxy, so that edit is unexercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)