### PR TITLE
fix: load the Pi extension from packaged source

### DIFF
--- a/.github/workflows/litellm-smoke.yml
+++ b/.github/workflows/litellm-smoke.yml
@@ -53,7 +53,6 @@ jobs:
           cache: 'npm'
 
       - run: npm ci --ignore-scripts
-      - run: npm run build
 
       - name: Install VidaiMock
         shell: bash
@@ -212,19 +211,37 @@ jobs:
           PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-cli-smoke
         run: npm test -- tests/terminal-smoke.test.ts
 
+      # `--list-models` also reports models Pi has persisted in its own store, so running it
+      # against the shared agent dir the terminal smoke already refreshed would pass even if
+      # the extension failed to load. Use a dedicated empty agent dir for this leg, and prove
+      # the assertion discriminates by first running it with a manifest entrypoint that does
+      # not exist -- the loader skips a missing entry silently, so the models must be absent.
       - name: Run Pi CLI smoke
         env:
           LITELLM_DISCOVERY_TIMEOUT_MS: '60000'
-          PI_CODING_AGENT_DIR: ${{ runner.temp }}/pi-cli-smoke
         run: |
           set -euo pipefail
 
-          ./node_modules/.bin/pi -e ./dist/index.js --list-models litellm 2>&1 | tee /tmp/pi-litellm-models.txt
+          list_models_dir="${{ runner.temp }}/pi-list-models"
+          rm -rf "$list_models_dir" && mkdir -p "$list_models_dir"
+
+          cp package.json /tmp/pi-manifest.bak
+          node -e 'const f="package.json";const p=require(`./${f}`);p.pi.extensions=["./src/does-not-exist.ts"];require("fs").writeFileSync(f,JSON.stringify(p,null,2))'
+          PI_CODING_AGENT_DIR="$list_models_dir" ./node_modules/.bin/pi -e . --list-models litellm 2>&1 | tee /tmp/pi-negative.txt || true
+          cp /tmp/pi-manifest.bak package.json
+          if grep -qF "vidaimock-openai" /tmp/pi-negative.txt; then
+            echo "negative control failed: models listed without a loadable entrypoint" >&2
+            exit 1
+          fi
+
+          rm -rf "$list_models_dir" && mkdir -p "$list_models_dir"
+          PI_CODING_AGENT_DIR="$list_models_dir" ./node_modules/.bin/pi -e . --list-models litellm 2>&1 | tee /tmp/pi-litellm-models.txt
           grep -F "vidaimock-openai" /tmp/pi-litellm-models.txt
           grep -F "anthropic/vidaimock-claude" /tmp/pi-litellm-models.txt
 
+          export PI_CODING_AGENT_DIR="${{ runner.temp }}/pi-cli-smoke"
           ./node_modules/.bin/pi \
-            -e ./dist/index.js \
+            -e . \
             --provider litellm \
             --model "$LITELLM_CLI_SMOKE_MODEL" \
             --no-tools \
@@ -235,7 +252,7 @@ jobs:
           # Anthropic-backed route: covers the cacheControlFormat "anthropic"
           # compat path through LiteLLM's Anthropic translation.
           ./node_modules/.bin/pi \
-            -e ./dist/index.js \
+            -e . \
             --provider litellm \
             --model "$LITELLM_CLI_SMOKE_MODEL_ANTHROPIC" \
             --no-tools \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 
 - This package is a Pi extension that registers a `litellm` provider from `src/index.ts`.
 - Source is TypeScript ESM under `src/`; tests are Vitest specs under `tests/`.
-- Build output is `dist/`; do not edit generated output by hand.
-- The package entrypoint is `./dist/index.js`, and the Pi extension registration comes from `package.json` `pi.extensions`.
+- Build output is `dist/`; do not edit generated output by hand or publish it.
+- Git and npm installs load `./src/index.ts` through `package.json` `pi.extensions`.
 - Node support starts at `>=22.19.0`; GitHub workflows currently run Node `26.5.0`.
 
 ## Commands
@@ -13,7 +13,7 @@
 - Use `npm ci` when reinstalling dependencies from the lockfile.
 - Use `npm test` for the full test suite.
 - Use `npm test -- tests/<file>.test.ts` for a focused Vitest run.
-- Use `npm run check` before committing code changes; it runs Biome, typecheck, and tests.
+- Use `npm run check` before committing code changes; it runs Biome, typecheck, tests, and the package-content guard.
 - Use `npm run clean && npm run build` when changing exported/runtime code.
 - Use `npm run supply-chain:guard` and `npm pack --dry-run` when package contents, dependency policy, or release packaging change.
 
@@ -24,7 +24,9 @@
 - The `/v1/models` fallback enriches metadata from the Pi catalog only; keep fallback metadata tests current.
 - Keep `LITELLM_OFFLINE` and `LITELLM_DISCOVERY_TIMEOUT_MS` behavior compatible with README docs.
 - Stored Pi `/login litellm` credentials take precedence over `LITELLM_API_KEY`.
-- Cache data is stored as `litellm-models.json` under the Pi agent dir with a keyed API-key fingerprint and a 24-hour stale refresh window.
+- Pi owns discovered-model persistence in `models-store.json`; this extension does not write a model cache. Legacy `litellm-models*.json` files are ignored and never deleted.
+- Google ADC is resolved in process through `src/gcloud-token.ts`; there is no helper subprocess and no `src/gcloud-token-cli.ts`. Only `authorized_user` credentials are supported, and service accounts warn and fail closed.
+- `apiKey.check` performs no network call, so it reports credential shape, not mintability. Its source label must mirror the precedence in `resolveCredentials`, so ADC is named whenever a complete ADC file exists; if the refresh token no longer mints, `resolve` falls back and reports the credential it actually used.
 
 ## LiteLLM Request Hooks
 
@@ -41,19 +43,20 @@
 
 ## Smoke And CI
 
-- CI runs `npm ci` and `npm run prepublishOnly`.
+- CI runs `npm ci` and `npm run prepublishOnly`; release relies on `npm publish` invoking `prepublishOnly`.
 - `.github/workflows/litellm-smoke.yml` uses VidaiMock plus a real LiteLLM proxy; it should not require real provider API keys.
 - Keep smoke readiness probes bounded with `curl --connect-timeout 1 --max-time 3`.
 - `scripts/smoke-runner.ts` exercises discovery and `/v1/chat/completions` through the proxy.
-- The non-interactive Pi CLI smoke uses `./dist/index.js`, so runtime changes need a fresh build before running it.
+- The non-interactive Pi CLI smoke loads the package root (`-e .`) so it exercises `pi.extensions` resolution; the interactive terminal smoke loads `src/index.ts` by path.
+- `--list-models` alone does not prove an extension loaded, because Pi also reports models from its own store. Assert a load-specific side effect instead.
 
 ## Release And Packaging
 
 - The release workflow is tag-driven for `v*.*.*`; it publishes with `npm publish --access public --provenance` and creates a GitHub release.
 - Local release prep should keep `package.json` and `package-lock.json` versions in sync, build `dist/`, run package checks, and create only local commits/tags unless the user explicitly overrides the no-push rule.
 - Verify released state with `gh release view <tag>` and `npm view pi-provider-litellm version dist-tags --json` after the user pushes the tag.
-- The npm package should stay limited to `dist`, `README.md`, and `LICENSE`.
-- `scripts/supply-chain-guard.ts` rejects install lifecycle scripts, runtime dependencies, non-registry specs, non-registry lockfile URLs, and unexpected package files; update tests before changing that policy.
+- The npm package should stay limited to `src`, `README.md`, and `LICENSE`; builds are verification-only.
+- `scripts/supply-chain-guard.ts` rejects install lifecycle scripts, runtime dependencies, non-registry specs, non-registry lockfile URLs, and unexpected package files, and requires every allowlisted source file to ship; update tests before changing that policy.
 
 ## Package Metadata
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pi-provider-litellm
 
