### PR TITLE
Fail smoke for inactive LiteLLM Enterprise licenses

### DIFF
--- a/scripts/smoke-auth.ts
+++ b/scripts/smoke-auth.ts
@@ -58,6 +58,18 @@ function isAuthFailure(status: number): boolean {
   return status === 401 || status === 403;
 }
 
+function isPremiumUserToken(token: unknown): boolean {
+  if (typeof token !== "string") return false;
+  const [, payload] = token.split(".");
+  if (!payload) return false;
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as { premium_user?: unknown };
+    return claims.premium_user === true;
+  } catch {
+    return false;
+  }
+}
+
 async function expectAuthFailure(label: string, response: Response): Promise<void> {
   if (!isAuthFailure(response.status)) {
     throw new Error(`${label} should reject auth, got ${response.status}`);
@@ -223,6 +235,20 @@ export async function runAuthSmoke(options: AuthSmokeOptions): Promise<AuthSmoke
   checks.push("master-key-chat");
 
   if (options.enterprise) {
+    const loginResponse = await fetchWithTimeout(
+      `${baseUrl}/v2/login`,
+      {
+        method: "POST",
+        headers: { ...authHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ username: "admin", password: options.masterKey }),
+      },
+      timeoutMs,
+    );
+    await expectOk("enterprise license /v2/login", loginResponse);
+    const login = (await loginResponse.json()) as { token?: unknown };
+    if (!isPremiumUserToken(login.token)) throw new Error("LiteLLM Enterprise license is not active");
+    checks.push("enterprise-license");
+
     await expectAuthFailure("bad-token /v1/models", await fetchModels(baseUrl, BAD_SMOKE_KEY, timeoutMs));
     checks.push("bad-token");
 

--- a/tests/smoke-auth.test.ts
+++ b/tests/smoke-auth.test.ts
@@ -11,6 +11,49 @@ function jsonResponse(status: number, body: unknown): Response {
   });
 }
 
+type SmokeRequest = { url: string; body?: unknown; auth?: string };
+
+function adminToken(premiumUser: boolean): string {
+  const encode = (value: unknown): string => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode({ alg: "HS256" })}.${encode({ premium_user: premiumUser })}.signature`;
+}
+
+function mockEnterpriseProxy(premiumUser: boolean, requests: SmokeRequest[] = []): SmokeRequest[] {
+  vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+    const url = String(input);
+    const headers = init?.headers as Record<string, string> | undefined;
+    const auth = headers?.Authorization;
+    requests.push({
+      url,
+      auth,
+      body: init?.body ? JSON.parse(String(init.body)) : undefined,
+    });
+
+    if (url.endsWith("/v2/login")) {
+      return jsonResponse(200, { token: adminToken(premiumUser) });
+    }
+    if (url.endsWith("/v1/models")) {
+      if (!auth) return jsonResponse(401, { error: "missing token" });
+      if (auth === "Bearer bad-smoke-key") return jsonResponse(403, { error: "bad token" });
+      return jsonResponse(200, { data: [{ id: "vidaimock-openai" }] });
+    }
+    if (url.endsWith("/key/generate") && auth === "Bearer sk-master") {
+      return jsonResponse(200, { key: "sk-virtual" });
+    }
+    if (url.endsWith("/key/generate") && auth === "Bearer sk-virtual") {
+      return jsonResponse(403, { error: "admin only" });
+    }
+    if (url.endsWith("/model/info")) {
+      return jsonResponse(200, { data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }] });
+    }
+    if (url.endsWith("/v1/chat/completions")) {
+      return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
+    }
+    throw new Error(`unexpected URL: ${url}`);
+  });
+  return requests;
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
@@ -78,37 +121,28 @@ describe("runAuthSmoke", () => {
     });
   });
 
-  it("checks virtual-key auth, enterprise admin-route enforcement, and SSO login", async () => {
-    const requests: Array<{ url: string; body?: unknown; auth?: string }> = [];
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = String(input);
-      const headers = init?.headers as Record<string, string> | undefined;
-      const auth = headers?.Authorization;
-      requests.push({
-        url,
-        auth,
-        body: init?.body ? JSON.parse(String(init.body)) : undefined,
-      });
+  it("rejects a configured but inactive Enterprise license", async () => {
+    const requests = mockEnterpriseProxy(false);
 
-      if (url.endsWith("/v1/models")) {
-        if (!auth) return jsonResponse(401, { error: "missing token" });
-        if (auth === "Bearer bad-smoke-key") return jsonResponse(403, { error: "bad token" });
-        return jsonResponse(200, { data: [{ id: "vidaimock-openai" }] });
-      }
-      if (url.endsWith("/key/generate") && auth === "Bearer sk-master") {
-        return jsonResponse(200, { key: "sk-virtual" });
-      }
-      if (url.endsWith("/key/generate") && auth === "Bearer sk-virtual") {
-        return jsonResponse(403, { error: "admin only" });
-      }
-      if (url.endsWith("/model/info")) {
-        return jsonResponse(200, { data: [{ model_name: "vidaimock-openai", model_info: { mode: "chat" } }] });
-      }
-      if (url.endsWith("/v1/chat/completions")) {
-        return jsonResponse(200, { choices: [{ message: { content: "pong" } }] });
-      }
-      throw new Error(`unexpected URL: ${url}`);
+    await expect(
+      runAuthSmoke({
+        baseUrl: "http://127.0.0.1:4000",
+        masterKey: "sk-master",
+        modelId: "vidaimock-openai",
+        timeoutMs: 1000,
+        enterprise: true,
+      }),
+    ).rejects.toThrow("LiteLLM Enterprise license is not active");
+
+    expect(requests).toContainEqual({
+      url: "http://127.0.0.1:4000/v2/login",
+      body: { username: "admin", password: "sk-master" },
+      auth: undefined,
     });
+  });
+
+  it("checks virtual-key auth, enterprise admin-route enforcement, and SSO login", async () => {
+    const requests = mockEnterpriseProxy(true);
 
     const result = await runAuthSmoke({
       baseUrl: "http://127.0.0.1:4000",
@@ -124,6 +158,7 @@ describe("runAuthSmoke", () => {
         "missing-token",
         "master-key-models",
         "master-key-chat",
+        "enterprise-license",
         "bad-token",
         "virtual-key-chat",
         "enterprise-admin-route",


### PR DESCRIPTION
## Summary

- validate the configured Enterprise license through LiteLLM's authenticated `premium_user` claim
- fail the Enterprise smoke path when the license is inactive or rejected
- keep community and pull-request smoke behavior unchanged

## Testing

- `npm run check` (255 passed, 1 skipped)
