### PR TITLE
fix: gate Moonshot reasoning suppression on the LiteLLM route

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -83,23 +83,16 @@ export function getRouteDialect(modelId: string): RouteDialect | undefined {
   return routeDialects.get(modelId);
 }
 
-export function isMoonshotRoute(modelId: string): boolean {
-  const dialect = getRouteDialect(modelId);
-  if (dialect) return dialect === "moonshot";
-  return isMoonshotModel(modelId);
-}
-
 export function shouldSuppressReasoningContent(modelId: string): boolean {
   return getRouteDialect(modelId) === "moonshot" && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
 }
 
 export function emitsThinkTags(modelId: string): boolean {
-  return isMoonshotRoute(modelId) && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+  return isMoonshotModel(modelId) && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
 }
 
-export function buildCompat(modelId: string, dialect?: RouteDialect): DiscoveredModel["compat"] {
-  const moonshotRoute = dialect ? dialect === "moonshot" : isMoonshotModel(modelId);
-  if (moonshotRoute) {
+export function buildCompat(modelId: string): DiscoveredModel["compat"] {
+  if (isMoonshotModel(modelId)) {
     return {
       supportsStore: false,
       supportsDeveloperRole: false,
@@ -274,7 +267,7 @@ function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
     cost: mapModelInfoCost(info, catalogModel?.cost),
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
-    compat: buildCompat(id, dialect),
+    compat: buildCompat(id),
     ...(responsesMode ? { api: "openai-responses" as const } : {}),
   };
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -60,12 +60,46 @@ export function isGpt55Model(modelId: string): boolean {
   return GPT55_MODEL_PATTERN.test(modelId);
 }
 
-export function shouldSuppressReasoningContent(modelId: string): boolean {
-  return isMoonshotModel(modelId) && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+export type RouteDialect = "moonshot" | "other";
+
+const MOONSHOT_ROUTE_PROVIDERS = new Set(["moonshot", "moonshotai"]);
+
+export function routeDialectFromEntry(entry: ModelInfoEntry): RouteDialect | undefined {
+  const params = entry.litellm_params;
+  if (!params) return undefined;
+  const provider = params.custom_llm_provider ?? params.model?.split("/")[0];
+  if (!provider) return undefined;
+  return MOONSHOT_ROUTE_PROVIDERS.has(provider.toLowerCase()) ? "moonshot" : "other";
 }
 
-export function buildCompat(modelId: string): DiscoveredModel["compat"] {
-  if (isMoonshotModel(modelId)) {
+const routeDialects = new Map<string, RouteDialect>();
+
+export function recordRouteDialect(modelId: string, dialect: RouteDialect | undefined): void {
+  if (dialect) routeDialects.set(modelId, dialect);
+  else routeDialects.delete(modelId);
+}
+
+export function getRouteDialect(modelId: string): RouteDialect | undefined {
+  return routeDialects.get(modelId);
+}
+
+export function isMoonshotRoute(modelId: string): boolean {
+  const dialect = getRouteDialect(modelId);
+  if (dialect) return dialect === "moonshot";
+  return isMoonshotModel(modelId);
+}
+
+export function shouldSuppressReasoningContent(modelId: string): boolean {
+  return getRouteDialect(modelId) === "moonshot" && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+}
+
+export function emitsThinkTags(modelId: string): boolean {
+  return isMoonshotRoute(modelId) && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+}
+
+export function buildCompat(modelId: string, dialect?: RouteDialect): DiscoveredModel["compat"] {
+  const moonshotRoute = dialect ? dialect === "moonshot" : isMoonshotModel(modelId);
+  if (moonshotRoute) {
     return {
       supportsStore: false,
       supportsDeveloperRole: false,
@@ -223,6 +257,8 @@ function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
   const info = entry.model_info ?? {};
   if (!isChatStyleMode(info.mode)) return undefined;
   const responsesMode = isResponsesMode(info.mode);
+  const dialect = routeDialectFromEntry(entry);
+  recordRouteDialect(id, dialect);
   const catalogModel = findCatalogModel(id);
   const reasoningEffortMap = mapReasoningEfforts(info);
   const thinkingLevelMap =
@@ -238,7 +274,7 @@ function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
     cost: mapModelInfoCost(info, catalogModel?.cost),
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
-    compat: buildCompat(id),
+    compat: buildCompat(id, dialect),
     ...(responsesMode ? { api: "openai-responses" as const } : {}),
   };
 }

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -11,7 +11,6 @@ import type {
   ModelInfoResponse,
   ModelsListEntry,
   ModelsListResponse,
-  RouteDialect,
 } from "./types.js";
 
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -63,21 +62,29 @@ export function isGpt55Model(modelId: string): boolean {
 
 const MOONSHOT_ROUTE_PROVIDERS = new Set(["moonshot", "moonshotai"]);
 
-export function routeDialectFromEntry(entry: ModelInfoEntry): RouteDialect | undefined {
+function isMoonshotRoute(entry: ModelInfoEntry): boolean {
   const params = entry.litellm_params;
-  if (!params) return undefined;
+  if (!params) return false;
   const provider = params.custom_llm_provider ?? params.model?.split("/")[0];
-  if (!provider) return undefined;
-  return MOONSHOT_ROUTE_PROVIDERS.has(provider.toLowerCase()) ? "moonshot" : "other";
+  return provider !== undefined && MOONSHOT_ROUTE_PROVIDERS.has(provider.toLowerCase());
 }
 
-function aggregateRouteDialects(dialects: ReadonlySet<RouteDialect | undefined>): RouteDialect | undefined {
-  const [dialect] = dialects;
-  return dialects.size === 1 ? dialect : "other";
+function shouldSuppressReasoningContent(modelId: string, entry: ModelInfoEntry): boolean {
+  const routeModelId = entry.litellm_params?.model;
+  return (
+    isMoonshotRoute(entry) &&
+    !FORCED_THINKING_MODEL_PATTERN.test(modelId) &&
+    !(routeModelId && FORCED_THINKING_MODEL_PATTERN.test(routeModelId))
+  );
 }
 
-export function shouldSuppressReasoningContent(modelId: string, dialect: RouteDialect | undefined): boolean {
-  return dialect === "moonshot" && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+function aggregateSuppressionEvidence(evidence: Iterable<boolean>): boolean {
+  let hasEvidence = false;
+  for (const suppress of evidence) {
+    hasEvidence = true;
+    if (!suppress) return false;
+  }
+  return hasEvidence;
 }
 
 export function emitsThinkTags(modelId: string): boolean {
@@ -237,7 +244,10 @@ function mapReasoningEfforts(
   return Object.keys(map).length > 0 ? map : undefined;
 }
 
-function mapFromModelInfo(entry: ModelInfoEntry, dialect = routeDialectFromEntry(entry)): DiscoveredModel | undefined {
+function mapFromModelInfo(
+  entry: ModelInfoEntry,
+  suppressReasoningContent = shouldSuppressReasoningContent(entry.model_name ?? "", entry),
+): DiscoveredModel | undefined {
   const id = entry.model_name;
   if (!id) return undefined;
   const info = entry.model_info ?? {};
@@ -259,7 +269,7 @@ function mapFromModelInfo(entry: ModelInfoEntry, dialect = routeDialectFromEntry
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
-    ...(dialect ? { routeDialect: dialect } : {}),
+    ...(suppressReasoningContent ? { suppressReasoningContent: true } : {}),
     ...(responsesMode ? { api: "openai-responses" as const } : {}),
   };
 }
@@ -340,11 +350,20 @@ async function discoverFromHealth(
 }
 
 function deduplicateModels(models: DiscoveredModel[]): DiscoveredModel[] {
-  const seen = new Set<string>();
-  return models.filter((m) => {
-    if (seen.has(m.id)) return false;
-    seen.add(m.id);
-    return true;
+  const entries = new Map<string, { model: DiscoveredModel; suppressions: boolean[] }>();
+  for (const model of models) {
+    const existing = entries.get(model.id);
+    if (existing) {
+      existing.suppressions.push(model.suppressReasoningContent === true);
+    } else {
+      entries.set(model.id, { model, suppressions: [model.suppressReasoningContent === true] });
+    }
+  }
+  return [...entries.values()].map(({ model, suppressions }) => {
+    const deduplicated = { ...model };
+    if (aggregateSuppressionEvidence(suppressions)) deduplicated.suppressReasoningContent = true;
+    else delete deduplicated.suppressReasoningContent;
+    return deduplicated;
   });
 }
 
@@ -359,13 +378,13 @@ export async function discoverModels(
   const infoResult = await fetchJson<ModelInfoResponse>(`${base}/model/info`, apiKey, options);
   if (infoResult.ok) {
     const entries = new Map<string, ModelInfoEntry>();
-    const routeEvidence = new Map<string, Set<RouteDialect | undefined>>();
+    const suppressionEvidence = new Map<string, Set<boolean>>();
     for (const entry of infoResult.data.data ?? []) {
       if (!entry.model_name) continue;
       const previous = entries.get(entry.model_name);
-      const dialects = routeEvidence.get(entry.model_name) ?? new Set<RouteDialect | undefined>();
-      dialects.add(routeDialectFromEntry(entry));
-      routeEvidence.set(entry.model_name, dialects);
+      const suppressions = suppressionEvidence.get(entry.model_name) ?? new Set<boolean>();
+      suppressions.add(shouldSuppressReasoningContent(entry.model_name, entry));
+      suppressionEvidence.set(entry.model_name, suppressions);
       entries.set(entry.model_name, {
         ...previous,
         ...entry,
@@ -373,7 +392,7 @@ export async function discoverModels(
       });
     }
     let models = [...entries.entries()]
-      .map(([id, entry]) => mapFromModelInfo(entry, aggregateRouteDialects(routeEvidence.get(id)!)))
+      .map(([id, entry]) => mapFromModelInfo(entry, aggregateSuppressionEvidence(suppressionEvidence.get(id)!)))
       .filter((m): m is DiscoveredModel => m !== undefined);
     // LiteLLM's /model/info does NOT expand wildcard model_name entries (e.g.
     // "lemonade/*" backed by model: openai/* + check_provider_endpoint: true)

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -76,19 +76,8 @@ function aggregateRouteDialects(dialects: ReadonlySet<RouteDialect | undefined>)
   return dialects.size === 1 ? dialect : "other";
 }
 
-const routeDialects = new Map<string, RouteDialect>();
-
-export function recordRouteDialect(modelId: string, dialect: RouteDialect | undefined): void {
-  if (dialect) routeDialects.set(modelId, dialect);
-  else routeDialects.delete(modelId);
-}
-
-export function getRouteDialect(modelId: string): RouteDialect | undefined {
-  return routeDialects.get(modelId);
-}
-
-export function shouldSuppressReasoningContent(modelId: string): boolean {
-  return getRouteDialect(modelId) === "moonshot" && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
+export function shouldSuppressReasoningContent(modelId: string, dialect: RouteDialect | undefined): boolean {
+  return dialect === "moonshot" && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
 }
 
 export function emitsThinkTags(modelId: string): boolean {
@@ -248,16 +237,12 @@ function mapReasoningEfforts(
   return Object.keys(map).length > 0 ? map : undefined;
 }
 
-function mapFromModelInfo(
-  entry: ModelInfoEntry,
-  dialect = routeDialectFromEntry(entry),
-): DiscoveredModel | undefined {
+function mapFromModelInfo(entry: ModelInfoEntry, dialect = routeDialectFromEntry(entry)): DiscoveredModel | undefined {
   const id = entry.model_name;
   if (!id) return undefined;
   const info = entry.model_info ?? {};
   if (!isChatStyleMode(info.mode)) return undefined;
   const responsesMode = isResponsesMode(info.mode);
-  recordRouteDialect(id, dialect);
   const catalogModel = findCatalogModel(id);
   const reasoningEffortMap = mapReasoningEfforts(info);
   const thinkingLevelMap =

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -65,8 +65,13 @@ const MOONSHOT_ROUTE_PROVIDERS = new Set(["moonshot", "moonshotai"]);
 function isMoonshotRoute(entry: ModelInfoEntry): boolean {
   const params = entry.litellm_params;
   if (!params) return false;
-  const provider = params.custom_llm_provider ?? params.model?.split("/")[0];
-  return provider !== undefined && MOONSHOT_ROUTE_PROVIDERS.has(provider.toLowerCase());
+  const model = params.model?.trim();
+  if (!model) return false;
+  const providers = [
+    params.custom_llm_provider?.trim(),
+    model.includes("/") ? model.split("/", 1)[0] : undefined,
+  ].filter((provider): provider is string => Boolean(provider));
+  return providers.length > 0 && providers.every((provider) => MOONSHOT_ROUTE_PROVIDERS.has(provider.toLowerCase()));
 }
 
 function shouldSuppressReasoningContent(modelId: string, entry: ModelInfoEntry): boolean {

--- a/src/discover.ts
+++ b/src/discover.ts
@@ -11,6 +11,7 @@ import type {
   ModelInfoResponse,
   ModelsListEntry,
   ModelsListResponse,
+  RouteDialect,
 } from "./types.js";
 
 const DEFAULT_TIMEOUT_MS = 5000;
@@ -60,8 +61,6 @@ export function isGpt55Model(modelId: string): boolean {
   return GPT55_MODEL_PATTERN.test(modelId);
 }
 
-export type RouteDialect = "moonshot" | "other";
-
 const MOONSHOT_ROUTE_PROVIDERS = new Set(["moonshot", "moonshotai"]);
 
 export function routeDialectFromEntry(entry: ModelInfoEntry): RouteDialect | undefined {
@@ -70,6 +69,11 @@ export function routeDialectFromEntry(entry: ModelInfoEntry): RouteDialect | und
   const provider = params.custom_llm_provider ?? params.model?.split("/")[0];
   if (!provider) return undefined;
   return MOONSHOT_ROUTE_PROVIDERS.has(provider.toLowerCase()) ? "moonshot" : "other";
+}
+
+function aggregateRouteDialects(dialects: ReadonlySet<RouteDialect | undefined>): RouteDialect | undefined {
+  const [dialect] = dialects;
+  return dialects.size === 1 ? dialect : "other";
 }
 
 const routeDialects = new Map<string, RouteDialect>();
@@ -244,13 +248,15 @@ function mapReasoningEfforts(
   return Object.keys(map).length > 0 ? map : undefined;
 }
 
-function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
+function mapFromModelInfo(
+  entry: ModelInfoEntry,
+  dialect = routeDialectFromEntry(entry),
+): DiscoveredModel | undefined {
   const id = entry.model_name;
   if (!id) return undefined;
   const info = entry.model_info ?? {};
   if (!isChatStyleMode(info.mode)) return undefined;
   const responsesMode = isResponsesMode(info.mode);
-  const dialect = routeDialectFromEntry(entry);
   recordRouteDialect(id, dialect);
   const catalogModel = findCatalogModel(id);
   const reasoningEffortMap = mapReasoningEfforts(info);
@@ -268,6 +274,7 @@ function mapFromModelInfo(entry: ModelInfoEntry): DiscoveredModel | undefined {
     contextWindow: info.max_input_tokens ?? DEFAULT_CONTEXT_WINDOW,
     maxTokens: info.max_output_tokens ?? DEFAULT_MAX_TOKENS,
     compat: buildCompat(id),
+    ...(dialect ? { routeDialect: dialect } : {}),
     ...(responsesMode ? { api: "openai-responses" as const } : {}),
   };
 }
@@ -367,16 +374,22 @@ export async function discoverModels(
   const infoResult = await fetchJson<ModelInfoResponse>(`${base}/model/info`, apiKey, options);
   if (infoResult.ok) {
     const entries = new Map<string, ModelInfoEntry>();
+    const routeEvidence = new Map<string, Set<RouteDialect | undefined>>();
     for (const entry of infoResult.data.data ?? []) {
       if (!entry.model_name) continue;
       const previous = entries.get(entry.model_name);
+      const dialects = routeEvidence.get(entry.model_name) ?? new Set<RouteDialect | undefined>();
+      dialects.add(routeDialectFromEntry(entry));
+      routeEvidence.set(entry.model_name, dialects);
       entries.set(entry.model_name, {
         ...previous,
         ...entry,
         model_info: { ...previous?.model_info, ...entry.model_info },
       });
     }
-    let models = [...entries.values()].map(mapFromModelInfo).filter((m): m is DiscoveredModel => m !== undefined);
+    let models = [...entries.entries()]
+      .map(([id, entry]) => mapFromModelInfo(entry, aggregateRouteDialects(routeEvidence.get(id)!)))
+      .filter((m): m is DiscoveredModel => m !== undefined);
     // LiteLLM's /model/info does NOT expand wildcard model_name entries (e.g.
     // "lemonade/*" backed by model: openai/* + check_provider_endpoint: true)
     // — it returns the literal wildcard only. The discovered ids live in

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,9 @@ import { getAgentDir, readStoredCredential } from "@earendil-works/pi-coding-age
 import { setupLiteLLMCostTracking } from "./cost.js";
 import {
   discoverModels,
+  emitsThinkTags,
   isGpt55Model,
-  isMoonshotModel,
+  isMoonshotRoute,
   normalizeBaseUrl,
   shouldSuppressReasoningContent,
 } from "./discover.js";
@@ -958,7 +959,7 @@ function prepareLiteLLMRequestPayload(
 
   // Moonshot/Kimi applies strict OpenAI schema validation: assistant tool calls
   // must carry string content, and tool results must be plain text.
-  if (modelId && isMoonshotModel(modelId)) {
+  if (modelId && isMoonshotRoute(modelId)) {
     const messages = (next ?? payload).messages;
     if (Array.isArray(messages)) {
       const normalized = normalizeStrictToolMessages(messages);
@@ -1004,7 +1005,7 @@ function normalizeThinkTags(
   message: AssistantMessage,
   litellmProviderNames: Set<string>,
 ): AssistantMessage | undefined {
-  if (!litellmProviderNames.has(message.provider) || !shouldSuppressReasoningContent(message.model)) return;
+  if (!litellmProviderNames.has(message.provider) || !emitsThinkTags(message.model)) return;
 
   let changed = false;
   const content: AssistantMessage["content"] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ import {
   isGpt55Model,
   isMoonshotModel,
   normalizeBaseUrl,
-  shouldSuppressReasoningContent,
 } from "./discover.js";
 import {
   getGcloudToken,
@@ -920,7 +919,7 @@ function prepareLiteLLMRequestPayload(
     next[key] = value;
   };
 
-  if (api !== "openai-responses" && modelId && shouldSuppressReasoningContent(modelId, model.routeDialect)) {
+  if (api !== "openai-responses" && model?.suppressReasoningContent === true) {
     for (const [key, value] of Object.entries(REASONING_SUPPRESSION_DEFAULTS)) {
       if (key !== "thinking") update(key, value);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import type {
-  Api,
   ApiKeyCredential,
   AssistantMessage,
   AuthInteraction,
@@ -34,7 +33,7 @@ import { getSessionIdFromFile } from "./litellm.js";
 import { createMcpToolDefinitions } from "./mcp-tools.js";
 import { createLiteLLMProvider, toNativeModels } from "./provider.js";
 import { createSkillsPromptSection, createSkillToolDefinitions, listSkills } from "./skills.js";
-import type { LiteLLMApi, LiteLLMRuntimeAuth, ResolvedCredentials } from "./types.js";
+import type { LiteLLMApi, LiteLLMModel, LiteLLMRuntimeAuth, ResolvedCredentials } from "./types.js";
 
 const PROVIDER_NAME = "litellm";
 const SETTINGS_KEY = "litellm";
@@ -909,10 +908,11 @@ const GEMINI_MODEL_PATTERN = /(?:^|[-_/.:])gemini(?=$|[-_/.:])/i;
 
 function prepareLiteLLMRequestPayload(
   payload: Record<string, unknown>,
-  modelId: string | undefined,
-  api: Api | undefined,
+  model: LiteLLMModel | undefined,
   sessionId: string | undefined,
 ): Record<string, unknown> | undefined {
+  const modelId = model?.id;
+  const api = model?.api;
   let next: Record<string, unknown> | undefined;
   const update = (key: string, value: unknown): void => {
     if (payload[key] !== undefined) return;
@@ -920,7 +920,7 @@ function prepareLiteLLMRequestPayload(
     next[key] = value;
   };
 
-  if (api !== "openai-responses" && modelId && shouldSuppressReasoningContent(modelId)) {
+  if (api !== "openai-responses" && modelId && shouldSuppressReasoningContent(modelId, model.routeDialect)) {
     for (const [key, value] of Object.entries(REASONING_SUPPRESSION_DEFAULTS)) {
       if (key !== "thinking") update(key, value);
     }
@@ -1301,12 +1301,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
   pi.on("before_provider_request", (event, ctx) => {
     if (!ctx.model?.provider || !providerNames.has(ctx.model.provider)) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
-    return prepareLiteLLMRequestPayload(
-      event.payload as Record<string, unknown>,
-      ctx.model?.id,
-      ctx.model?.api,
-      sessionId,
-    );
+    return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model as LiteLLMModel, sessionId);
   });
 
   // Skills enrichment is best-effort: an expired credential or an unreachable proxy must not

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   discoverModels,
   emitsThinkTags,
   isGpt55Model,
-  isMoonshotRoute,
+  isMoonshotModel,
   normalizeBaseUrl,
   shouldSuppressReasoningContent,
 } from "./discover.js";
@@ -959,7 +959,7 @@ function prepareLiteLLMRequestPayload(
 
   // Moonshot/Kimi applies strict OpenAI schema validation: assistant tool calls
   // must carry string content, and tool results must be plain text.
-  if (modelId && isMoonshotRoute(modelId)) {
+  if (modelId && isMoonshotModel(modelId)) {
     const messages = (next ?? payload).messages;
     if (Array.isArray(messages)) {
       const normalized = normalizeStrictToolMessages(messages);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,7 @@ import type {
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { getAgentDir, readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { setupLiteLLMCostTracking } from "./cost.js";
-import {
-  discoverModels,
-  emitsThinkTags,
-  isGpt55Model,
-  isMoonshotModel,
-  normalizeBaseUrl,
-} from "./discover.js";
+import { discoverModels, emitsThinkTags, isGpt55Model, isMoonshotModel, normalizeBaseUrl } from "./discover.js";
 import {
   getGcloudToken,
   getGcloudTokenCacheKey,

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,7 @@
-import { type Credential, createProvider, type Model, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
+import { type Credential, createProvider, type Provider, type ProviderAuth } from "@earendil-works/pi-ai";
 import { openAICompletionsApi, openAIResponsesApi } from "@earendil-works/pi-ai/compat";
 import { enrichCachedModel } from "./discover.js";
-import type { DiscoveredModel, DiscoveryResult, LiteLLMApi } from "./types.js";
+import type { DiscoveredModel, DiscoveryResult, LiteLLMApi, LiteLLMModel } from "./types.js";
 
 export type LiteLLMProviderOptions = {
   id: string;
@@ -10,21 +10,17 @@ export type LiteLLMProviderOptions = {
   auth: ProviderAuth;
   /** Catalog discovered during activation. Pi's startup refresh never allows network access, so
    * without a seed the provider stays empty until the user opens /model. */
-  models?: readonly Model<LiteLLMApi>[];
+  models?: readonly LiteLLMModel[];
   discover(credential: Credential, signal?: AbortSignal): Promise<DiscoveryResult & { baseUrl?: string }>;
 };
 
-export function toNativeModels(
-  provider: string,
-  baseUrl: string,
-  models: readonly DiscoveredModel[],
-): Model<LiteLLMApi>[] {
+export function toNativeModels(provider: string, baseUrl: string, models: readonly DiscoveredModel[]): LiteLLMModel[] {
   return models.map((model) => ({
     ...model,
     provider,
     api: model.api ?? "openai-completions",
     baseUrl,
-  })) as Model<LiteLLMApi>[];
+  })) as LiteLLMModel[];
 }
 
 export function createLiteLLMProvider(options: LiteLLMProviderOptions): Provider<LiteLLMApi> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import type { Model } from "@earendil-works/pi-ai";
 export type DiscoverySource = "model_info" | "models_list" | "health";
 
 export type LiteLLMApi = "openai-completions" | "openai-responses";
+export type RouteDialect = "moonshot" | "other";
 
 export type LiteLLMRuntimeAuth = {
   baseUrl: string;
@@ -13,6 +14,7 @@ export type LiteLLMRuntimeAuth = {
 
 export type DiscoveredModel = Omit<Model<"openai-completions">, "provider" | "api" | "baseUrl"> & {
   api?: LiteLLMApi;
+  routeDialect?: RouteDialect;
 };
 
 export interface DiscoveryResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,10 @@ export interface DiscoveryOptions {
 
 export interface ModelInfoEntry {
   model_name?: string;
+  litellm_params?: {
+    model?: string;
+    custom_llm_provider?: string;
+  };
   model_info?: {
     mode?: string | null;
     input_cost_per_token?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ import type { Model } from "@earendil-works/pi-ai";
 export type DiscoverySource = "model_info" | "models_list" | "health";
 
 export type LiteLLMApi = "openai-completions" | "openai-responses";
-export type RouteDialect = "moonshot" | "other";
 
 export type LiteLLMRuntimeAuth = {
   baseUrl: string;
@@ -14,10 +13,10 @@ export type LiteLLMRuntimeAuth = {
 
 export type DiscoveredModel = Omit<Model<"openai-completions">, "provider" | "api" | "baseUrl"> & {
   api?: LiteLLMApi;
-  routeDialect?: RouteDialect;
+  suppressReasoningContent?: boolean;
 };
 
-export type LiteLLMModel = Model<LiteLLMApi> & { routeDialect?: RouteDialect };
+export type LiteLLMModel = Model<LiteLLMApi> & { suppressReasoningContent?: boolean };
 
 export interface DiscoveryResult {
   models: DiscoveredModel[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,8 @@ export type DiscoveredModel = Omit<Model<"openai-completions">, "provider" | "ap
   routeDialect?: RouteDialect;
 };
 
+export type LiteLLMModel = Model<LiteLLMApi> & { routeDialect?: RouteDialect };
+
 export interface DiscoveryResult {
   models: DiscoveredModel[];
   source: DiscoverySource;

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -453,7 +453,7 @@ describe("discoverModels via /health", () => {
           healthy_endpoints: routes.map((_, index) => ({ model: "kimi-prod", model_id: `route-${index}` })),
         });
       }
-      const route = routes[Number(url.match(/route-(\\d+)/)?.[1])];
+      const route = routes[Number(url.match(/route-(\d+)/)?.[1])];
       return jsonResponse(200, { data: [{ litellm_params: { model: route }, model_info: { mode: "chat" } }] });
     });
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -382,6 +382,28 @@ describe("discoverModels via /model/info", () => {
 
     expect(result.models[0]?.compat).toEqual(buildCompat("kimi-k3"));
   });
+
+  it.each([
+    ["Moonshot deployments", ["moonshot/kimi-k3", "moonshot/kimi-k3"], "moonshot", true],
+    ["mixed deployments", ["moonshot/kimi-k3", "azure_ai/FW-Kimi-K3"], "other", false],
+    ["reversed mixed deployments", ["azure_ai/FW-Kimi-K3", "moonshot/kimi-k3"], "other", false],
+    ["incomplete deployment metadata", ["moonshot/kimi-k3", undefined], "other", false],
+  ] as const)("aggregates %s conservatively", async (_name, routes, dialect, suppress) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: routes.map((model) => ({
+          model_name: "kimi-prod",
+          ...(model ? { litellm_params: { model } } : {}),
+          model_info: { mode: "chat" },
+        })),
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.routeDialect).toBe(dialect);
+    expect(shouldSuppressReasoningContent("kimi-prod")).toBe(suppress);
+  });
 });
 
 describe("discoverModels wildcard expansion via /v1/models", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -364,6 +364,24 @@ describe("discoverModels via /model/info", () => {
       cost: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
     });
   });
+
+  it("keeps Kimi compatibility on non-Moonshot routes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "kimi-k3",
+            litellm_params: { model: "azure_ai/FW-Kimi-K3" },
+            model_info: { mode: "chat" },
+          },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.compat).toEqual(buildCompat("kimi-k3"));
+  });
 });
 
 describe("discoverModels wildcard expansion via /v1/models", () => {

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -1,5 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildCompat, discoverModels, normalizeBaseUrl, shouldSuppressReasoningContent } from "../src/discover.js";
+import {
+  buildCompat,
+  discoverModels,
+  emitsThinkTags,
+  normalizeBaseUrl,
+  recordRouteDialect,
+  shouldSuppressReasoningContent,
+} from "../src/discover.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -114,17 +121,40 @@ describe("buildCompat", () => {
 });
 
 describe("shouldSuppressReasoningContent", () => {
-  it("suppresses separate reasoning streams for Kimi/Moonshot aliases", () => {
+  afterEach(() => {
+    for (const id of ["kimi-k2.6", "moonshotai/kimi-k2", "kimi-k2-thinking", "kimi-k3", "openai/gpt-4o"]) {
+      recordRouteDialect(id, undefined);
+    }
+  });
+
+  it("suppresses separate reasoning streams for Moonshot-native routes", () => {
+    recordRouteDialect("kimi-k2.6", "moonshot");
+    recordRouteDialect("moonshotai/kimi-k2", "moonshot");
     expect(shouldSuppressReasoningContent("kimi-k2.6")).toBe(true);
     expect(shouldSuppressReasoningContent("moonshotai/kimi-k2")).toBe(true);
   });
 
   it("does not suppress explicit forced-thinking models", () => {
+    recordRouteDialect("kimi-k2-thinking", "moonshot");
     expect(shouldSuppressReasoningContent("kimi-k2-thinking")).toBe(false);
   });
 
   it("does not suppress unrelated models", () => {
     expect(shouldSuppressReasoningContent("openai/gpt-4o")).toBe(false);
+  });
+
+  it("does not suppress Kimi aliases routed to a non-Moonshot upstream", () => {
+    recordRouteDialect("kimi-k3", "other");
+    expect(shouldSuppressReasoningContent("kimi-k3")).toBe(false);
+  });
+
+  it("does not suppress when the route is unknown", () => {
+    expect(shouldSuppressReasoningContent("kimi-k3")).toBe(false);
+  });
+
+  it("still parses think tags for unknown routes that look like Kimi", () => {
+    expect(emitsThinkTags("kimi-k3")).toBe(true);
+    expect(emitsThinkTags("openai/gpt-4o")).toBe(false);
   });
 });
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -1,10 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  buildCompat,
-  discoverModels,
-  emitsThinkTags,
-  normalizeBaseUrl,
-} from "../src/discover.js";
+import { buildCompat, discoverModels, emitsThinkTags, normalizeBaseUrl } from "../src/discover.js";
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -381,6 +376,24 @@ describe("discoverModels via /model/info", () => {
             model_info: { mode: "chat" },
           },
         ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.suppressReasoningContent).toBeUndefined();
+  });
+
+  it.each([
+    ["provider-only metadata", { custom_llm_provider: "moonshot" }],
+    [
+      "conflicting Moonshot provider and Azure backend",
+      { custom_llm_provider: "moonshot", model: "azure_ai/FW-Kimi-K3" },
+    ],
+  ])("does not suppress with %s", async (_name, litellm_params) => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [{ model_name: "kimi-prod", litellm_params, model_info: { mode: "chat" } }],
       }),
     );
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -4,7 +4,6 @@ import {
   discoverModels,
   emitsThinkTags,
   normalizeBaseUrl,
-  recordRouteDialect,
   shouldSuppressReasoningContent,
 } from "../src/discover.js";
 
@@ -121,35 +120,25 @@ describe("buildCompat", () => {
 });
 
 describe("shouldSuppressReasoningContent", () => {
-  afterEach(() => {
-    for (const id of ["kimi-k2.6", "moonshotai/kimi-k2", "kimi-k2-thinking", "kimi-k3", "openai/gpt-4o"]) {
-      recordRouteDialect(id, undefined);
-    }
-  });
-
   it("suppresses separate reasoning streams for Moonshot-native routes", () => {
-    recordRouteDialect("kimi-k2.6", "moonshot");
-    recordRouteDialect("moonshotai/kimi-k2", "moonshot");
-    expect(shouldSuppressReasoningContent("kimi-k2.6")).toBe(true);
-    expect(shouldSuppressReasoningContent("moonshotai/kimi-k2")).toBe(true);
+    expect(shouldSuppressReasoningContent("kimi-k2.6", "moonshot")).toBe(true);
+    expect(shouldSuppressReasoningContent("moonshotai/kimi-k2", "moonshot")).toBe(true);
   });
 
   it("does not suppress explicit forced-thinking models", () => {
-    recordRouteDialect("kimi-k2-thinking", "moonshot");
-    expect(shouldSuppressReasoningContent("kimi-k2-thinking")).toBe(false);
+    expect(shouldSuppressReasoningContent("kimi-k2-thinking", "moonshot")).toBe(false);
   });
 
   it("does not suppress unrelated models", () => {
-    expect(shouldSuppressReasoningContent("openai/gpt-4o")).toBe(false);
+    expect(shouldSuppressReasoningContent("openai/gpt-4o", undefined)).toBe(false);
   });
 
   it("does not suppress Kimi aliases routed to a non-Moonshot upstream", () => {
-    recordRouteDialect("kimi-k3", "other");
-    expect(shouldSuppressReasoningContent("kimi-k3")).toBe(false);
+    expect(shouldSuppressReasoningContent("kimi-k3", "other")).toBe(false);
   });
 
   it("does not suppress when the route is unknown", () => {
-    expect(shouldSuppressReasoningContent("kimi-k3")).toBe(false);
+    expect(shouldSuppressReasoningContent("kimi-k3", undefined)).toBe(false);
   });
 
   it("still parses think tags for unknown routes that look like Kimi", () => {
@@ -402,7 +391,58 @@ describe("discoverModels via /model/info", () => {
     const result = await discoverModels("https://litellm.example.com", "sk-test", {});
 
     expect(result.models[0]?.routeDialect).toBe(dialect);
-    expect(shouldSuppressReasoningContent("kimi-prod")).toBe(suppress);
+    expect(shouldSuppressReasoningContent("kimi-prod", result.models[0]?.routeDialect)).toBe(suppress);
+  });
+
+  it("keeps route evidence isolated between discoveries", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      const model = url.startsWith("https://moonshot.example.com") ? "moonshot/kimi-k3" : "azure_ai/FW-Kimi-K3";
+      return jsonResponse(200, {
+        data: [
+          {
+            model_name: "kimi-prod",
+            litellm_params: { model },
+            model_info: { mode: "chat" },
+          },
+        ],
+      });
+    });
+
+    const moonshot = await discoverModels("https://moonshot.example.com", "sk-test", {});
+    const azure = await discoverModels("https://azure.example.com", "sk-test", {});
+
+    expect(shouldSuppressReasoningContent("kimi-prod", moonshot.models[0]?.routeDialect)).toBe(true);
+    expect(shouldSuppressReasoningContent("kimi-prod", azure.models[0]?.routeDialect)).toBe(false);
+  });
+
+  it("does not reuse route evidence after metadata fallback", async () => {
+    let fallback = false;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return fallback
+          ? jsonResponse(403, {})
+          : jsonResponse(200, {
+              data: [
+                {
+                  model_name: "kimi-prod",
+                  litellm_params: { model: "moonshot/kimi-k3" },
+                  model_info: { mode: "chat" },
+                },
+              ],
+            });
+      }
+      if (url.endsWith("/v1/models")) return jsonResponse(200, { data: [{ id: "kimi-prod" }] });
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    await discoverModels("https://litellm.example.com", "sk-test", {});
+    fallback = true;
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.routeDialect).toBeUndefined();
+    expect(shouldSuppressReasoningContent("kimi-prod", result.models[0]?.routeDialect)).toBe(false);
   });
 });
 

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -4,7 +4,6 @@ import {
   discoverModels,
   emitsThinkTags,
   normalizeBaseUrl,
-  shouldSuppressReasoningContent,
 } from "../src/discover.js";
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -119,28 +118,7 @@ describe("buildCompat", () => {
   });
 });
 
-describe("shouldSuppressReasoningContent", () => {
-  it("suppresses separate reasoning streams for Moonshot-native routes", () => {
-    expect(shouldSuppressReasoningContent("kimi-k2.6", "moonshot")).toBe(true);
-    expect(shouldSuppressReasoningContent("moonshotai/kimi-k2", "moonshot")).toBe(true);
-  });
-
-  it("does not suppress explicit forced-thinking models", () => {
-    expect(shouldSuppressReasoningContent("kimi-k2-thinking", "moonshot")).toBe(false);
-  });
-
-  it("does not suppress unrelated models", () => {
-    expect(shouldSuppressReasoningContent("openai/gpt-4o", undefined)).toBe(false);
-  });
-
-  it("does not suppress Kimi aliases routed to a non-Moonshot upstream", () => {
-    expect(shouldSuppressReasoningContent("kimi-k3", "other")).toBe(false);
-  });
-
-  it("does not suppress when the route is unknown", () => {
-    expect(shouldSuppressReasoningContent("kimi-k3", undefined)).toBe(false);
-  });
-
+describe("Kimi reasoning compatibility", () => {
   it("still parses think tags for unknown routes that look like Kimi", () => {
     expect(emitsThinkTags("kimi-k3")).toBe(true);
     expect(emitsThinkTags("openai/gpt-4o")).toBe(false);
@@ -373,11 +351,11 @@ describe("discoverModels via /model/info", () => {
   });
 
   it.each([
-    ["Moonshot deployments", ["moonshot/kimi-k3", "moonshot/kimi-k3"], "moonshot", true],
-    ["mixed deployments", ["moonshot/kimi-k3", "azure_ai/FW-Kimi-K3"], "other", false],
-    ["reversed mixed deployments", ["azure_ai/FW-Kimi-K3", "moonshot/kimi-k3"], "other", false],
-    ["incomplete deployment metadata", ["moonshot/kimi-k3", undefined], "other", false],
-  ] as const)("aggregates %s conservatively", async (_name, routes, dialect, suppress) => {
+    ["Moonshot deployments", ["moonshot/kimi-k3", "moonshot/kimi-k3"], true],
+    ["mixed deployments", ["moonshot/kimi-k3", "azure_ai/FW-Kimi-K3"], false],
+    ["reversed mixed deployments", ["azure_ai/FW-Kimi-K3", "moonshot/kimi-k3"], false],
+    ["incomplete deployment metadata", ["moonshot/kimi-k3", undefined], false],
+  ] as const)("aggregates %s conservatively", async (_name, routes, suppress) => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse(200, {
         data: routes.map((model) => ({
@@ -390,8 +368,25 @@ describe("discoverModels via /model/info", () => {
 
     const result = await discoverModels("https://litellm.example.com", "sk-test", {});
 
-    expect(result.models[0]?.routeDialect).toBe(dialect);
-    expect(shouldSuppressReasoningContent("kimi-prod", result.models[0]?.routeDialect)).toBe(suppress);
+    expect(result.models[0]?.suppressReasoningContent === true).toBe(suppress);
+  });
+
+  it("does not suppress an alias routed to a forced-thinking Moonshot model", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "k3-prod",
+            litellm_params: { model: "moonshot/kimi-k2-thinking" },
+            model_info: { mode: "chat" },
+          },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.suppressReasoningContent).toBeUndefined();
   });
 
   it("keeps route evidence isolated between discoveries", async () => {
@@ -412,8 +407,8 @@ describe("discoverModels via /model/info", () => {
     const moonshot = await discoverModels("https://moonshot.example.com", "sk-test", {});
     const azure = await discoverModels("https://azure.example.com", "sk-test", {});
 
-    expect(shouldSuppressReasoningContent("kimi-prod", moonshot.models[0]?.routeDialect)).toBe(true);
-    expect(shouldSuppressReasoningContent("kimi-prod", azure.models[0]?.routeDialect)).toBe(false);
+    expect(moonshot.models[0]?.suppressReasoningContent).toBe(true);
+    expect(azure.models[0]?.suppressReasoningContent).toBeUndefined();
   });
 
   it("does not reuse route evidence after metadata fallback", async () => {
@@ -441,8 +436,54 @@ describe("discoverModels via /model/info", () => {
     fallback = true;
     const result = await discoverModels("https://litellm.example.com", "sk-test", {});
 
-    expect(result.models[0]?.routeDialect).toBeUndefined();
-    expect(shouldSuppressReasoningContent("kimi-prod", result.models[0]?.routeDialect)).toBe(false);
+    expect(result.models[0]?.suppressReasoningContent).toBeUndefined();
+  });
+});
+
+describe("discoverModels via /health", () => {
+  it.each([
+    ["Moonshot first", ["moonshot/kimi-k3", "azure_ai/FW-Kimi-K3"]],
+    ["Azure first", ["azure_ai/FW-Kimi-K3", "moonshot/kimi-k3"]],
+  ] as const)("does not suppress duplicate mixed routes when %s", async (_name, routes) => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info") || url.endsWith("/v1/models")) return jsonResponse(403, {});
+      if (url.endsWith("/health")) {
+        return jsonResponse(200, {
+          healthy_endpoints: routes.map((_, index) => ({ model: "kimi-prod", model_id: `route-${index}` })),
+        });
+      }
+      const route = routes[Number(url.match(/route-(\\d+)/)?.[1])];
+      return jsonResponse(200, { data: [{ litellm_params: { model: route }, model_info: { mode: "chat" } }] });
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("health");
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]?.suppressReasoningContent).toBeUndefined();
+  });
+
+  it("suppresses duplicate proven non-forced Moonshot health routes", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info") || url.endsWith("/v1/models")) return jsonResponse(403, {});
+      if (url.endsWith("/health")) {
+        return jsonResponse(200, {
+          healthy_endpoints: [
+            { model: "kimi-prod", model_id: "route-1" },
+            { model: "kimi-prod", model_id: "route-2" },
+          ],
+        });
+      }
+      return jsonResponse(200, {
+        data: [{ litellm_params: { model: "moonshot/kimi-k3" }, model_info: { mode: "chat" } }],
+      });
+    });
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models[0]?.suppressReasoningContent).toBe(true);
   });
 });
 

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -622,6 +622,11 @@ describe("feature parity", () => {
         return jsonResponse(200, {
           data: [
             {
+              model_name: "kimi-k2.6",
+              litellm_params: { model: "moonshot/kimi-k2.6" },
+              model_info: { mode: "chat" },
+            },
+            {
               model_name: "anthropic/claude-3-5-sonnet",
               model_info: {
                 mode: "chat",
@@ -676,6 +681,7 @@ describe("feature parity", () => {
           data: [
             {
               model_name: "kimi-k3",
+              litellm_params: { model: "moonshot/kimi-k3" },
               model_info: { mode: "chat" },
             },
           ],
@@ -692,6 +698,77 @@ describe("feature parity", () => {
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
       { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions" } },
+    );
+    expect(updated).toEqual({
+      messages: [],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+    });
+  });
+
+  it("keeps Moonshot suppression off routes that only look like Kimi", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "kimi-k3",
+              litellm_params: { model: "azure_ai/FW-Kimi-K3" },
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      { payload: { messages: [] } },
+      { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions" } },
+    );
+    expect(updated).toBeUndefined();
+  });
+
+  it("still suppresses reasoning on Moonshot-native routes", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+    process.env.LITELLM_API_KEY = "sk-test";
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.endsWith("/model/info")) {
+        return jsonResponse(200, {
+          data: [
+            {
+              model_name: "k3-prod",
+              litellm_params: { model: "moonshot/kimi-k3" },
+              model_info: { mode: "chat" },
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected URL: ${url}`);
+    });
+
+    const extension = await loadExtension(agentDir);
+    const pi = createPi();
+    await extension(pi);
+
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const updated = beforeRequest?.(
+      { payload: { messages: [] } },
+      { model: { provider: "litellm", id: "k3-prod", api: "openai-completions" } },
     );
     expect(updated).toEqual({
       messages: [],
@@ -726,7 +803,17 @@ describe("feature parity", () => {
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "kimi-k3",
+            litellm_params: { model: "moonshot/kimi-k3" },
+            model_info: { mode: "chat" },
+          },
+        ],
+      }),
+    );
 
     const extension = await loadExtension(agentDir);
     const pi = createPi();
@@ -771,7 +858,17 @@ describe("feature parity", () => {
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "kimi-k3",
+            litellm_params: { model: "moonshot/kimi-k3" },
+            model_info: { mode: "chat" },
+          },
+        ],
+      }),
+    );
 
     const extension = await loadExtension(agentDir);
     const pi = createPi();
@@ -823,7 +920,17 @@ describe("feature parity", () => {
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { data: [] }));
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "kimi-k3",
+            litellm_params: { model: "moonshot/kimi-k3" },
+            model_info: { mode: "chat" },
+          },
+        ],
+      }),
+    );
 
     const extension = await loadExtension(agentDir);
     const pi = createPi();

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -696,11 +696,14 @@ describe("feature parity", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await refreshProvider(pi);
 
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const model = pi.providers[0]?.getModels().find((candidate) => candidate.id === "kimi-k3");
+    expect(model).toMatchObject({ suppressReasoningContent: true });
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions", suppressReasoningContent: true } },
+      { model },
     );
     expect(updated).toEqual({
       messages: [],
@@ -749,7 +752,7 @@ describe("feature parity", () => {
     });
   });
 
-  it("does not suppress reasoning when discovery has no suppression marker", async () => {
+  it("does not suppress reasoning for forced public or backend discovered models", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
@@ -759,6 +762,11 @@ describe("feature parity", () => {
       if (url.endsWith("/model/info")) {
         return jsonResponse(200, {
           data: [
+            {
+              model_name: "kimi-k2-thinking",
+              litellm_params: { model: "moonshot/kimi-k3" },
+              model_info: { mode: "chat" },
+            },
             {
               model_name: "k3-prod",
               litellm_params: { model: "moonshot/kimi-k2-thinking" },
@@ -773,13 +781,14 @@ describe("feature parity", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
+    await refreshProvider(pi);
 
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const updated = beforeRequest?.(
-      { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "k3-prod", api: "openai-completions" } },
-    );
-    expect(updated).toBeUndefined();
+    for (const id of ["kimi-k2-thinking", "k3-prod"]) {
+      const model = pi.providers[0]?.getModels().find((candidate) => candidate.id === id);
+      expect(model).toBeDefined();
+      expect(beforeRequest?.({ payload: { messages: [] } }, { model })).toBeUndefined();
+    }
   });
 
   it("leaves Kimi Responses requests unchanged", async () => {

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -659,7 +659,10 @@ describe("feature parity", () => {
     }
 
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const updated = beforeRequest?.({ payload: { messages: [] } }, { model: { provider: "litellm", id: "kimi-k2.6" } });
+    const updated = beforeRequest?.(
+      { payload: { messages: [] } },
+      { model: { provider: "litellm", id: "kimi-k2.6", routeDialect: "moonshot" } },
+    );
     expect(updated).toMatchObject({
       messages: [],
       include_reasoning: false,
@@ -697,7 +700,7 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions" } },
+      { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions", routeDialect: "moonshot" } },
     );
     expect(updated).toEqual({
       messages: [],
@@ -774,7 +777,7 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "k3-prod", api: "openai-completions" } },
+      { model: { provider: "litellm", id: "k3-prod", api: "openai-completions", routeDialect: "moonshot" } },
     );
     expect(updated).toEqual({
       messages: [],
@@ -840,7 +843,7 @@ describe("feature parity", () => {
           ],
         },
       },
-      { model: { provider: "litellm", id: "kimi-k3" } },
+      { model: { provider: "litellm", id: "kimi-k3", routeDialect: "moonshot" } },
     );
 
     expect(updated).toEqual({
@@ -899,7 +902,7 @@ describe("feature parity", () => {
           ],
         },
       },
-      { model: { provider: "litellm", id: "kimi-k3" } },
+      { model: { provider: "litellm", id: "kimi-k3", routeDialect: "moonshot" } },
     );
 
     expect(updated).toEqual({
@@ -951,7 +954,10 @@ describe("feature parity", () => {
       { role: "tool", tool_call_id: "call_1", content: "tool output" },
     ];
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const updated = beforeRequest?.({ payload: { messages } }, { model: { provider: "litellm", id: "kimi-k3" } });
+    const updated = beforeRequest?.(
+      { payload: { messages } },
+      { model: { provider: "litellm", id: "kimi-k3", routeDialect: "moonshot" } },
+    );
 
     expect(updated?.messages).toBe(messages);
   });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -734,10 +734,16 @@ describe("feature parity", () => {
 
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
-      { payload: { messages: [] } },
+      {
+        payload: {
+          messages: [{ role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: "tool output" }] }],
+        },
+      },
       { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions" } },
     );
-    expect(updated).toBeUndefined();
+    expect(updated).toEqual({
+      messages: [{ role: "tool", tool_call_id: "call_1", content: "tool output" }],
+    });
   });
 
   it("still suppresses reasoning on Moonshot-native routes", async () => {
@@ -1195,6 +1201,7 @@ describe("feature parity", () => {
           data: [
             {
               model_name: "kimi-k2.6",
+              litellm_params: { model: "azure_ai/FW-Kimi-K2.6" },
               model_info: { mode: "chat" },
             },
           ],

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -701,10 +701,7 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const model = pi.providers[0]?.getModels().find((candidate) => candidate.id === "kimi-k3");
     expect(model).toMatchObject({ suppressReasoningContent: true });
-    const updated = beforeRequest?.(
-      { payload: { messages: [] } },
-      { model },
-    );
+    const updated = beforeRequest?.({ payload: { messages: [] } }, { model });
     expect(updated).toEqual({
       messages: [],
       include_reasoning: false,

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -661,7 +661,7 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "kimi-k2.6", routeDialect: "moonshot" } },
+      { model: { provider: "litellm", id: "kimi-k2.6", suppressReasoningContent: true } },
     );
     expect(updated).toMatchObject({
       messages: [],
@@ -700,7 +700,7 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions", routeDialect: "moonshot" } },
+      { model: { provider: "litellm", id: "kimi-k3", api: "openai-completions", suppressReasoningContent: true } },
     );
     expect(updated).toEqual({
       messages: [],
@@ -749,7 +749,7 @@ describe("feature parity", () => {
     });
   });
 
-  it("still suppresses reasoning on Moonshot-native routes", async () => {
+  it("does not suppress reasoning when discovery has no suppression marker", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
@@ -761,7 +761,7 @@ describe("feature parity", () => {
           data: [
             {
               model_name: "k3-prod",
-              litellm_params: { model: "moonshot/kimi-k3" },
+              litellm_params: { model: "moonshot/kimi-k2-thinking" },
               model_info: { mode: "chat" },
             },
           ],
@@ -777,14 +777,9 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
       { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "k3-prod", api: "openai-completions", routeDialect: "moonshot" } },
+      { model: { provider: "litellm", id: "k3-prod", api: "openai-completions" } },
     );
-    expect(updated).toEqual({
-      messages: [],
-      include_reasoning: false,
-      reasoning_content: false,
-      merge_reasoning_content_in_choices: true,
-    });
+    expect(updated).toBeUndefined();
   });
 
   it("leaves Kimi Responses requests unchanged", async () => {
@@ -843,7 +838,7 @@ describe("feature parity", () => {
           ],
         },
       },
-      { model: { provider: "litellm", id: "kimi-k3", routeDialect: "moonshot" } },
+      { model: { provider: "litellm", id: "kimi-k3", suppressReasoningContent: true } },
     );
 
     expect(updated).toEqual({
@@ -902,7 +897,7 @@ describe("feature parity", () => {
           ],
         },
       },
-      { model: { provider: "litellm", id: "kimi-k3", routeDialect: "moonshot" } },
+      { model: { provider: "litellm", id: "kimi-k3", suppressReasoningContent: true } },
     );
 
     expect(updated).toEqual({
@@ -956,7 +951,7 @@ describe("feature parity", () => {
     const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
     const updated = beforeRequest?.(
       { payload: { messages } },
-      { model: { provider: "litellm", id: "kimi-k3", routeDialect: "moonshot" } },
+      { model: { provider: "litellm", id: "kimi-k3", suppressReasoningContent: true } },
     );
 
     expect(updated?.messages).toBe(messages);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -504,14 +504,17 @@ describe("extension startup", () => {
     await extension(pi);
 
     const result = await pi.handlers.get("before_provider_request")?.[0]?.(
-      { payload: { model: "kimi-k2.6" } },
+      {
+        payload: {
+          model: "kimi-k2.6",
+          messages: [{ role: "tool", tool_call_id: "call_1", content: [{ type: "text", text: "tool output" }] }],
+        },
+      },
       { model: { provider: "litellm-anthropic", id: "kimi-k2.6" } },
     );
 
     expect(result).toMatchObject({
-      include_reasoning: false,
-      reasoning_content: false,
-      merge_reasoning_content_in_choices: true,
+      messages: [{ role: "tool", tool_call_id: "call_1", content: "tool output" }],
     });
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -524,14 +524,14 @@ describe("extension startup", () => {
           provider: "litellm-anthropic",
           id: "k3-prod",
           api: "openai-completions",
-          routeDialect: "moonshot",
+          suppressReasoningContent: true,
         },
       },
     );
     const otherRoute = await pi.handlers.get("before_provider_request")?.[0]?.(
       { payload: { messages: [] } },
       {
-        model: { provider: "litellm", id: "k3-prod", api: "openai-completions", routeDialect: "other" },
+        model: { provider: "litellm", id: "k3-prod", api: "openai-completions" },
       },
     );
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -516,6 +516,32 @@ describe("extension startup", () => {
     expect(result).toMatchObject({
       messages: [{ role: "tool", tool_call_id: "call_1", content: "tool output" }],
     });
+
+    const moonshotRoute = await pi.handlers.get("before_provider_request")?.[0]?.(
+      { payload: { messages: [] } },
+      {
+        model: {
+          provider: "litellm-anthropic",
+          id: "k3-prod",
+          api: "openai-completions",
+          routeDialect: "moonshot",
+        },
+      },
+    );
+    const otherRoute = await pi.handlers.get("before_provider_request")?.[0]?.(
+      { payload: { messages: [] } },
+      {
+        model: { provider: "litellm", id: "k3-prod", api: "openai-completions", routeDialect: "other" },
+      },
+    );
+
+    expect(moonshotRoute).toEqual({
+      messages: [],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+    });
+    expect(otherRoute).toBeUndefined();
   });
 
   it("returns a native API-key credential without discovery side effects", async () => {


### PR DESCRIPTION
## Summary

- decide Moonshot request tweaks from the LiteLLM route (`litellm_params`) instead of the `model_name` alias
- stop injecting LiteLLM reasoning switches unless the route is proven Moonshot-native
- keep the id heuristic for model-level traits (`<think>` parsing, strict tool schema, `buildCompat`)

## Problem

#112 removed `thinking` from `REASONING_SUPPRESSION_DEFAULTS`, but the three remaining keys are still injected for anything matching `MOONSHOT_MODEL_PATTERN`. A Kimi alias backed by Azure AI Foundry rejects the very next key, so the model is unusable through Pi:

```
400: litellm.BadRequestError: Azure_aiException - {"error":{"object":"error",
"type":"invalid_request_error","code":"invalid_request_error",
"message":"Extra inputs are not permitted, field: 'reasoning_content', value: False"}}
Received Model Group=kimi-k3
```

Note the different failure mode from #110: `thinking` was rejected by LiteLLM itself (`UnsupportedParamsError`), while `reasoning_content` passes through LiteLLM and is rejected by the upstream schema.

## Reproduction

`/model/info` for the alias:

```json
{
  "model_name": "kimi-k3",
  "litellm_params": {
    "model": "azure_ai/FW-Kimi-K3",
    "allowed_openai_params": ["tool_choice", "reasoning_effort"]
  }
}
```

Direct calls to the same proxy, isolating each injected key:

| request body | result |
|---|---|
| `reasoning_effort: "high"` (+ stream, + tools) | 200 |
| `include_reasoning: false` | 200 |
| `merge_reasoning_content_in_choices: true` | 200 |
| `reasoning_content: false` | **400** |

## Root cause

As #110 already noted, the gate is purely on the model id and never consults how the route is configured. A `model_name` is an operator-chosen alias: on this proxy `kimi-k3` resolves to `azure_ai/FW-Kimi-K3` and `kimi-k2.5` to `bedrock/moonshotai.kimi-k2.5`. Neither speaks the Moonshot dialect, and the reverse case is just as broken — an alias like `k3-prod` on a real `moonshot/` route matches nothing and silently loses the tweaks.

## Change

`/model/info` already returns `litellm_params`; discovery now records the route dialect per model id and the request hook consults it.

The two concerns are separated by their failure cost:

- **Request injection** (`shouldSuppressReasoningContent`) requires a proven Moonshot route. Manually configured models and metadata-less proxies report no route, and a wrong guess costs a 400 for the whole turn.
- **Response/message handling** (`emitsThinkTags`, strict tool normalisation, `buildCompat`) keeps the id heuristic. These follow the model family rather than the route, and a wrong guess only affects text Pi already received.

That fallback matters when `/model/info` returns 401/403/404 and discovery drops to `/v1/models`, where no route metadata exists at all.

## Validation

- `npm run check` — Biome, typecheck, 259 passed / 1 skipped
- verified against a live LiteLLM proxy: `kimi-k3` (`azure_ai/` route) now completes over `openai-completions`

New tests cover both directions: a Kimi alias on a non-Moonshot route gets no injection, and a non-Kimi alias on a `moonshot/` route still does.

Refs #110