-LiteLLM proxy native Provider extension for [Pi](https://pi.dev). Pi 0.81.0+ is required.
+LiteLLM proxy native Provider extension for [Pi](https://pi.dev). Pi 0.81.0+ is required; the TypeScript source
+entrypoint has been smoke-tested with Pi 0.81.0.
 
 Discovers models from self-hosted LiteLLM proxies and registers them under Pi providers. The default provider is `litellm`; optional aliases can register additional LiteLLM providers with separate credentials. Supports `/login litellm`, LiteLLM MCP tools, LiteLLM Skills Gateway prompt injection, and Google ADC token auth. Tries `/model/info` first (admin endpoint with rich metadata), falls back to `/v1/models` (OpenAI-compatible) on 401/403/404, then tries `/health` plus per-endpoint `/model/info` for older LiteLLM proxies.
 
@@ -23,10 +24,12 @@ pi -e npm:pi-provider-litellm
 
 ```bash
 git clone https://github.com/balcsida/pi-provider-litellm.git ~/.pi/agent/extensions/pi-provider-litellm
-cd ~/.pi/agent/extensions/pi-provider-litellm
-npm ci
-npm run clean && npm run build
 ```
+
+Pi loads the TypeScript source entrypoint declared in `package.json` `pi.extensions`, so a source install needs no
+build step and no `node_modules`. Install dependencies only to run the test suite or the local checks.
+
+The previously published 2.2.0 package was also importable as `pi-provider-litellm` from JavaScript or TypeScript. The source-only package no longer exposes that library import; it is supported only as a Pi extension.
 
 </details>
 
@@ -152,7 +155,7 @@ Treat the configured LiteLLM proxy as trusted: Skills can add instructions to th
 
 | Variable | Default | Effect |
 |---|---|---|
-| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. Registered as a `!command` provider key; Pi re-runs it on every request (the per-request auth path is uncached), so rotating/short-lived tokens stay fresh. |
+| `LITELLM_API_KEY_HELPER` | unset | Command that prints a fresh LiteLLM bearer token. Takes precedence over `LITELLM_API_KEY`. The extension runs it while resolving request auth, and Pi's per-request auth path is uncached, so rotating/short-lived tokens stay fresh. |
 | `LITELLM_HEADERS` | unset | JSON object of extra headers sent to LiteLLM provider, discovery, MCP, and Skills Gateway requests. Provider aliases can use it with `"headers": "$LITELLM_HEADERS"`. |
 | `LITELLM_GCLOUD_TOKEN_AUTH` | unset | If set to a non-empty value other than `0`, use Google Application Default Credentials as the LiteLLM bearer token source. This takes precedence over `LITELLM_API_KEY_HELPER` and `LITELLM_API_KEY` when no stored `/login litellm` credential exists. |
 | `GOOGLE_APPLICATION_CREDENTIALS` | Google default ADC path | Optional path to an ADC JSON file used by `LITELLM_GCLOUD_TOKEN_AUTH`. If unset, the extension checks the default gcloud ADC locations. |
@@ -175,7 +178,7 @@ export LITELLM_BASE_URL="https://litellm.your-domain.com"
 export LITELLM_GCLOUD_TOKEN_AUTH=1
 ```
 
-Only `authorized_user` ADC files are supported. Service account JSON files are rejected with a warning. Tokens are cached in memory for 50 minutes and the registered provider key is a Pi `!command`, so request-time auth resolves a fresh token when Pi sends model requests.
+Only `authorized_user` ADC files are supported. Service account JSON files are rejected with a warning. An `authorized_user` file with a missing, empty, or whitespace-only `client_id`, `client_secret`, or `refresh_token` is rejected before any token exchange. Tokens are refreshed in-process when Pi resolves request auth and cached in memory for 50 minutes.
 
 ## LiteLLM MCP tools
 
@@ -210,7 +213,7 @@ npm run check
 npm run clean && npm run build
 ```
 
-`npm run check` runs Biome, type checking, and the Vitest suite. Runtime changes must be built before local Pi smoke checks because the extension entrypoint is `./dist/index.js`.
+`npm run check` runs Biome, type checking, the Vitest suite, and the supply-chain package-content guard. Pi installs and local smoke checks load the shipped `src/index.ts` entrypoint directly; `dist/` is verification output only.
 
 Before changing package contents or dependency policy, also run:
 
@@ -219,11 +222,11 @@ npm run supply-chain:guard
 npm pack --dry-run
 ```
 
-The published npm package should contain only `dist`, `README.md`, and `LICENSE`.
+The published npm package contains only `src`, `README.md`, `LICENSE`, and the `package.json` npm always includes. Pi loads the TypeScript source entrypoint for both npm and Git installs. The package does not expose a JavaScript or TypeScript library import; load it through Pi.
 
 ## Release
 
-Releases are driven by semver tags named `v*.*.*`. The GitHub release workflow installs from the lockfile, runs the checks, builds `dist`, verifies the package tarball, publishes to npm with provenance, and creates a GitHub release.
+Releases are driven by semver tags named `v*.*.*`. The GitHub release workflow installs from the lockfile, then `npm publish` runs `prepublishOnly` to check the source, build `dist` for verification, verify the package contents, and publish to npm with provenance before the workflow creates a GitHub release.
 
 Before tagging a release, keep `package.json` and `package-lock.json` versions in sync and verify the dry-run package contents.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@kitlangton/terminal-control": "0.6.0",
         "@types/node": "^26.0.0",
         "@typescript/native-preview": "7.0.0-dev.20260707.2",
+        "es-module-lexer": "^2.1.0",
         "tsx": "^4.21.0",
         "vitest": "^4.1.7"
       },

--- a/package.json
+++ b/package.json
@@ -20,22 +20,14 @@
     "provider",
     "proxy"
   ],
-  "main": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
-    }
-  },
   "files": [
-    "dist",
+    "src",
     "README.md",
     "LICENSE"
   ],
   "pi": {
     "extensions": [
-      "./dist/index.js"
+      "./src/index.ts"
     ],
     "image": "https://raw.githubusercontent.com/balcsida/pi-provider-litellm/refs/heads/main/assets/pi_litellm_gallery.png"
   },
@@ -48,7 +40,7 @@
     "format": "biome check --write .",
     "test": "vitest --run --dir tests",
     "supply-chain:guard": "tsx scripts/supply-chain-guard.ts",
-    "check": "npm run lint && npm run typecheck && npm test",
+    "check": "npm run lint && npm run typecheck && npm test && npm run supply-chain:guard",
     "prepublishOnly": "npm run check && npm run clean && npm run build && npm run supply-chain:guard"
   },
   "engines": {
@@ -79,6 +71,7 @@
     "@kitlangton/terminal-control": "0.6.0",
     "@types/node": "^26.0.0",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",
+    "es-module-lexer": "^2.1.0",
     "tsx": "^4.21.0",
     "vitest": "^4.1.7"
   }

--- a/scripts/supply-chain-guard.ts
+++ b/scripts/supply-chain-guard.ts
@@ -7,7 +7,29 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 
-const installLifecycleScripts = new Set(["preinstall", "install", "postinstall", "prepare"]);
+// Hooks npm runs automatically during install, packing or publishing. Any of these can
+// mutate the tarball or the consumer's machine without the guard observing it, because
+// the guard inspects `npm pack --dry-run --ignore-scripts`. `prepare` has automatic
+// pre/post siblings that also run on `npm ci`, and the release workflow runs `npm ci`
+// before publishing, so a `postprepare` would execute with repository write access
+// before the tarball is built. `prepublishOnly` is deliberately absent: it runs only on
+// an explicit publish and is this package's verification command, not a mutation hook.
+const automaticLifecycleScripts = new Set([
+  "preinstall",
+  "install",
+  "postinstall",
+  "predependencies",
+  "dependencies",
+  "postdependencies",
+  "preprepare",
+  "prepare",
+  "postprepare",
+  "prepack",
+  "postpack",
+  "prepublish",
+  "publish",
+  "postpublish",
+]);
 const runtimeDependencySections = new Set([
   "dependencies",
   "optionalDependencies",
@@ -40,11 +62,26 @@ const nonRegistrySpecPrefixes = [
   "./",
 ];
 
+// The published source modules, listed explicitly so adding one is a reviewed
+// decision. `tests/supply-chain-guard.test.ts` asserts this list matches `src/`
+// exactly, so an entry for a module this branch does not ship fails the suite.
+export const allowedSourceModules = [
+  "cost",
+  "discover",
+  "gcloud-token",
+  "index",
+  "litellm",
+  "mcp-tools",
+  "provider",
+  "skills",
+  "types",
+];
+
 const allowedPackageFiles = [
   /^package\.json$/,
   /^README\.md$/,
   /^LICENSE$/,
-  /^dist\/(?:cache|cost|discover|gcloud-token|gcloud-token-cli|index|litellm|mcp-tools|provider|skills|types)\.(?:js|d\.ts)$/,
+  new RegExp(`^src/(?:${allowedSourceModules.join("|")})\\.ts$`),
 ];
 
 export interface SupplyChainGuardOptions {
@@ -128,8 +165,8 @@ function checkDependencyValue(section: string, value: unknown, errors: string[],
 
 function checkManifest(manifest: PackageManifest, errors: string[]): void {
   for (const [name] of Object.entries(manifest.scripts ?? {})) {
-    if (installLifecycleScripts.has(name)) {
-      errors.push(`package.json: scripts.${name} runs during package installation`);
+    if (automaticLifecycleScripts.has(name)) {
+      errors.push(`package.json: scripts.${name} runs automatically during install, pack, or publish`);
     }
   }
 
@@ -169,7 +206,22 @@ async function listPackageFiles(root: string, errors: string[]): Promise<string[
   }
 }
 
+// The allowlist bounds what may ship; this bounds what must. Without it a `files` typo
+// publishes a package with no source at all and the guard reports success, because it
+// only ever inspects files that are present. Only the source modules are checked: npm
+// includes package.json, README and LICENSE whatever `files` says, so asserting those
+// could never fail.
+function checkRequiredPackageFiles(files: string[], errors: string[]): void {
+  const present = new Set(files);
+  for (const module of allowedSourceModules) {
+    if (!present.has(`src/${module}.ts`)) {
+      errors.push(`npm package: required published file src/${module}.ts is missing`);
+    }
+  }
+}
+
 function checkPackageFiles(files: string[], errors: string[]): void {
+  checkRequiredPackageFiles(files, errors);
   for (const file of files) {
     if (!allowedPackageFiles.some((pattern) => pattern.test(file))) {
       errors.push(`npm package: unexpected published file ${file}`);

--- a/src/gcloud-token-cli.ts
+++ b/src/gcloud-token-cli.ts
@@ -1,8 +1,0 @@
-import { getGcloudToken } from "./gcloud-token.js";
-
-const token = await getGcloudToken();
-if (token) {
-  process.stdout.write(token);
-} else {
-  process.exitCode = 1;
-}

--- a/src/gcloud-token.ts
+++ b/src/gcloud-token.ts
@@ -2,7 +2,6 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { fileURLToPath } from "node:url";
 
 export const CACHE_TTL_MS = 50 * 60 * 1000;
 export const GCLOUD_TOKEN_CACHE_KEY = "gcloud-adc";
@@ -27,26 +26,21 @@ interface ServiceAccountCredentials {
 type GoogleCredentials = AuthorizedUserCredentials | ServiceAccountCredentials | { type?: string };
 
 function isAuthorizedUserCredentials(credentials: GoogleCredentials): credentials is AuthorizedUserCredentials {
+  const authorizedUser = credentials as Partial<AuthorizedUserCredentials>;
   return (
     credentials.type === "authorized_user" &&
-    typeof (credentials as Partial<AuthorizedUserCredentials>).client_id === "string" &&
-    typeof (credentials as Partial<AuthorizedUserCredentials>).client_secret === "string" &&
-    typeof (credentials as Partial<AuthorizedUserCredentials>).refresh_token === "string"
+    typeof authorizedUser.client_id === "string" &&
+    authorizedUser.client_id.trim() !== "" &&
+    typeof authorizedUser.client_secret === "string" &&
+    authorizedUser.client_secret.trim() !== "" &&
+    typeof authorizedUser.refresh_token === "string" &&
+    authorizedUser.refresh_token.trim() !== ""
   );
 }
 
 export function isGcloudTokenAuthEnabled(): boolean {
   const raw = process.env.LITELLM_GCLOUD_TOKEN_AUTH;
   return raw !== undefined && raw !== "" && raw !== "0";
-}
-
-function shellQuote(value: string): string {
-  return `'${value.replaceAll("'", "'\\''")}'`;
-}
-
-export function getGcloudTokenCommand(): string {
-  const cliPath = fileURLToPath(new URL("./gcloud-token-cli.js", import.meta.url));
-  return `!${shellQuote(process.execPath)} ${shellQuote(cliPath)}`;
 }
 
 function getAdcPath(): string | null {
@@ -59,11 +53,8 @@ function getAdcPath(): string | null {
   return candidates.find((path) => existsSync(path)) ?? null;
 }
 
-function getCredentialsCacheKey(credentials: GoogleCredentials): string | null {
-  if (isAuthorizedUserCredentials(credentials)) {
-    return `${GCLOUD_TOKEN_CACHE_KEY}:authorized_user:${credentials.client_id}:${credentials.refresh_token}`;
-  }
-  return null;
+function getCredentialsCacheKey(credentials: AuthorizedUserCredentials): string {
+  return `${GCLOUD_TOKEN_CACHE_KEY}:authorized_user:${credentials.client_id}:${credentials.refresh_token}`;
 }
 
 async function readCredentials(path: string): Promise<GoogleCredentials | null> {
@@ -74,7 +65,9 @@ async function readCredentials(path: string): Promise<GoogleCredentials | null> 
   }
 }
 
-export async function getGcloudTokenCacheKey(): Promise<string | null> {
+// Single ADC resolution path: locate the file, read it, and either return usable
+// authorized_user credentials or warn with the specific reason they are not.
+async function resolveAuthorizedUserAdc(): Promise<AuthorizedUserCredentials | null> {
   const adcPath = getAdcPath();
   if (!adcPath) {
     console.warn(
@@ -89,8 +82,12 @@ export async function getGcloudTokenCacheKey(): Promise<string | null> {
     return null;
   }
 
-  const cacheKey = getCredentialsCacheKey(credentials);
-  if (cacheKey) return cacheKey;
+  if (isAuthorizedUserCredentials(credentials)) return credentials;
+
+  if (credentials.type === "authorized_user") {
+    console.warn("LiteLLM gcloud auth: authorized_user ADC has invalid or incomplete required fields.");
+    return null;
+  }
 
   if (credentials.type === "service_account") {
     console.warn("LiteLLM gcloud auth: Service account credentials are not supported; use authorized_user ADC.");
@@ -99,6 +96,14 @@ export async function getGcloudTokenCacheKey(): Promise<string | null> {
 
   console.warn(`LiteLLM gcloud auth: Unknown credential type: ${credentials.type ?? "missing"}`);
   return null;
+}
+
+// Reports whether a complete `authorized_user` ADC file is present, emitting the same
+// diagnostics as the token path. This is a check on credential *shape*: whether the
+// refresh token is still honored by Google is only knowable at mint time, and
+// `apiKey.check` deliberately performs no network call.
+export async function hasGcloudAdcCredentials(): Promise<boolean> {
+  return (await resolveAuthorizedUserAdc()) !== null;
 }
 
 async function exchangeRefreshToken(credentials: AuthorizedUserCredentials): Promise<string | null> {
@@ -133,41 +138,19 @@ async function exchangeRefreshToken(credentials: AuthorizedUserCredentials): Pro
 }
 
 export async function getGcloudToken(): Promise<string | null> {
-  const adcPath = getAdcPath();
-  if (!adcPath) {
-    console.warn(
-      "LiteLLM gcloud auth: No Google ADC file found. Set GOOGLE_APPLICATION_CREDENTIALS or run `gcloud auth application-default login`.",
-    );
-    return null;
-  }
-
-  const credentials = await readCredentials(adcPath);
-  if (!credentials) {
-    console.warn(`LiteLLM gcloud auth: Failed to read ADC file: ${adcPath}`);
-    return null;
-  }
+  const credentials = await resolveAuthorizedUserAdc();
+  if (!credentials) return null;
 
   const cacheKey = getCredentialsCacheKey(credentials);
-  if (cacheKey && cachedToken && cachedTokenKey === cacheKey && Date.now() - cachedAt < CACHE_TTL_MS)
-    return cachedToken;
+  if (cachedToken && cachedTokenKey === cacheKey && Date.now() - cachedAt < CACHE_TTL_MS) return cachedToken;
 
-  if (isAuthorizedUserCredentials(credentials)) {
-    const token = await exchangeRefreshToken(credentials);
-    if (token) {
-      cachedToken = token;
-      cachedTokenKey = cacheKey;
-      cachedAt = Date.now();
-    }
-    return token;
+  const token = await exchangeRefreshToken(credentials);
+  if (token) {
+    cachedToken = token;
+    cachedTokenKey = cacheKey;
+    cachedAt = Date.now();
   }
-
-  if (credentials.type === "service_account") {
-    console.warn("LiteLLM gcloud auth: Service account credentials are not supported; use authorized_user ADC.");
-    return null;
-  }
-
-  console.warn(`LiteLLM gcloud auth: Unknown credential type: ${credentials.type ?? "missing"}`);
-  return null;
+  return token;
 }
 
 export function resetGcloudTokenCache(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,12 +16,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { getAgentDir, readStoredCredential } from "@earendil-works/pi-coding-agent";
 import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, emitsThinkTags, isGpt55Model, isMoonshotModel, normalizeBaseUrl } from "./discover.js";
-import {
-  getGcloudToken,
-  getGcloudTokenCacheKey,
-  getGcloudTokenCommand,
-  isGcloudTokenAuthEnabled,
-} from "./gcloud-token.js";
+import { getGcloudToken, hasGcloudAdcCredentials, isGcloudTokenAuthEnabled } from "./gcloud-token.js";
 import { getSessionIdFromFile } from "./litellm.js";
 import { createMcpToolDefinitions } from "./mcp-tools.js";
 import { createLiteLLMProvider, toNativeModels } from "./provider.js";
@@ -32,6 +27,7 @@ const PROVIDER_NAME = "litellm";
 const SETTINGS_KEY = "litellm";
 const ENV_BASE_URL = "LITELLM_BASE_URL";
 const ENV_API_KEY = "LITELLM_API_KEY";
+const GCLOUD_ADC_SOURCE = "gcloud ADC";
 const ENV_API_KEY_HELPER = "LITELLM_API_KEY_HELPER";
 const ENV_HEADERS = "LITELLM_HEADERS";
 const ENV_TIMEOUT = "LITELLM_DISCOVERY_TIMEOUT_MS";
@@ -351,8 +347,7 @@ async function resolveCredentials(
   const envKey = definition.useDefaultEnv ? cleanConfig(process.env[ENV_API_KEY]) : undefined;
   const envHelperCommand = definition.useDefaultEnv ? getApiKeyHelperCommand() : undefined;
   const useGcloudToken = definition.useGcloudTokenAuth && isGcloudTokenAuthEnabled();
-  const gcloudCacheKey = useGcloudToken ? ((await getGcloudTokenCacheKey()) ?? undefined) : undefined;
-  const gcloudKey = executeHelpers && gcloudCacheKey ? (await getGcloudToken())?.trim() : undefined;
+  const gcloudKey = executeHelpers && useGcloudToken ? (await getGcloudToken())?.trim() : undefined;
   // Resolved lazily so a `!command` key is not executed when a
   // higher-precedence credential (saved auth, gcloud token) already won.
   let configuredKey: string | undefined;
@@ -369,11 +364,7 @@ async function resolveCredentials(
   const apiKey = gcloudKey || configuredKey || helperKey || envKey;
 
   let apiKeyConfig: string | undefined;
-  if (gcloudKey) {
-    apiKeyConfig = getGcloudTokenCommand();
-  } else if (!executeHelpers && gcloudCacheKey) {
-    apiKeyConfig = getGcloudTokenCommand();
-  } else if (configuredKey && definition.apiKeyConfig) {
+  if (configuredKey && definition.apiKeyConfig) {
     apiKeyConfig = definition.apiKeyConfig;
   } else if (!executeHelpers && definition.apiKeyConfig?.startsWith("!")) {
     apiKeyConfig = definition.apiKeyConfig;
@@ -388,6 +379,7 @@ async function resolveCredentials(
     baseUrl: configuredBase ? normalizeBaseUrl(configuredBase, definition.allowInsecureHttp) : undefined,
     apiKey: apiKey || undefined,
     apiKeyConfig,
+    apiKeyFromGcloudAdc: Boolean(gcloudKey),
   };
 }
 
@@ -775,7 +767,7 @@ async function resolveApiKeyAuth(
       headers: await resolveHeadersFromContext(definition, ctx.env),
     },
     env: baseUrl ? { [ENV_BASE_URL]: normalizeBaseUrl(baseUrl, definition.allowInsecureHttp) } : undefined,
-    source: source ?? creds.apiKeyConfig ?? ENV_API_KEY,
+    source: source ?? (creds.apiKeyFromGcloudAdc ? GCLOUD_ADC_SOURCE : undefined) ?? creds.apiKeyConfig ?? ENV_API_KEY,
   };
 }
 
@@ -791,29 +783,28 @@ function createProviderAuth(definition: ProviderDefinition): ProviderAuth {
           (definition.useDefaultEnv ? await ctx.env(ENV_BASE_URL) : undefined);
         if (!cleanConfig(baseUrl)) return undefined;
         if (credential?.key) return { type: "api_key", source: "stored credential" };
-        const configured = await resolveCredentials(
-          { ...definition, apiKeyConfig: undefined, useDefaultEnv: false },
-          { executeHelpers: false },
-        );
-        if (configured.apiKey || configured.apiKeyConfig)
-          return {
-            type: "api_key",
-            source:
-              definition.useGcloudTokenAuth && isGcloudTokenAuthEnabled()
-                ? "gcloud ADC"
-                : (configured.apiKeyConfig ?? ENV_API_KEY),
-          };
-        if (definition.apiKeyConfig) {
-          const configuredKey = definition.apiKeyConfig.startsWith("!")
-            ? definition.apiKeyConfig
-            : await resolveTemplateConfigValueFromContext(definition.apiKeyConfig, ctx.env);
-          if (configuredKey) return { type: "api_key", source: definition.apiKeyConfig };
-        }
-        if (definition.useDefaultEnv && cleanConfig(await ctx.env(ENV_API_KEY_HELPER)))
-          return { type: "api_key", source: ENV_API_KEY_HELPER };
-        return definition.useDefaultEnv && cleanConfig(await ctx.env(ENV_API_KEY))
-          ? { type: "api_key", source: ENV_API_KEY }
-          : undefined;
+
+        // Credentials `resolve` would fall back to if ADC cannot mint a token.
+        const fallbackSource = async (): Promise<string | undefined> => {
+          if (definition.apiKeyConfig) {
+            const configuredKey = definition.apiKeyConfig.startsWith("!")
+              ? definition.apiKeyConfig
+              : await resolveTemplateConfigValueFromContext(definition.apiKeyConfig, ctx.env);
+            if (configuredKey) return definition.apiKeyConfig;
+          }
+          if (definition.useDefaultEnv && cleanConfig(await ctx.env(ENV_API_KEY_HELPER))) return ENV_API_KEY_HELPER;
+          if (definition.useDefaultEnv && cleanConfig(await ctx.env(ENV_API_KEY))) return ENV_API_KEY;
+          return undefined;
+        };
+
+        // Mirror the precedence in `resolveCredentials`, where ADC outranks the config
+        // key, the helper and the environment key. Whether the refresh token still mints
+        // is only knowable at request time, and this must not make a network call; if it
+        // fails, `resolve` falls back and reports the credential it actually used.
+        if (definition.useGcloudTokenAuth && isGcloudTokenAuthEnabled() && (await hasGcloudAdcCredentials()))
+          return { type: "api_key", source: GCLOUD_ADC_SOURCE };
+        const fallback = await fallbackSource();
+        return fallback ? { type: "api_key", source: fallback } : undefined;
       },
       resolve: ({ ctx, credential }) => resolveApiKeyAuth(definition, ctx, credential),
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,8 +86,9 @@ export type AuthFileEntry =
 export interface ResolvedCredentials {
   baseUrl?: string;
   apiKey?: string;
-  apiKeyFingerprint?: string;
   apiKeyConfig?: string;
+  // `apiKey` was minted from Google ADC rather than config, helper, or env.
+  apiKeyFromGcloudAdc?: boolean;
 }
 
 export interface LiteLLMMcpTool {

--- a/tests/cold-start-discovery.test.ts
+++ b/tests/cold-start-discovery.test.ts
@@ -3,18 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPi, loadExtension } from "./test-helpers.js";
+import { createPi, loadExtension, useHermeticEnv } from "./test-helpers.js";
 
 vi.unmock("@earendil-works/pi-coding-agent");
 
-const ENV_KEYS = [
-  "LITELLM_BASE_URL",
-  "LITELLM_API_KEY",
-  "LITELLM_OFFLINE",
-  "LITELLM_DISCOVERY_TIMEOUT_MS",
-  "PI_OFFLINE",
-];
-const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+useHermeticEnv();
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
@@ -34,11 +27,6 @@ async function startup(agentDir: string): Promise<ModelRuntime> {
 }
 
 afterEach(() => {
-  for (const key of ENV_KEYS) {
-    const original = ORIGINAL_ENV.get(key);
-    if (original === undefined) delete process.env[key];
-    else process.env[key] = original;
-  }
   vi.restoreAllMocks();
   vi.resetModules();
 });

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -2,7 +2,9 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPi, loadExtension, type TestPi } from "./test-helpers.js";
+import { createPi, loadExtension, type TestPi, useHermeticEnv } from "./test-helpers.js";
+
+useHermeticEnv();
 
 vi.unmock("@earendil-works/pi-coding-agent");
 
@@ -30,45 +32,125 @@ async function refreshProvider(pi: TestPi, allowNetwork = true, signal?: AbortSi
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
-  delete process.env.LITELLM_BASE_URL;
-  delete process.env.LITELLM_API_KEY;
-  delete process.env.LITELLM_HEADERS;
-  delete process.env.LITELLM_DISCOVERY_TIMEOUT_MS;
-  delete process.env.LITELLM_GCLOUD_TOKEN_AUTH;
-  delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+});
+
+const VALID_ADC = {
+  type: "authorized_user",
+  client_id: "client-id",
+  client_secret: "client-secret",
+  refresh_token: "refresh-token",
+};
+
+// Builds a provider whose only credential source is Google ADC, so `check` and
+// `resolve` can be compared directly for one ADC file shape.
+async function setupAdcProvider(adc: unknown | undefined): Promise<{
+  check: () => Promise<unknown>;
+  resolve: () => Promise<unknown>;
+}> {
+  const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+  const adcPath = join(agentDir, "adc.json");
+  if (adc !== undefined) await writeFile(adcPath, JSON.stringify(adc), "utf8");
+  process.env.GOOGLE_APPLICATION_CREDENTIALS = adcPath;
+  process.env.LITELLM_BASE_URL = "https://litellm.example.com";
+  process.env.LITELLM_GCLOUD_TOKEN_AUTH = "1";
+  process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+
+  const extension = await loadExtension(agentDir);
+  const pi = createPi();
+  await extension(pi);
+  const ctx = {
+    env: async (name: string) => process.env[name],
+    fileExists: async () => false,
+  };
+  const signal = new AbortController().signal;
+
+  // Without these, `pi.providers[0]?.auth...?.()` yields undefined when registration
+  // never happened -- the same value the negative cases assert, so they would pass
+  // against a provider that was never registered at all.
+  const provider = pi.providers[0];
+  expect(pi.providers).toHaveLength(1);
+  expect(typeof provider?.auth.apiKey?.check).toBe("function");
+  expect(typeof provider?.auth.apiKey?.resolve).toBe("function");
+
+  return {
+    check: async () => provider?.auth.apiKey?.check?.({ ctx, signal }),
+    resolve: async () => provider?.auth.apiKey?.resolve?.({ ctx, signal }),
+  };
+}
+
+describe("gcloud ADC provider auth", () => {
+  it("resolves an in-process ADC token and labels both auth paths consistently", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url === "https://oauth2.googleapis.com/token") {
+        return jsonResponse(200, { access_token: "ya29.minted", expires_in: 3600 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    const provider = await setupAdcProvider(VALID_ADC);
+
+    await expect(provider.check()).resolves.toEqual({ type: "api_key", source: "gcloud ADC" });
+    const resolved = (await provider.resolve()) as { auth: { apiKey: string }; source: string };
+    expect(resolved.auth.apiKey).toBe("ya29.minted");
+    expect(resolved.source).toBe("gcloud ADC");
+  });
+
+  // ADC outranks the environment key in resolveCredentials, so check must name ADC here.
+  // Nothing covered this state before, and reporting the fallback instead looked correct
+  // in isolation while contradicting what every request actually sends.
+  it("names ADC when it outranks a configured fallback", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url === "https://oauth2.googleapis.com/token") {
+        return jsonResponse(200, { access_token: "ya29.minted", expires_in: 3600 });
+      }
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    process.env.LITELLM_API_KEY = "sk-env-fallback";
+    const provider = await setupAdcProvider(VALID_ADC);
+
+    const checked = (await provider.check()) as { source: string };
+    const resolved = (await provider.resolve()) as { auth: { apiKey: string }; source: string };
+
+    expect(resolved.auth.apiKey).toBe("ya29.minted");
+    expect(resolved.source).toBe("gcloud ADC");
+    expect(checked.source).toBe(resolved.source);
+  });
+
+  // The one state where the two legitimately differ: check cannot know the refresh token
+  // is dead without a network call, so resolve reports the credential it fell back to.
+  it("falls back to the environment key when ADC cannot mint", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input instanceof Request ? input.url : input);
+      if (url === "https://oauth2.googleapis.com/token") return jsonResponse(400, { error: "invalid_grant" });
+      throw new Error(`unexpected fetch ${url}`);
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.LITELLM_API_KEY = "sk-env-fallback";
+    const provider = await setupAdcProvider(VALID_ADC);
+
+    const resolved = (await provider.resolve()) as { auth: { apiKey: string }; source: string };
+
+    expect(resolved.auth.apiKey).toBe("sk-env-fallback");
+    expect(resolved.source).toBe("LITELLM_API_KEY");
+  });
+
+  it.for([
+    ["an unreadable ADC file", undefined],
+    ["service_account credentials", { type: "service_account", client_email: "a@b.iam.gserviceaccount.com" }],
+    ["external_account credentials", { type: "external_account", audience: "//iam.googleapis.com/x" }],
+    ["a malformed authorized_user file", { type: "authorized_user", client_id: "client-id" }],
+  ] as const)("reports the provider unconfigured for %s", async ([, adc]) => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const provider = await setupAdcProvider(adc);
+
+    await expect(provider.check()).resolves.toBeUndefined();
+    await expect(provider.resolve()).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("feature parity", () => {
-  it("registers a command-backed gcloud token provider key when ADC auth is enabled", async () => {
-    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
-    const adcPath = join(agentDir, "adc.json");
-    await writeFile(
-      adcPath,
-      JSON.stringify({
-        type: "authorized_user",
-        client_id: "client-id",
-        client_secret: "client-secret",
-        refresh_token: "refresh-token",
-      }),
-      "utf8",
-    );
-    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
-    process.env.LITELLM_GCLOUD_TOKEN_AUTH = "1";
-    process.env.GOOGLE_APPLICATION_CREDENTIALS = adcPath;
-    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
-
-    const extension = await loadExtension(agentDir);
-    const pi = createPi();
-    await extension(pi);
-
-    await expect(
-      pi.providers[0]?.auth.apiKey?.check?.({
-        ctx: { env: async (name) => process.env[name], fileExists: async () => false },
-        signal: new AbortController().signal,
-      }),
-    ).resolves.toEqual({ type: "api_key", source: "gcloud ADC" });
-  });
-
   it("registers discovered LiteLLM MCP tools as Pi tools", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";

--- a/tests/gcloud-token.test.ts
+++ b/tests/gcloud-token.test.ts
@@ -2,13 +2,12 @@ import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { CACHE_TTL_MS, getGcloudToken, resetGcloudTokenCache } from "../src/gcloud-token.js";
+import { CACHE_TTL_MS, getGcloudToken, hasGcloudAdcCredentials, resetGcloudTokenCache } from "../src/gcloud-token.js";
+import { useHermeticEnv } from "./test-helpers.js";
 
-const ORIGINAL_ENV = {
-  APPDATA: process.env.APPDATA,
-  GOOGLE_APPLICATION_CREDENTIALS: process.env.GOOGLE_APPLICATION_CREDENTIALS,
-  HOME: process.env.HOME,
-};
+// HOME is included because getAdcPath falls back to it when GOOGLE_APPLICATION_CREDENTIALS
+// is unset, which this suite exercises.
+useHermeticEnv(["HOME"]);
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -25,15 +24,60 @@ async function writeAdcFile(body: unknown): Promise<string> {
 }
 
 afterEach(() => {
-  for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
-    if (value === undefined) delete process.env[key];
-    else process.env[key] = value;
-  }
   resetGcloudTokenCache();
   vi.restoreAllMocks();
 });
 
 describe("getGcloudToken", () => {
+  it("detects authorized_user ADC without exchanging a token", async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      refresh_token: "refresh-token",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await expect(hasGcloudAdcCredentials()).resolves.toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["client_id", ""],
+    ["client_id", " \t"],
+    ["client_secret", ""],
+    ["client_secret", " \n"],
+    ["refresh_token", ""],
+    ["refresh_token", " \r\n"],
+  ] as const)("rejects a blank %s in authorized_user ADC", async (field, value) => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      refresh_token: "refresh-token",
+      [field]: value,
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(hasGcloudAdcCredentials()).resolves.toBe(false);
+    await expect(getGcloudToken()).resolves.toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("authorized_user ADC has invalid or incomplete required fields"),
+    );
+    expect(warnSpy.mock.calls.flat().join(" ")).not.toContain("Unknown credential type");
+  });
+
+  it("preserves the unknown-type diagnostic for unsupported credential types", async () => {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({ type: "external_account" });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(getGcloudToken()).resolves.toBeNull();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Unknown credential type: external_account"));
+  });
+
   it("exchanges authorized_user ADC credentials for an access token", async () => {
     process.env.GOOGLE_APPLICATION_CREDENTIALS = await writeAdcFile({
       type: "authorized_user",
@@ -77,6 +121,54 @@ describe("getGcloudToken", () => {
 
     vi.mocked(Date.now).mockReturnValue(now + CACHE_TTL_MS + 1);
     await expect(getGcloudToken()).resolves.toBe("second-token");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reuses the cached token while the credential is unchanged", async () => {
+    const adcPath = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "stable-client",
+      client_secret: "stable-secret",
+      refresh_token: "stable-refresh",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(jsonResponse(200, { access_token: "cached" }));
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-06-10T12:00:00.000Z").getTime());
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = adcPath;
+
+    await expect(getGcloudToken()).resolves.toBe("cached");
+    await expect(getGcloudToken()).resolves.toBe("cached");
+    await expect(getGcloudToken()).resolves.toBe("cached");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Re-running `gcloud auth application-default login` rewrites refresh_token and leaves
+  // client_id and client_secret alone, so the cache identity must react to that field on its
+  // own. Rotating all three at once cannot show this.
+  it("invalidates the cached token when only the refresh token rotates", async () => {
+    const before = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "same-client",
+      client_secret: "same-secret",
+      refresh_token: "refresh-one",
+    });
+    const after = await writeAdcFile({
+      type: "authorized_user",
+      client_id: "same-client",
+      client_secret: "same-secret",
+      refresh_token: "refresh-two",
+    });
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "before-relogin" }))
+      .mockResolvedValueOnce(jsonResponse(200, { access_token: "after-relogin" }));
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-06-10T12:00:00.000Z").getTime());
+
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = before;
+    await expect(getGcloudToken()).resolves.toBe("before-relogin");
+
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = after;
+    await expect(getGcloudToken()).resolves.toBe("after-relogin");
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 

--- a/tests/import-specifiers.test.ts
+++ b/tests/import-specifiers.test.ts
@@ -1,0 +1,101 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import {
+  FORBIDDEN_RESOLVER,
+  importSpecifiers,
+  initImportSpecifiers,
+  UNVERIFIABLE_SPECIFIER,
+} from "./import-specifiers.js";
+
+// The package-load contract in tests/package.test.ts trusts this oracle, and an assertion
+// over an empty result would be vacuously true -- so an oracle returning nothing would make
+// that contract pass for any source. These cases pin the oracle itself.
+describe("importSpecifiers", () => {
+  beforeAll(async () => {
+    await initImportSpecifiers();
+  });
+
+  it.for([
+    ['import "pkg";', ["pkg"]],
+    ['import a from "pkg";', ["pkg"]],
+    ['import { a } from "pkg";', ["pkg"]],
+    ['import\n  { a }\n  from\n  "pkg";', ["pkg"]],
+    ['import type { A } from "pkg";', ["pkg"]],
+    ['export { a } from "pkg";', ["pkg"]],
+    ['export * from "pkg";', ["pkg"]],
+    ['export * as ns from "pkg";', ["pkg"]],
+    ['await import("pkg");', ["pkg"]],
+    ['import a from "./rel.js";', ["./rel.js"]],
+    ['import { readFile } from "node:fs/promises";', ["node:fs/promises"]],
+  ] as const)("extracts %s", ([source, expected]) => {
+    expect(importSpecifiers(source)).toEqual([...expected]);
+  });
+
+  it.for([
+    ["a line comment", '// import "pkg";\n'],
+    ["a block comment", '/* import "pkg"; */'],
+    ["a comment mentioning from", '// see from "pkg" for details\n'],
+    ["a plain string", `const msg = "resolved from 'pkg'";`],
+    ["a string with escaped quotes", 'const doc = "import x from \\"pkg\\"";'],
+    ["a template literal", 'const msg = `alias from "pkg" is unknown`;'],
+    ["an error message quoting a dynamic import", `throw new Error("use import('./x.js') instead");`],
+  ] as const)("ignores %s", ([, source]) => {
+    expect(importSpecifiers(source)).toEqual([]);
+  });
+
+  it.for([
+    ["a bare identifier", "await import(name);"],
+    ["a template with substitution", `await import(\`$${"{base}"}/mod.js\`);`],
+    ["a plain template literal", "await import(`pkg`);"],
+    ["a concatenation", 'await import("pk" + "g");'],
+  ] as const)("reports %s as unverifiable", ([, source]) => {
+    expect(importSpecifiers(source)).toContain(UNVERIFIABLE_SPECIFIER);
+  });
+
+  it.for([
+    ["require", 'const m = require("pkg");'],
+    ["createRequire", 'const r = createRequire(import.meta.url); r("pkg");'],
+    ["eval", 'eval("import(\\"pkg\\")");'],
+    ["new Function", 'new Function("return import(\\"pkg\\")");'],
+    ["import.meta.resolve", 'import.meta.resolve("pkg");'],
+    ["resolver after a regex containing quotes", 'const re = /[`"]+/; require("pkg");'],
+    ["resolver after a regex containing comment markers", 'const re = /\\/\\/* not a comment/; eval("1");'],
+    ["resolver in a template substitution", 'const value = `\u0024{require("pkg")}`;'],
+    ["resolver after a nested brace in a template substitution", 'const value = `\u0024{({}), eval("1")}`;'],
+    ["resolver after a conditional regex", 'if (ok) /safe/.test(value); require("pkg");'],
+    ["resolver after division", 'const ratio = total / count; require("pkg");'],
+  ] as const)("rejects %s as a forbidden resolver", ([, source]) => {
+    expect(importSpecifiers(source)).toContain(FORBIDDEN_RESOLVER);
+  });
+
+  // Only executable text counts. Flagging prose would fail the package contract for a doc
+  // comment or an error message, which is worse than the bypass it would be guarding.
+  it.for([
+    ["a line comment", "// we never call require() here\n"],
+    ["a block comment", "/* eval() is forbidden in this package */"],
+    ["a double-quoted message", 'const hint = "do not call require() directly";'],
+    ["a single-quoted message", "const hint = 'createRequire() is not allowed';"],
+    ["a template message", "const hint = `new Function() is rejected`;"],
+    ["an error string", 'throw new Error("import.meta.resolve() is unsupported here");'],
+    ["a regex literal", 'const pattern = /require\\("pkg"\\)|eval\\("1"\\)/;'],
+    ["a conditional regex literal", 'if (ok) /require\\("pkg"\\)/.test(value);'],
+    ["a template literal body", 'const value = `require("pkg")`;'],
+    ["a string in a template substitution", 'const value = `\u0024{"require(\\"pkg\\")"}`;'],
+    ["an identifier that merely contains the word", "const requiredFields = [1];\nconst evaluate = () => 1;"],
+  ] as const)("does not read %s as a forbidden resolver", ([, source]) => {
+    expect(importSpecifiers(source)).toEqual([]);
+  });
+
+  it("finds a lazy import inside a function that is never called", () => {
+    const source = ["export async function unused() {", '  return await import("pkg");', "}"].join("\n");
+
+    expect(importSpecifiers(source)).toEqual(["pkg"]);
+  });
+
+  // Asserted literally so renaming either constant cannot turn a rejected specifier into one
+  // an allowlist would silently accept.
+  it.for([UNVERIFIABLE_SPECIFIER, FORBIDDEN_RESOLVER] as const)("uses a sentinel no allowlist accepts: %s", (s) => {
+    expect(s.startsWith("<")).toBe(true);
+    expect(s.startsWith("node:")).toBe(false);
+    expect(s.startsWith("./")).toBe(false);
+  });
+});

