### PR TITLE
chore: release v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-provider-litellm",
-      "version": "2.2.1",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.15",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-provider-litellm",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "LiteLLM proxy provider extension for Pi",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- bump package metadata to 2.3.0

## Verification

- npm ci --ignore-scripts
- npm run prepublishOnly
- npm pack --dry-run --json (23 files)
- npm audit --audit-level=high (0 vulnerabilities)