### PR TITLE
Fix Model_Info Merge To Keep Real Values Across Null Routes

### DIFF
--- a/src/discover.ts
+++ b/src/discover.ts
@@ -92,6 +92,27 @@ function aggregateSuppressionEvidence(evidence: Iterable<boolean>): boolean {
   return hasEvidence;
 }
 
+// Merges two LiteLLM /model/info `model_info` objects for the same model_name
+// across multiple routes (e.g. a cost-based fallback group). Unlike a plain
+// spread, this ignores `null`/`undefined` values from the incoming route so a
+// later route that doesn't report a field (Nebius/nscale return
+// `max_input_tokens: null`; see https://github.com/BerriAI/litellm/issues/27830)
+// cannot clobber a real value already held from an earlier route. Real values
+// from a later route still win.
+function mergeModelInfo(
+  previous: ModelInfoEntry["model_info"] | undefined,
+  next: ModelInfoEntry["model_info"] | undefined,
+): ModelInfoEntry["model_info"] {
+  const merged: ModelInfoEntry["model_info"] = { ...previous };
+  for (const [key, value] of Object.entries(next ?? {})) {
+    if (value !== null && value !== undefined) {
+      // biome will type key as string; assign through a typed record view.
+      (merged as Record<string, unknown>)[key] = value;
+    }
+  }
+  return merged;
+}
+
 export function emitsThinkTags(modelId: string): boolean {
   return isMoonshotModel(modelId) && !FORCED_THINKING_MODEL_PATTERN.test(modelId);
 }
@@ -393,7 +414,7 @@ export async function discoverModels(
       entries.set(entry.model_name, {
         ...previous,
         ...entry,
-        model_info: { ...previous?.model_info, ...entry.model_info },
+        model_info: mergeModelInfo(previous?.model_info, entry.model_info),
       });
     }
     let models = [...entries.entries()]

--- a/tests/discover.test.ts
+++ b/tests/discover.test.ts
@@ -327,6 +327,108 @@ describe("discoverModels via /model/info", () => {
     });
   });
 
+  it("does not let a later null model_info clobber an earlier real value", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "zai-glm-5-2",
+            litellm_params: { model: "mistral/zai-glm-5-2" },
+            model_info: { mode: "chat", max_input_tokens: 1048576, max_output_tokens: 131072 },
+          },
+          {
+            model_name: "zai-glm-5-2",
+            litellm_params: { model: "nebius/zai-org/GLM-5.2" },
+            model_info: { mode: null, max_input_tokens: null, max_output_tokens: null },
+          },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.source).toBe("model_info");
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "zai-glm-5-2",
+      contextWindow: 1048576,
+      maxTokens: 131072,
+    });
+  });
+
+  it("still lets a later real value override an earlier one", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          { model_name: "dup-model", model_info: { mode: "chat", max_input_tokens: 200000, max_output_tokens: 8192 } },
+          { model_name: "dup-model", model_info: { mode: "chat", max_input_tokens: 100000, max_output_tokens: 4096 } },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    // Later route's real value wins — this is "last real wins", not "max wins":
+    // with 200000 first and 100000 second, last-wins yields 100000/4096, while a
+    // hypothetical max-wins merge would keep 200000/8192.
+    expect(result.models[0]).toMatchObject({
+      id: "dup-model",
+      contextWindow: 100000,
+      maxTokens: 4096,
+    });
+  });
+
+  it("keeps the last real value across an interleaved real/null/real sequence", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "multi-model",
+            model_info: { mode: "chat", max_input_tokens: 200000, max_output_tokens: 8192 },
+          },
+          { model_name: "multi-model", model_info: { mode: null, max_input_tokens: null, max_output_tokens: null } },
+          {
+            model_name: "multi-model",
+            model_info: { mode: "chat", max_input_tokens: 300000, max_output_tokens: 16384 },
+          },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "multi-model",
+      contextWindow: 300000,
+      maxTokens: 16384,
+    });
+  });
+
+  it("keeps the first real value when only later routes are null", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        data: [
+          {
+            model_name: "first-real",
+            model_info: { mode: "chat", max_input_tokens: 500000, max_output_tokens: 65536 },
+          },
+          { model_name: "first-real", model_info: { mode: null, max_input_tokens: null, max_output_tokens: null } },
+          { model_name: "first-real", model_info: { mode: null, max_input_tokens: null, max_output_tokens: null } },
+        ],
+      }),
+    );
+
+    const result = await discoverModels("https://litellm.example.com", "sk-test", {});
+
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]).toMatchObject({
+      id: "first-real",
+      contextWindow: 500000,
+      maxTokens: 65536,
+    });
+  });
+
   it("keeps Kimi compatibility on non-Moonshot routes", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       jsonResponse(200, {


### PR DESCRIPTION
A 1M-context model (zai-glm-5-2) was reported to Pi as 128K, the DEFAULT_CONTEXT_WINDOW fallback. The trigger is a LiteLLM model-group that reuses one model_name across two routes (mistral/zai-glm-5-2 and nebius/zai-org/GLM-5.2, wired for cost-based fallback), where /model/info returns one entry per route and the Nebius route reports max_input_tokens: null because that provider does not auto-report context windows.

discoverModels() collapsed duplicate model_name entries with a raw spread, so the later route's null overwrote the earlier route's real
1048576. mapFromModelInfo then saw null and fell back via `?? DEFAULT_CONTEXT_WINDOW`, silently downgrading the model. The same collapse applies to cost and max_output_tokens, so a route that omits a field could also zero out another route's real value.

mergeModelInfo() copies keys from the incoming route only when they are not null or undefined, while still letting a later route's real value win over an earlier one. The top-level `...previous, ...entry` spread is left as-is; that last-route-wins behavior is intended for litellm_params and is separate from the model_info fix. Regression tests mirror the live two-entry zai-glm-5-2 payload (1048576 / 131072) and a later-real-wins case to guard against ignoring all later values.

https://github.com/BerriAI/litellm/issues/27830