--- a/tests/import-specifiers.ts
+++ b/tests/import-specifiers.ts
@@ -1,0 +1,144 @@
+import { SyntaxKind } from "@typescript/native-preview/unstable/ast";
+import { createScanner } from "@typescript/native-preview/unstable/ast/scanner";
+import { init, parse } from "es-module-lexer";
+
+// Extracts module specifiers from source text so the package-load contract can assert that
+// `src/` only imports things Pi's loader provides. es-module-lexer parses ESM imports, while
+// TypeScript's scanner identifies executable CommonJS and dynamic-evaluation escape hatches
+// without mistaking comments, strings, templates, or regex literals for calls.
+export const UNVERIFIABLE_SPECIFIER = "<unverifiable-dynamic-specifier>";
+export const FORBIDDEN_RESOLVER = "<forbidden-dynamic-resolver>";
+
+let ready: Promise<void> | undefined;
+
+// es-module-lexer compiles a WASM module on first use.
+export async function initImportSpecifiers(): Promise<void> {
+  ready ??= init;
+  await ready;
+}
+
+const REGEX_PRECEDERS = new Set([
+  SyntaxKind.OpenParenToken,
+  SyntaxKind.OpenBracketToken,
+  SyntaxKind.OpenBraceToken,
+  SyntaxKind.CommaToken,
+  SyntaxKind.SemicolonToken,
+  SyntaxKind.ColonToken,
+  SyntaxKind.QuestionToken,
+  SyntaxKind.EqualsToken,
+  SyntaxKind.EqualsGreaterThanToken,
+  SyntaxKind.ReturnKeyword,
+  SyntaxKind.ThrowKeyword,
+  SyntaxKind.CaseKeyword,
+  SyntaxKind.DeleteKeyword,
+  SyntaxKind.TypeOfKeyword,
+  SyntaxKind.VoidKeyword,
+  SyntaxKind.YieldKeyword,
+  SyntaxKind.AwaitKeyword,
+]);
+
+function tokenEndsExpression(kind: SyntaxKind): boolean {
+  return (
+    kind === SyntaxKind.Identifier ||
+    kind === SyntaxKind.RequireKeyword ||
+    kind === SyntaxKind.NumericLiteral ||
+    kind === SyntaxKind.BigIntLiteral ||
+    kind === SyntaxKind.StringLiteral ||
+    kind === SyntaxKind.RegularExpressionLiteral ||
+    kind === SyntaxKind.NoSubstitutionTemplateLiteral ||
+    kind === SyntaxKind.TemplateTail ||
+    kind === SyntaxKind.TrueKeyword ||
+    kind === SyntaxKind.FalseKeyword ||
+    kind === SyntaxKind.NullKeyword ||
+    kind === SyntaxKind.ThisKeyword ||
+    kind === SyntaxKind.SuperKeyword ||
+    kind === SyntaxKind.CloseParenToken ||
+    kind === SyntaxKind.CloseBracketToken ||
+    kind === SyntaxKind.CloseBraceToken ||
+    kind === SyntaxKind.PlusPlusToken ||
+    kind === SyntaxKind.MinusMinusToken
+  );
+}
+
+function scanTokens(source: string): Array<{ kind: SyntaxKind; text: string }> {
+  const scanner = createScanner(true, undefined, source);
+  const tokens: Array<{ kind: SyntaxKind; text: string }> = [];
+  const templateBraceDepths: number[] = [];
+  let previousKind: SyntaxKind | undefined;
+
+  while (true) {
+    let kind = scanner.scan();
+    if (
+      (kind === SyntaxKind.SlashToken || kind === SyntaxKind.SlashEqualsToken) &&
+      (previousKind === undefined || REGEX_PRECEDERS.has(previousKind) || !tokenEndsExpression(previousKind))
+    ) {
+      kind = scanner.reScanSlashToken();
+    }
+    if (kind === SyntaxKind.EndOfFile) break;
+
+    const text = scanner.getTokenText();
+    if (kind === SyntaxKind.TemplateHead) templateBraceDepths.push(0);
+    tokens.push({ kind, text });
+
+    const templateIndex = templateBraceDepths.length - 1;
+    if (kind === SyntaxKind.OpenBraceToken && templateIndex >= 0) {
+      templateBraceDepths[templateIndex] += 1;
+    } else if (kind === SyntaxKind.CloseBraceToken && templateIndex >= 0) {
+      if (templateBraceDepths[templateIndex] > 0) {
+        templateBraceDepths[templateIndex] -= 1;
+      } else {
+        kind = scanner.reScanTemplateToken(false);
+        tokens.push({ kind, text: scanner.getTokenText() });
+        if (kind === SyntaxKind.TemplateTail) templateBraceDepths.pop();
+      }
+    }
+    previousKind = kind;
+  }
+
+  return tokens;
+}
+
+function containsForbiddenResolver(source: string): boolean {
+  const tokens = scanTokens(source);
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const current = tokens[index];
+    const next = tokens[index + 1];
+    const previous = tokens[index - 1];
+
+    if (
+      next?.kind === SyntaxKind.OpenParenToken &&
+      (current.kind === SyntaxKind.RequireKeyword || current.text === "createRequire" || current.text === "eval")
+    ) {
+      return true;
+    }
+
+    if (
+      current.kind === SyntaxKind.NewKeyword &&
+      next?.text === "Function" &&
+      tokens[index + 2]?.kind === SyntaxKind.OpenParenToken
+    ) {
+      return true;
+    }
+
+    if (
+      previous?.kind === SyntaxKind.DotToken &&
+      current.text === "resolve" &&
+      next?.kind === SyntaxKind.OpenParenToken &&
+      tokens[index - 2]?.text === "meta" &&
+      tokens[index - 3]?.kind === SyntaxKind.DotToken &&
+      tokens[index - 4]?.kind === SyntaxKind.ImportKeyword
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function importSpecifiers(source: string, filename = "source.ts"): string[] {
+  const [imports] = parse(source, filename);
+  const specifiers = imports.map((entry) => entry.n ?? UNVERIFIABLE_SPECIFIER);
+  if (containsForbiddenResolver(source)) specifiers.push(FORBIDDEN_RESOLVER);
+  return specifiers;
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -10,15 +10,9 @@ import type {
   RefreshModelsContext,
 } from "@earendil-works/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPi, loadExtension } from "./test-helpers.js";
+import { createPi, loadExtension, useHermeticEnv } from "./test-helpers.js";
 
-const ENV_KEYS = [
-  "LITELLM_BASE_URL",
-  "LITELLM_API_KEY",
-  "LITELLM_API_KEY_HELPER",
-  "LITELLM_HEADERS",
-  "LITELLM_OFFLINE",
-  "LITELLM_VERBOSE_DISCOVERY",
+const SUITE_ENV_VARS = [
   "LITELLM_ANTHROPIC_API_KEY",
   "LITELLM_ANTHROPIC_HEADERS",
   "LITELLM_DISCOVERY_TIMEOUT_MS",
@@ -27,8 +21,10 @@ const ENV_KEYS = [
   "GOOGLE_APPLICATION_CREDENTIALS",
   "STORED_LITELLM_KEY",
   "CUSTOM_LITELLM_KEY",
-];
-const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+] as const;
+
+// Suite-specific names beyond the shared managed set.
+useHermeticEnv(SUITE_ENV_VARS);
 
 vi.unmock("@earendil-works/pi-coding-agent");
 
@@ -174,11 +170,6 @@ async function loginOAuth(
 }
 
 afterEach(() => {
-  for (const key of ENV_KEYS) {
-    const original = ORIGINAL_ENV.get(key);
-    if (original === undefined) delete process.env[key];
-    else process.env[key] = original;
-  }
   vi.restoreAllMocks();
   vi.resetModules();
 });

--- a/tests/litellm-smoke-workflow.test.ts
+++ b/tests/litellm-smoke-workflow.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { parsePushTriggers } from "./workflow-triggers.js";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
@@ -65,7 +66,8 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow).toContain("Run interactive Pi terminal smoke");
     expect(workflow).toContain("LITELLM_TERMINAL_SMOKE: '1'");
     expect(workflow).toContain("npm test -- tests/terminal-smoke.test.ts");
-    expect(workflow).toContain("./node_modules/.bin/pi -e ./dist/index.js --list-models litellm");
+    expect(workflow).toContain("./node_modules/.bin/pi -e . --list-models litellm");
+    expect(workflow).not.toContain("-e ./dist/index.js");
     expect(workflow).toContain("--provider litellm");
     expect(workflow).toContain('--model "$LITELLM_CLI_SMOKE_MODEL"');
     expect(workflow).toContain("LITELLM_CLI_SMOKE_MODEL_ANTHROPIC: anthropic/vidaimock-claude");
@@ -82,11 +84,51 @@ describe("LiteLLM smoke workflow", () => {
   });
 
   it("reuses the package publish gate in CI and release", () => {
+    const manifest = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8")) as {
+      scripts: Record<string, string>;
+    };
     expect(readCiWorkflow()).toContain("run: npm run prepublishOnly");
+    expect(manifest.scripts.check).toContain("npm run supply-chain:guard");
+    // `npm pack` selects by the `files` manifest, not by what is on disk, so the
+    // post-build run is not there to observe `dist/` existing. It is there to catch a
+    // manifest that re-authorizes `dist`: with `files` listing it, the pre-build run
+    // passes on a fresh checkout that has no `dist/` yet, and only a run after `build`
+    // fails. Pinned as full equality so the ordering cannot be relaxed and
+    // `npm run check` -- CI's only quality gate -- cannot be dropped.
+    expect(manifest.scripts.prepublishOnly).toBe(
+      "npm run check && npm run clean && npm run build && npm run supply-chain:guard",
+    );
     expect(readCiWorkflow()).not.toContain("run: npm pack --dry-run");
-    expect(readReleaseWorkflow()).not.toContain("run: npm run check");
     expect(readReleaseWorkflow()).not.toContain("run: npm pack --dry-run");
+    expect(readReleaseWorkflow()).not.toContain("run: npm run prepublishOnly");
     expect(readReleaseWorkflow()).toContain("run: npm publish --access public --provenance");
+  });
+
+  it("keeps the publish flow tag-only", () => {
+    expect(parsePushTriggers(readReleaseWorkflow())).toEqual({
+      branches: [],
+      tags: ["v*.*.*"],
+    });
+  });
+
+  // `--list-models` also reports models from Pi's own store, so this leg must run against an
+  // agent dir no earlier step has populated, and must prove it discriminates.
+  it("isolates and negative-controls the list-models smoke leg", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain('list_models_dir="$' + '{{ runner.temp }}/pi-list-models"');
+    expect(workflow).toContain(
+      'PI_CODING_AGENT_DIR="$list_models_dir" ./node_modules/.bin/pi -e . --list-models litellm',
+    );
+    expect(workflow).toContain('p.pi.extensions=["./src/does-not-exist.ts"]');
+    expect(workflow).toContain("negative control failed: models listed without a loadable entrypoint");
+    // The shared agent dir stays available to the completion legs, which need the login the
+    // terminal smoke performed, but must not be what --list-models reads.
+    expect(workflow).toContain('export PI_CODING_AGENT_DIR="$' + '{{ runner.temp }}/pi-cli-smoke"');
+  });
+
+  it("does not leave a dist build step in the smoke job", () => {
+    expect(readWorkflow()).not.toContain("run: npm run build");
   });
 
   it("runs for path-filtered pull requests", () => {
@@ -202,7 +244,11 @@ describe("LiteLLM smoke workflow", () => {
     expect(workflow.slice(initializeStart, terminalStart)).toContain(agentDir);
     expect(workflow.slice(initializeStart, terminalStart)).toContain('mkdir -p "$PI_CODING_AGENT_DIR"');
     expect(workflow.slice(terminalStart, cliStart)).toContain(agentDir);
-    expect(workflow.slice(cliStart, dumpLogsStart)).toContain(agentDir);
+    // The CLI step exports the shared dir inside its script rather than declaring it as step
+    // env, because its --list-models leg deliberately runs against a separate empty dir.
+    expect(workflow.slice(cliStart, dumpLogsStart)).toContain(
+      'export PI_CODING_AGENT_DIR="$' + '{{ runner.temp }}/pi-cli-smoke"',
+    );
     expect(workflow.slice(cliStart)).not.toContain('rm -rf "$PI_CODING_AGENT_DIR"');
   });
 

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -1,10 +1,77 @@
-import { cp, mkdtemp, readFile, rm } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { promisify } from "node:util";
 import { describe, expect, it } from "vitest";
+import { checkSupplyChain } from "../scripts/supply-chain-guard.js";
+import { importSpecifiers, initImportSpecifiers } from "./import-specifiers.js";
+import { hermeticChildEnv } from "./test-helpers.js";
 
+const execFileAsync = promisify(execFile);
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+interface PackageManifest {
+  main?: string;
+  types?: string;
+  exports?: unknown;
+  files: string[];
+  pi: { extensions: string[]; image: string };
+}
+
+interface LoadResult {
+  errors: unknown[];
+  extensions: unknown[];
+}
+
+async function loadExtension(
+  entrypoint: string,
+  cwd: string,
+  loaderPath = resolve(repoRoot, "node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/loader.js"),
+): Promise<LoadResult> {
+  let loader: unknown;
+  try {
+    loader = await import(pathToFileURL(loaderPath).href);
+  } catch (error) {
+    throw new Error(
+      `Pi's internal extension loader is unavailable at ${loaderPath}; update this package test for the installed @earendil-works/pi-coding-agent layout`,
+      { cause: error },
+    );
+  }
+
+  const loadExtensions = (loader as { loadExtensions?: unknown }).loadExtensions;
+  if (typeof loadExtensions !== "function") {
+    throw new Error(`Pi's internal extension loader at ${loaderPath} does not export loadExtensions`);
+  }
+
+  return (loadExtensions as (paths: string[], cwd: string) => Promise<LoadResult>)([entrypoint], cwd);
+}
+
+function isPathOutsideRepo(path: string, root = repoRoot): boolean {
+  const pathFromRepo = relative(root, path);
+  return (
+    pathFromRepo !== "" && (isAbsolute(pathFromRepo) || pathFromRepo === ".." || pathFromRepo.startsWith(`..${sep}`))
+  );
+}
+
+function expectFixtureOutsideRepo(fixture: string): void {
+  expect(isPathOutsideRepo(fixture), `${fixture} must be outside ${repoRoot}`).toBe(true);
+}
+
+async function runListModels(piBin: string, cwd: string, agentDir: string): Promise<string> {
+  const { stdout, stderr } = await execFileAsync(piBin, ["-e", ".", "--list-models", "litellm"], {
+    cwd,
+    env: hermeticChildEnv({
+      PI_CODING_AGENT_DIR: agentDir,
+      LITELLM_HEADERS: "{bad json",
+      LITELLM_OFFLINE: "1",
+      LITELLM_BASE_URL: "https://proxy.invalid",
+      LITELLM_API_KEY: "sk-not-a-real-key",
+    }),
+  });
+  return `${stdout}${stderr}`;
+}
 
 describe("package gallery metadata", () => {
   it("uses the gallery image URL expected by pi.dev", async () => {
@@ -18,32 +85,229 @@ describe("package gallery metadata", () => {
   });
 
   it("does not expose the npm badge as gallery media", async () => {
-    const readme = await readFile("README.md", "utf8");
+    const readme = await readFile(join(repoRoot, "README.md"), "utf8");
 
     expect(readme).not.toContain("https://img.shields.io/npm/v/pi-provider-litellm.svg");
   });
 });
 
 describe("pi package compatibility", () => {
-  it("loads outside the repository without Pi peer dependencies", async () => {
-    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-package-"));
-    try {
-      const source = join(fixture, "src");
-      await cp(join(repoRoot, "src"), source, { recursive: true });
-      const loaderUrl = pathToFileURL(
-        resolve(repoRoot, "node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/loader.js"),
-      ).href;
-      const { loadExtensions } = (await import(loaderUrl)) as {
-        loadExtensions(paths: string[], cwd: string): Promise<{ errors: unknown[] }>;
-      };
+  it("declares a single source-only Pi entrypoint", async () => {
+    const manifest = JSON.parse(await readFile(join(repoRoot, "package.json"), "utf8")) as PackageManifest;
 
-      const result = await loadExtensions([join(source, "index.ts")], fixture);
+    expect(manifest.pi.extensions).toEqual(["./src/index.ts"]);
+    expect(manifest.files).toEqual(["src", "README.md", "LICENSE"]);
+    expect(manifest).not.toHaveProperty("main");
+    expect(manifest).not.toHaveProperty("types");
+    expect(manifest).not.toHaveProperty("exports");
+  });
+
+  it("reports when Pi's internal extension loader path changes", async () => {
+    const missingLoader = join(repoRoot, "node_modules/@earendil-works/pi-coding-agent/dist/missing-loader.js");
+
+    await expect(loadExtension("unused.ts", repoRoot, missingLoader)).rejects.toThrow(
+      `Pi's internal extension loader is unavailable at ${missingLoader}`,
+    );
+  });
+
+  it("loads a production-only Git archive from its manifest entrypoint", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-git-package-"));
+    try {
+      expectFixtureOutsideRepo(fixture);
+      // Archive HEAD, not the working tree: a Git install materialises the committed
+      // tree, `git stash create` writes objects into an object store shared with sibling
+      // worktrees, and its output silently omits untracked files. Working-tree fidelity
+      // is owned by the `npm pack` test below, which is filesystem-based.
+      const archivePath = join(fixture, "git-package.tar");
+      await execFileAsync("git", ["archive", "--format=tar", `--output=${archivePath}`, "HEAD"], { cwd: repoRoot });
+      await execFileAsync("tar", ["-xf", archivePath, "-C", fixture]);
+      await rm(archivePath);
+      const manifest = JSON.parse(await readFile(join(fixture, "package.json"), "utf8")) as PackageManifest;
+      const entrypoint = resolve(fixture, manifest.pi.extensions[0]);
+
+      const result = await loadExtension(entrypoint, fixture);
 
       expect(result.errors).toEqual([]);
+      expect(result.extensions).toHaveLength(1);
     } finally {
       await rm(fixture, { force: true, recursive: true });
     }
-  }, 15_000);
+  }, 30_000);
+
+  // Proves the packed tarball ships the right files and that its declared entrypoint
+  // loads through Pi's real loader from both the extracted package root and a
+  // node_modules-shaped path. Peer resolution is deliberately not asserted: the loader
+  // is imported from this repository, so it resolves the extension's bare specifiers
+  // through its own context rather than from the fixture. `npm install` here could not
+  // prove peer resolution either, and cost a registry download of the peers' transitive
+  // dependencies on every run.
+  it("packs, installs, and loads the source package without TypeScript stripping in node_modules", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-npm-package-"));
+    try {
+      expectFixtureOutsideRepo(fixture);
+      const { stdout: tarballName } = await execFileAsync(
+        "npm",
+        ["pack", "--ignore-scripts", "--pack-destination", fixture],
+        { cwd: repoRoot },
+      );
+      const tarballPath = resolve(fixture, tarballName.trim().split("\n").at(-1) ?? "");
+      const { stdout: fileList } = await execFileAsync("tar", ["-tzf", tarballPath]);
+      await execFileAsync("tar", ["-xzf", tarballPath, "-C", fixture]);
+
+      const packageRoot = join(fixture, "package");
+      const manifest = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")) as PackageManifest;
+      const entrypoint = resolve(packageRoot, manifest.pi.extensions[0]);
+      const result = await loadExtension(entrypoint, packageRoot);
+
+      const nodeModules = join(fixture, "node_modules");
+      await mkdir(nodeModules, { recursive: true });
+      await cp(packageRoot, join(nodeModules, "pi-provider-litellm"), { recursive: true });
+      const installedEntrypoint = resolve(fixture, "node_modules/pi-provider-litellm", manifest.pi.extensions[0]);
+      const installedResult = await loadExtension(installedEntrypoint, fixture);
+
+      const guard = await checkSupplyChain(repoRoot);
+      expect(guard.errors).toEqual([]);
+      expect(fileList.trim().split("\n").sort()).toEqual(guard.packageFiles.map((file) => `package/${file}`).sort());
+      expect(result.errors).toEqual([]);
+      expect(result.extensions).toHaveLength(1);
+      expect(installedResult.errors).toEqual([]);
+      expect(installedResult.extensions).toHaveLength(1);
+    } finally {
+      await rm(fixture, { force: true, recursive: true });
+    }
+  }, 30_000);
+
+  // The in-process loader tests hand `loadExtensions` an absolute file path, so they skip
+  // the manifest resolution that `pi -e <dir>` and `pi install` actually perform. This
+  // drives the real CLI against a Git-install-shaped tree instead. A malformed
+  // LITELLM_HEADERS value is used as the load detector because the extension writes a
+  // distinctive line while registering the provider -- `--list-models` alone is not
+  // discriminating, since it also reports models from a cached store. The agent dir is
+  // redirected at an empty directory so no globally installed copy can satisfy the probe.
+  it("loads through the Pi CLI from a Git-install-shaped tree", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-cli-"));
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-agent-"));
+    const detector = "failed to parse custom headers";
+    const piBin = resolve(repoRoot, "node_modules/.bin/pi");
+
+    try {
+      expectFixtureOutsideRepo(fixture);
+      expectFixtureOutsideRepo(agentDir);
+      const archivePath = join(fixture, "git-package.tar");
+      await execFileAsync("git", ["archive", "--format=tar", `--output=${archivePath}`, "HEAD"], { cwd: repoRoot });
+      await execFileAsync("tar", ["-xf", archivePath, "-C", fixture]);
+      await rm(archivePath);
+
+      expect(await runListModels(piBin, fixture, agentDir)).toContain(detector);
+
+      // Negative control: a manifest entrypoint that does not exist is skipped silently by
+      // the loader, so without this the assertion above could pass on a stale global copy.
+      const manifestPath = join(fixture, "package.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as PackageManifest;
+      manifest.pi.extensions = ["./src/does-not-exist.ts"];
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      expect(await runListModels(piBin, fixture, agentDir)).not.toContain(detector);
+    } finally {
+      await rm(fixture, { force: true, recursive: true });
+      await rm(agentDir, { force: true, recursive: true });
+    }
+  }, 60_000);
+
+  // The CI smoke asserts model ids in `--list-models` output, and Pi serves those from its own
+  // models-store as well as from a loaded extension. This proves the assertion cannot be
+  // satisfied by a prepopulated store alone: with a cached model present and the manifest
+  // entrypoint broken, the extension does not load and its provider is absent.
+  it("cannot satisfy the list-models assertion from a prepopulated store alone", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-cache-"));
+    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-cachedir-"));
+    const cachedModelId = "cached-only-model";
+    const piBin = resolve(repoRoot, "node_modules/.bin/pi");
+
+    try {
+      expectFixtureOutsideRepo(fixture);
+      expectFixtureOutsideRepo(agentDir);
+      const archivePath = join(fixture, "git-package.tar");
+      await execFileAsync("git", ["archive", "--format=tar", `--output=${archivePath}`, "HEAD"], { cwd: repoRoot });
+      await execFileAsync("tar", ["-xf", archivePath, "-C", fixture]);
+      await rm(archivePath);
+
+      await writeFile(
+        join(agentDir, "models-store.json"),
+        JSON.stringify({
+          litellm: {
+            checkedAt: Date.now(),
+            models: [
+              {
+                id: cachedModelId,
+                name: cachedModelId,
+                provider: "litellm",
+                api: "openai-completions",
+                baseUrl: "https://litellm.example.com/v1",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                contextWindow: 128_000,
+                maxTokens: 4096,
+              },
+            ],
+          },
+        }),
+        "utf8",
+      );
+
+      const populatedOutput = await runListModels(piBin, fixture, agentDir);
+      expect(populatedOutput).toContain(cachedModelId);
+
+      const manifestPath = join(fixture, "package.json");
+      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as PackageManifest;
+      manifest.pi.extensions = ["./src/does-not-exist.ts"];
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      const brokenEntrypointOutput = await runListModels(piBin, fixture, agentDir);
+      expect(brokenEntrypointOutput).not.toContain("failed to parse custom headers");
+    } finally {
+      await rm(fixture, { force: true, recursive: true });
+      await rm(agentDir, { force: true, recursive: true });
+    }
+  }, 60_000);
+
+  it("keeps source runtime imports loader-provided or built-in", async () => {
+    await initImportSpecifiers();
+    const sourceDir = join(repoRoot, "src");
+    const sourceFiles = (await readdir(sourceDir, { recursive: true })).filter((file) => file.endsWith(".ts"));
+    const imports = await Promise.all(
+      sourceFiles.map(
+        async (file) => [file, importSpecifiers(await readFile(join(sourceDir, file), "utf8"), file)] as const,
+      ),
+    );
+
+    // A scanner bug that returned nothing would make the allowlist vacuously true, so
+    // require every shipped module to yield at least one specifier. The oracle itself is
+    // pinned by tests/import-specifiers.test.ts.
+    expect(sourceFiles.length).toBeGreaterThan(0);
+    for (const [file, specifiers] of imports) {
+      expect(specifiers.length, `${file}: no module specifiers found`).toBeGreaterThan(0);
+    }
+
+    const allowed = new Set([
+      "@earendil-works/pi-ai",
+      "@earendil-works/pi-ai/compat",
+      "@earendil-works/pi-ai/providers/all",
+      "@earendil-works/pi-coding-agent",
+    ]);
+    for (const [file, specifiers] of imports) {
+      for (const specifier of specifiers) {
+        // UNVERIFIABLE_SPECIFIER and FORBIDDEN_RESOLVER land here too: a computed `import()`
+        // cannot be shown to resolve to something the loader provides, and a CommonJS or
+        // dynamic-evaluation resolver bypasses the loader entirely. Both fail by default.
+        expect(
+          specifier.startsWith("node:") || specifier.startsWith("./") || allowed.has(specifier),
+          `${file}: ${specifier}`,
+        ).toBe(true);
+      }
+    }
+  });
 
   it("requires the native Provider extension API", async () => {
     const { default: manifest } = await import("../package.json", {
@@ -60,10 +324,12 @@ describe("pi package compatibility", () => {
     expect(manifest.devDependencies["@earendil-works/pi-coding-agent"]).toBe("^0.84.2");
   });
 
-  it("documents native Provider model persistence", async () => {
-    const readme = await readFile("README.md", "utf8");
+  it("documents native Provider model persistence and the extension-only package surface", async () => {
+    const readme = await readFile(join(repoRoot, "README.md"), "utf8");
 
     expect(readme).toContain("Pi 0.81.0+ is required");
+    expect(readme).toMatch(/source\s+entrypoint has been smoke-tested with Pi 0\.81\.0/);
+    expect(readme).toMatch(/no\s+longer exposes that library import/);
     expect(readme).toContain("native Provider");
     expect(readme).toContain("run `/login`, choose `Sign in with an API key`, then choose `LiteLLM API key`");
     expect(readme).toContain("With `/login litellm`, choose `Sign in with an API key` directly");
@@ -78,7 +344,7 @@ describe("pi package compatibility", () => {
 
 describe("dependency security overrides", () => {
   it("keeps vulnerable transitive dependencies above alerted ranges", async () => {
-    const lockfile = JSON.parse(await readFile("package-lock.json", "utf8")) as {
+    const lockfile = JSON.parse(await readFile(join(repoRoot, "package-lock.json"), "utf8")) as {
       packages?: Record<string, { version?: string }>;
     };
 

--- a/tests/pi-core-model-overrides.test.ts
+++ b/tests/pi-core-model-overrides.test.ts
@@ -3,10 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { ModelRuntime } from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPi, loadExtension } from "./test-helpers.js";
+import { createPi, loadExtension, useHermeticEnv } from "./test-helpers.js";
 
-const ENV_KEYS = ["LITELLM_BASE_URL", "LITELLM_API_KEY"];
-const ORIGINAL_ENV = new Map(ENV_KEYS.map((key) => [key, process.env[key]]));
+useHermeticEnv();
 
 function jsonResponse(status: number, body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -24,11 +23,6 @@ async function writeModelsConfig(agentDir: string, modelId: string, name: string
 }
 
 afterEach(() => {
-  for (const key of ENV_KEYS) {
-    const original = ORIGINAL_ENV.get(key);
-    if (original === undefined) delete process.env[key];
-    else process.env[key] = original;
-  }
   vi.restoreAllMocks();
   vi.resetModules();
 });

--- a/tests/provider-compat/helpers.ts
+++ b/tests/provider-compat/helpers.ts
@@ -2,6 +2,13 @@ import type { Api, AssistantMessage, AuthContext, Model, Models, Provider } from
 import { createModels, createProvider, InMemoryCredentialStore, InMemoryModelsStore } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { afterEach, vi } from "vitest";
+import { useHermeticEnv } from "../test-helpers.js";
+
+// Every provider-compat suite imports this module, and each drives real discovery through
+// the extension, which reads LITELLM_* from the environment. Registering the hermetic
+// hooks here gives all of them a known-empty environment; without it an ambient
+// LITELLM_OFFLINE or LITELLM_BASE_URL changes what these tests exercise.
+useHermeticEnv();
 
 export const RED_CIRCLE_PNG =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wl2nLkAAAAASUVORK5CYII=";

--- a/tests/supply-chain-guard.test.ts
+++ b/tests/supply-chain-guard.test.ts
@@ -1,9 +1,38 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { checkSupplyChain, parsePackageFiles } from "../scripts/supply-chain-guard.js";
+import { allowedSourceModules, checkSupplyChain, parsePackageFiles } from "../scripts/supply-chain-guard.js";
+
+async function writeFixturePackage(
+  fixture: string,
+  files: string[],
+  contents: Array<{ path: string; body?: string }>,
+): Promise<void> {
+  await writeFile(
+    join(fixture, "package.json"),
+    JSON.stringify({ name: "allowed-fixture", version: "1.0.0", files }, null, 2),
+  );
+  await writeFile(
+    join(fixture, "package-lock.json"),
+    JSON.stringify({
+      name: "allowed-fixture",
+      version: "1.0.0",
+      lockfileVersion: 3,
+      packages: { "": { name: "allowed-fixture", version: "1.0.0" } },
+    }),
+  );
+  await writeFile(join(fixture, "README.md"), "# fixture\n");
+  await writeFile(join(fixture, "LICENSE"), "MIT\n");
+  for (const { path, body } of contents) {
+    await mkdir(join(fixture, dirname(path)), { recursive: true });
+    await writeFile(join(fixture, path), body ?? "export {};\n");
+  }
+}
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 
 describe("supply-chain guard", () => {
   it("parses npm 11 and npm 12 package metadata", () => {
@@ -75,61 +104,153 @@ describe("supply-chain guard", () => {
   });
 
   it("accepts this package policy while keeping the publish build gate", async () => {
-    const result = await checkSupplyChain(process.cwd(), { checkPackageContents: false });
+    const result = await checkSupplyChain(repoRoot, { checkPackageContents: false });
 
     expect(result.errors).toEqual([]);
     expect(result.ok).toBe(true);
   });
 
-  it("accepts the intentional runtime dist files in the package", async () => {
+  it("authorizes exactly the source modules this branch ships", async () => {
+    const shipped = (await readdir(join(repoRoot, "src")))
+      .filter((file) => file.endsWith(".ts"))
+      .map((file) => file.replace(/\.ts$/, ""))
+      .sort();
+
+    expect([...allowedSourceModules].sort()).toEqual(shipped);
+  });
+
+  it("accepts only the intentional source modules in the package", async () => {
     const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-allowed-"));
 
     try {
-      await mkdir(join(fixture, "dist"), { recursive: true });
-      await writeFile(
-        join(fixture, "package.json"),
-        JSON.stringify(
-          {
-            name: "allowed-fixture",
-            version: "1.0.0",
-            files: ["dist", "README.md", "LICENSE"],
-          },
-          null,
-          2,
-        ),
+      await writeFixturePackage(
+        fixture,
+        ["src", "README.md", "LICENSE"],
+        allowedSourceModules.map((module) => ({ path: `src/${module}.ts` })),
       );
-      await writeFile(
-        join(fixture, "package-lock.json"),
-        JSON.stringify({
-          name: "allowed-fixture",
-          version: "1.0.0",
-          lockfileVersion: 3,
-          packages: { "": { name: "allowed-fixture", version: "1.0.0" } },
-        }),
-      );
-      await writeFile(join(fixture, "README.md"), "# fixture\n");
-      await writeFile(join(fixture, "LICENSE"), "MIT\n");
-      for (const file of [
-        "cache",
-        "cost",
-        "discover",
-        "gcloud-token",
-        "gcloud-token-cli",
-        "index",
-        "litellm",
-        "mcp-tools",
-        "provider",
-        "skills",
-        "types",
-      ]) {
-        await writeFile(join(fixture, "dist", `${file}.js`), "export {};\n");
-        await writeFile(join(fixture, "dist", `${file}.d.ts`), "export {};\n");
-      }
 
       const result = await checkSupplyChain(fixture);
 
       expect(result.errors).toEqual([]);
       expect(result.ok).toBe(true);
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a published build directory", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-dist-"));
+
+    try {
+      await writeFixturePackage(
+        fixture,
+        ["src", "dist", "README.md", "LICENSE"],
+        [{ path: "src/index.ts" }, { path: "dist/index.js" }, { path: "dist/index.d.ts" }],
+      );
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain("npm package: unexpected published file dist/index.js");
+      expect(result.errors).toContain("npm package: unexpected published file dist/index.d.ts");
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it.for([
+    ["an empty files list", [] as string[]],
+    ["a misspelled files entry", ["scr", "README.md", "LICENSE"]],
+  ] as const)("rejects %s that ships no source", async ([, files]) => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-nosrc-"));
+
+    try {
+      await writeFixturePackage(fixture, [...files], [{ path: "src/index.ts" }]);
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain("npm package: required published file src/index.ts is missing");
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it.for([
+    "preinstall",
+    "install",
+    "postinstall",
+    "predependencies",
+    "dependencies",
+    "postdependencies",
+    "preprepare",
+    "prepare",
+    "postprepare",
+    "prepack",
+    "postpack",
+    "prepublish",
+    "publish",
+    "postpublish",
+  ] as const)("rejects an automatic %s lifecycle hook", async (hook) => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-hook-"));
+
+    try {
+      await writeFixturePackage(
+        fixture,
+        ["src", "README.md", "LICENSE"],
+        allowedSourceModules.map((module) => ({ path: `src/${module}.ts` })),
+      );
+      const manifest = JSON.parse(await readFile(join(fixture, "package.json"), "utf8")) as Record<string, unknown>;
+      manifest.scripts = { [hook]: "node inject.js" };
+      await writeFile(join(fixture, "package.json"), JSON.stringify(manifest, null, 2));
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain(
+        `package.json: scripts.${hook} runs automatically during install, pack, or publish`,
+      );
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts prepublishOnly as an explicit verification command", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-verify-"));
+
+    try {
+      await writeFixturePackage(
+        fixture,
+        ["src", "README.md", "LICENSE"],
+        allowedSourceModules.map((module) => ({ path: `src/${module}.ts` })),
+      );
+      const manifest = JSON.parse(await readFile(join(fixture, "package.json"), "utf8")) as Record<string, unknown>;
+      manifest.scripts = { prepublishOnly: "npm run check" };
+      await writeFile(join(fixture, "package.json"), JSON.stringify(manifest, null, 2));
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.errors).toEqual([]);
+      expect(result.ok).toBe(true);
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a source module outside the allowlist", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "pi-provider-litellm-unlisted-"));
+
+    try {
+      await writeFixturePackage(
+        fixture,
+        ["src", "README.md", "LICENSE"],
+        [{ path: "src/index.ts" }, { path: "src/exfiltrate.ts" }],
+      );
+
+      const result = await checkSupplyChain(fixture);
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toContain("npm package: unexpected published file src/exfiltrate.ts");
     } finally {
       await rm(fixture, { recursive: true, force: true });
     }

--- a/tests/terminal-smoke.test.ts
+++ b/tests/terminal-smoke.test.ts
@@ -7,7 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const piPath = resolve(repoRoot, "node_modules/.bin/pi");
-const extensionPath = resolve(repoRoot, "dist/index.js");
+const extensionPath = resolve(repoRoot, "src/index.ts");
 const enabled = process.env.LITELLM_TERMINAL_SMOKE === "1";
 const smokeBaseUrl = process.env.LITELLM_BASE_URL ?? "http://127.0.0.1:4000";
 const waitTimeoutMs = 90_000;

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -1,6 +1,55 @@
 import { readFileSync } from "node:fs";
 import type { Provider } from "@earendil-works/pi-ai";
-import { vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
+
+// Every environment variable src/ reads. Tests that assert credential or discovery
+// behavior must start from a known-empty environment, not from the developer's
+// shell, and must not leak into the next test.
+export const MANAGED_ENV_VARS = [
+  "LITELLM_API_KEY",
+  "LITELLM_API_KEY_HELPER",
+  "LITELLM_BASE_URL",
+  "LITELLM_HEADERS",
+  "LITELLM_OFFLINE",
+  "LITELLM_DISCOVERY_TIMEOUT_MS",
+  "LITELLM_VERBOSE_DISCOVERY",
+  "LITELLM_GCLOUD_TOKEN_AUTH",
+  "GOOGLE_APPLICATION_CREDENTIALS",
+  "PI_OFFLINE",
+  "APPDATA",
+] as const;
+
+// Returns a subprocess environment with every source-read variable cleared before
+// applying explicit overrides.
+export function hermeticChildEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  for (const name of MANAGED_ENV_VARS) delete env[name];
+  return { ...env, ...overrides };
+}
+
+// Snapshots and clears the managed variables before each test and restores the
+// original values afterwards, so a result never depends on ambient environment or
+// on which test ran first in the file.
+//
+// `extra` adds suite-specific names. HOME is deliberately not in the shared set: clearing
+// it for every suite would break the npm and git subprocesses tests/package.test.ts spawns,
+// so only the suites that exercise ADC path discovery opt into it.
+export function useHermeticEnv(extra: readonly string[] = []): void {
+  const managed = [...MANAGED_ENV_VARS, ...extra];
+  let saved: Array<[string, string | undefined]> = [];
+
+  beforeEach(() => {
+    saved = managed.map((name) => [name, process.env[name]]);
+    for (const name of managed) delete process.env[name];
+  });
+
+  afterEach(() => {
+    for (const [name, value] of saved) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  });
+}
 
 type TestCommandContext = {
   ui: {

--- a/tests/workflow-triggers.test.ts
+++ b/tests/workflow-triggers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parsePushTriggers } from "./workflow-triggers.js";
+
+describe("parsePushTriggers", () => {
+  it("parses block tag filters", () => {
+    expect(
+      parsePushTriggers(`name: Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+permissions:
+  contents: write
+`),
+    ).toEqual({ branches: [], tags: ["v*.*.*"] });
+  });
+
+  it("parses inline branch and tag filters", () => {
+    expect(
+      parsePushTriggers(`on:
+  push:
+    branches: [main, release]
+    tags: ['v*', "rc-*"]
+jobs: {}
+`),
+    ).toEqual({ branches: ["main", "release"], tags: ["v*", "rc-*"] });
+  });
+
+  it("reports branch-triggered workflows instead of accepting an unrelated tags key", () => {
+    expect(
+      parsePushTriggers(`on:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    tags:
+      - 'v*.*.*'
+`),
+    ).toEqual({ branches: ["main"], tags: [] });
+  });
+});

--- a/tests/workflow-triggers.ts
+++ b/tests/workflow-triggers.ts
@@ -1,0 +1,49 @@
+export interface WorkflowTriggers {
+  branches: string[];
+  tags: string[];
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith("'") && trimmed.endsWith("'")) || (trimmed.startsWith('"') && trimmed.endsWith('"')))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseInlineList(value: string): string[] {
+  const trimmed = value.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return [];
+  return trimmed.slice(1, -1).split(",").map(unquote).filter(Boolean);
+}
+
+export function parsePushTriggers(workflow: string): WorkflowTriggers {
+  const lines = workflow.split(/\r?\n/);
+  const onIndex = lines.findIndex((line) => /^on:\s*$/.test(line));
+  if (onIndex === -1) return { branches: [], tags: [] };
+
+  const pushIndex = lines.findIndex((line, index) => index > onIndex && /^ {2}push:\s*$/.test(line));
+  if (pushIndex === -1) return { branches: [], tags: [] };
+
+  const result: WorkflowTriggers = { branches: [], tags: [] };
+  let section: keyof WorkflowTriggers | undefined;
+
+  for (const line of lines.slice(pushIndex + 1)) {
+    if (/^ {2}\S/.test(line)) break;
+
+    const key = /^ {4}(branches|tags):\s*(.*)$/.exec(line);
+    if (key) {
+      section = key[1] as keyof WorkflowTriggers;
+      result[section].push(...parseInlineList(key[2]));
+      continue;
+    }
+
+    const item = /^ {6}-\s+(.+)$/.exec(line);
+    if (section && item) result[section].push(unquote(item[1]));
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- ship the runtime TypeScript graph and load `src/index.ts` through Pi's extension loader
- replace the compiled-only ADC helper process with in-process credential resolution
- enforce both allowed and required package files, import specifiers, and release-workflow behavior
- document the intentional removal of the former Node library import surface

## Compatibility

This changes the package from a general Node import plus Pi extension to a Pi-extension-only package. The published `main`, `types`, and `exports` surface is intentionally removed.

The TypeScript source entrypoint was previously smoke-tested with Pi 0.81.0. This reconstruction was validated with the locked Pi 0.84.2 dependency.

## Validation

- `npm run check` — 363 passed, 1 skipped
- `npm run clean && npm run build`
- `npm run supply-chain:guard` — 12 package files
- `npm pack --dry-run` — source-only 12-file package
- package-root Pi CLI load smoke
- repo-consistency and `git diff --check`
