### PR TITLE
fix: use Pi session IDs for LiteLLM request grouping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 
 - `before_provider_request` is a global Pi hook. Only mutate provider payloads when `ctx.model?.provider === "litellm"`.
 - Do not add user-facing flags or environment variables to hide provider-scoping bugs.
-- `litellm_session_id` is optional LiteLLM session grouping metadata. If a LiteLLM server rejects it for LiteLLM-routed requests, keep Pi requests working first and document the admin-facing recommendation separately.
+- `before_provider_headers` sends Pi's canonical session id as `x-litellm-session-id`, scoped to the configured LiteLLM provider names; no session field is added to request bodies.
 - Kimi/Moonshot responses may include `<think>` text; Pi-visible normalization happens in the `message_end` hook and should stay covered by feature tests.
 
 ## Compatibility Rules

--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Treat the configured LiteLLM proxy as trusted: Skills can add instructions to th
 /model
 ```
 
+Every request routed through a configured LiteLLM provider includes Pi's canonical session ID in the
+`x-litellm-session-id` header. This groups Chat Completions, Responses, and native Messages requests in LiteLLM without
+adding transport-specific fields to request bodies.
+
 ## Optional environment variables
 
 | Variable | Default | Effect |

--- a/scripts/supply-chain-guard.ts
+++ b/scripts/supply-chain-guard.ts
@@ -70,7 +70,6 @@ export const allowedSourceModules = [
   "discover",
   "gcloud-token",
   "index",
-  "litellm",
   "mcp-tools",
   "provider",
   "skills",

--- a/src/index.ts
+++ b/src/index.ts
@@ -892,7 +892,6 @@ const GEMINI_MODEL_PATTERN = /(?:^|[-_/.:])gemini(?=$|[-_/.:])/i;
 function prepareLiteLLMRequestPayload(
   payload: Record<string, unknown>,
   model: LiteLLMModel | undefined,
-  sessionId: string | undefined,
 ): Record<string, unknown> | undefined {
   const modelId = model?.id;
   const api = model?.api;
@@ -974,11 +973,6 @@ function prepareLiteLLMRequestPayload(
         };
       }
     }
-  }
-
-  if (sessionId) {
-    next ??= { ...payload };
-    next.litellm_session_id = sessionId;
   }
 
   return next;
@@ -1276,15 +1270,15 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     }
   }
 
-  let sessionId: string | undefined;
-  pi.on("session_start", (_event, ctx) => {
-    sessionId = ctx.sessionManager.getSessionId();
+  pi.on("before_provider_headers", (event, ctx) => {
+    if (!ctx.model?.provider || !providerNames.has(ctx.model.provider)) return;
+    event.headers["x-litellm-session-id"] = ctx.sessionManager.getSessionId();
   });
 
   pi.on("before_provider_request", (event, ctx) => {
     if (!ctx.model?.provider || !providerNames.has(ctx.model.provider)) return;
     if (typeof event.payload !== "object" || event.payload === null) return;
-    return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model as LiteLLMModel, sessionId);
+    return prepareLiteLLMRequestPayload(event.payload as Record<string, unknown>, ctx.model as LiteLLMModel);
   });
 
   // Skills enrichment is best-effort: an expired credential or an unreachable proxy must not

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import { getAgentDir, readStoredCredential } from "@earendil-works/pi-coding-age
 import { setupLiteLLMCostTracking } from "./cost.js";
 import { discoverModels, emitsThinkTags, isGpt55Model, isMoonshotModel, normalizeBaseUrl } from "./discover.js";
 import { getGcloudToken, hasGcloudAdcCredentials, isGcloudTokenAuthEnabled } from "./gcloud-token.js";
-import { getSessionIdFromFile } from "./litellm.js";
 import { createMcpToolDefinitions } from "./mcp-tools.js";
 import { createLiteLLMProvider, toNativeModels } from "./provider.js";
 import { createSkillsPromptSection, createSkillToolDefinitions, listSkills } from "./skills.js";
@@ -1279,7 +1278,7 @@ export default async function (pi: ExtensionAPI): Promise<void> {
 
   let sessionId: string | undefined;
   pi.on("session_start", (_event, ctx) => {
-    sessionId = getSessionIdFromFile(ctx.sessionManager.getSessionFile());
+    sessionId = ctx.sessionManager.getSessionId();
   });
 
   pi.on("before_provider_request", (event, ctx) => {

--- a/src/litellm.ts
+++ b/src/litellm.ts
@@ -1,9 +1,0 @@
-import { basename } from "node:path";
-
-export function getSessionIdFromFile(sessionFile?: string): string | undefined {
-  if (!sessionFile) return undefined;
-  const filename = basename(sessionFile).replace(/\.jsonl$/i, "");
-  if (!filename) return undefined;
-  const uuidMatch = filename.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i);
-  return uuidMatch?.[1] ?? filename;
-}

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -15,7 +15,7 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPi, loadExtension, type TestPi, useHermeticEnv } from "./test-helpers.js";
 
-useHermeticEnv();
+useHermeticEnv(["PI_CODING_AGENT_DIR"]);
 
 vi.unmock("@earendil-works/pi-coding-agent");
 
@@ -703,6 +703,9 @@ describe("feature parity", () => {
 
   it("sends the Pi session id as a LiteLLM header across runtime request paths", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
+    // This test loads the extension through Pi's real loader, so getAgentDir() is not
+    // mocked and must be pointed at the temp dir or it reads the developer's settings.
+    process.env.PI_CODING_AGENT_DIR = agentDir;
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
     process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -679,7 +679,7 @@ describe("feature parity", () => {
         { reason: "reload" },
         {
           sessionManager: {
-            getSessionFile: () => join(agentDir, "2026-05-11T16-00-00-000Z_123e4567-e89b-12d3-a456-426614174000.jsonl"),
+            getSessionId: () => "123e4567-e89b-12d3-a456-426614174000",
           },
         },
       );
@@ -693,7 +693,7 @@ describe("feature parity", () => {
     expect(updated).toBeUndefined();
   });
 
-  it("injects LiteLLM session ids into LiteLLM provider requests", async () => {
+  it("omits session metadata before session_start and then uses the canonical Pi session id", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
@@ -728,30 +728,40 @@ describe("feature parity", () => {
     const pi = createPi();
     await extension(pi);
 
+    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
+    const model = { provider: "litellm", id: "kimi-k2.6", suppressReasoningContent: true };
+    const beforeSessionStart = beforeRequest?.({ payload: { messages: [] } }, { model });
+    expect(beforeSessionStart).toMatchObject({
+      messages: [],
+      include_reasoning: false,
+      reasoning_content: false,
+      merge_reasoning_content_in_choices: true,
+    });
+    expect(beforeSessionStart).not.toHaveProperty("litellm_session_id");
+
+    const getSessionFile = vi.fn(() => join(agentDir, "run-0", "session.jsonl"));
     const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
     for (const handler of sessionStartHandlers) {
       await handler(
         { reason: "reload" },
         {
           sessionManager: {
-            getSessionFile: () => join(agentDir, "2026-05-11T16-00-00-000Z_123e4567-e89b-12d3-a456-426614174000.jsonl"),
+            getSessionId: () => "canonical-pi-session-id",
+            getSessionFile,
           },
         },
       );
     }
 
-    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const updated = beforeRequest?.(
-      { payload: { messages: [] } },
-      { model: { provider: "litellm", id: "kimi-k2.6", suppressReasoningContent: true } },
-    );
+    const updated = beforeRequest?.({ payload: { messages: [] } }, { model });
     expect(updated).toMatchObject({
       messages: [],
       include_reasoning: false,
       reasoning_content: false,
       merge_reasoning_content_in_choices: true,
-      litellm_session_id: "123e4567-e89b-12d3-a456-426614174000",
+      litellm_session_id: "canonical-pi-session-id",
     });
+    expect(getSessionFile).not.toHaveBeenCalled();
   });
 
   it("does not send thinking for Kimi OpenAI completions requests", async () => {
@@ -1392,7 +1402,7 @@ describe("feature parity", () => {
 
     const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
     for (const handler of sessionStartHandlers) {
-      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+      await handler({ reason: "start" }, { sessionManager: { getSessionId: () => "test-session" } });
     }
 
     const responseHandler = pi.handlers.get("after_provider_response")?.[0];

--- a/tests/features.test.ts
+++ b/tests/features.test.ts
@@ -1,6 +1,17 @@
 import { mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { Api, Model, Provider } from "@earendil-works/pi-ai";
+import { createProvider } from "@earendil-works/pi-ai";
+import { anthropicMessagesApi, openAICompletionsApi, openAIResponsesApi } from "@earendil-works/pi-ai/compat";
+import {
+  createEventBus,
+  discoverAndLoadExtensions,
+  ExtensionRunner,
+  ModelRegistry,
+  ModelRuntime,
+  SessionManager,
+} from "@earendil-works/pi-coding-agent";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createPi, loadExtension, type TestPi, useHermeticEnv } from "./test-helpers.js";
 
@@ -26,6 +37,53 @@ async function refreshProvider(pi: TestPi, allowNetwork = true, signal?: AbortSi
       env: { LITELLM_BASE_URL: process.env.LITELLM_BASE_URL ?? "https://litellm.example.com" },
     },
     signal: signal ?? new AbortController().signal,
+  });
+}
+
+const testModel = (provider: string, id: string, api: Api): Model<Api> => ({
+  id,
+  name: id,
+  api,
+  provider,
+  baseUrl: "https://litellm.example.com/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128_000,
+  maxTokens: 4096,
+});
+
+const successfulStream = (api: Api): string =>
+  api === "anthropic-messages"
+    ? [
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"claude","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n',
+        'event: message_stop\ndata: {"type":"message_stop"}\n',
+      ].join("\n")
+    : api === "openai-responses"
+      ? [
+          'data: {"type":"response.created","response":{"id":"resp_1","object":"response","created_at":1,"status":"in_progress","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-test","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":false,"temperature":1,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}\n',
+          'data: {"type":"response.completed","response":{"id":"resp_1","object":"response","created_at":1,"status":"completed","error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"model":"gpt-test","output":[],"parallel_tool_calls":true,"previous_response_id":null,"reasoning":{"effort":null,"summary":null},"store":false,"temperature":1,"text":{"format":{"type":"text"}},"tool_choice":"auto","tools":[],"top_p":1,"truncation":"disabled","usage":{"input_tokens":1,"input_tokens_details":{"cached_tokens":0},"output_tokens":0,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":1},"user":null,"metadata":{}}}\n',
+          "data: [DONE]\n",
+        ].join("\n")
+      : 'data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n';
+
+function nativeProvider(id: string, models: readonly Model<Api>[]): Provider {
+  return createProvider({
+    id,
+    name: id,
+    baseUrl: "https://litellm.example.com/v1",
+    auth: {
+      apiKey: {
+        name: "test key",
+        resolve: async () => ({ auth: { apiKey: "sk-test" }, source: "test" }),
+      },
+    },
+    models,
+    api: {
+      "openai-completions": openAICompletionsApi(),
+      "openai-responses": openAIResponsesApi(),
+      "anthropic-messages": anthropicMessagesApi(),
+    },
   });
 }
 
@@ -643,125 +701,146 @@ describe("feature parity", () => {
     expect(pi.handlers.has("message_end")).toBe(true);
   });
 
-  it("does not inject LiteLLM session ids into non-LiteLLM provider requests", async () => {
+  it("sends the Pi session id as a LiteLLM header across runtime request paths", async () => {
     const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
     process.env.LITELLM_BASE_URL = "https://litellm.example.com";
     process.env.LITELLM_API_KEY = "sk-test";
-
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
-      if (url.endsWith("/model/info")) {
-        return jsonResponse(200, {
-          data: [
-            {
-              model_name: "anthropic/claude-3-5-sonnet",
-              model_info: {
-                mode: "chat",
-                input_cost_per_token: 0.000003,
-                output_cost_per_token: 0.000015,
-                cache_read_input_token_cost: 0.0000003,
-                cache_creation_input_token_cost: 0.00000375,
-              },
+    process.env.LITELLM_DISCOVERY_TIMEOUT_MS = "0";
+    await writeFile(
+      join(agentDir, "settings.json"),
+      JSON.stringify({
+        litellm: {
+          providers: {
+            "litellm-dev": {
+              baseUrl: "https://litellm.example.com",
+              apiKey: "sk-test",
+              mcp: { enabled: false },
+              skills: { enabled: false },
             },
-          ],
-        });
-      }
-      throw new Error(`unexpected URL: ${url}`);
-    });
-
-    const extension = await loadExtension(agentDir);
-    const pi = createPi();
-    await extension(pi);
-
-    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
-    for (const handler of sessionStartHandlers) {
-      await handler(
-        { reason: "reload" },
-        {
-          sessionManager: {
-            getSessionId: () => "123e4567-e89b-12d3-a456-426614174000",
           },
+          mcp: { enabled: false },
+          skills: { enabled: false },
         },
-      );
-    }
-
-    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const updated = beforeRequest?.(
-      { payload: { messages: [] } },
-      { model: { provider: "openai-codex", id: "gpt-5.5" } },
+      }),
+      "utf8",
     );
-    expect(updated).toBeUndefined();
-  });
 
-  it("omits session metadata before session_start and then uses the canonical Pi session id", async () => {
-    const agentDir = await mkdtemp(join(tmpdir(), "pi-provider-litellm-"));
-    process.env.LITELLM_BASE_URL = "https://litellm.example.com";
-    process.env.LITELLM_API_KEY = "sk-test";
+    const runtime = await ModelRuntime.create({
+      authPath: join(agentDir, "auth.json"),
+      modelsPath: null,
+      allowModelNetwork: false,
+    });
+    const sessionManager = SessionManager.inMemory(agentDir, { id: "canonical-pi-session-id" });
+    const loaded = await discoverAndLoadExtensions(
+      [join(process.cwd(), "src/index.ts")],
+      agentDir,
+      agentDir,
+      createEventBus(),
+    );
+    expect(loaded.errors).toEqual([]);
+    const extension = loaded.extensions[0];
+    if (!extension) throw new Error("extension did not load");
+    const modelRegistry = new ModelRegistry(runtime);
+    let currentModel: Model<Api> | undefined;
+    const runner = new ExtensionRunner([extension], loaded.runtime, agentDir, sessionManager, modelRegistry);
+    runner.bindCore(
+      {
+        sendMessage: () => {},
+        sendUserMessage: () => {},
+        appendEntry: () => {},
+        setSessionName: () => {},
+        getSessionName: () => undefined,
+        setLabel: () => {},
+        getActiveTools: () => [],
+        getAllTools: () => [],
+        setActiveTools: () => {},
+        refreshTools: () => {},
+        getCommands: () => [],
+        setModel: async () => true,
+        getThinkingLevel: () => "off",
+        setThinkingLevel: () => {},
+      },
+      {
+        getModel: () => currentModel,
+        getScopedModels: () => [],
+        isIdle: () => false,
+        isProjectTrusted: () => true,
+        getSignal: () => undefined,
+        abort: () => {},
+        hasPendingMessages: () => false,
+        shutdown: () => {},
+        getContextUsage: () => undefined,
+        compact: () => {},
+        getSystemPrompt: () => "",
+      },
+    );
 
-    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const chat = testModel("litellm", "chat-model", "openai-completions");
+    const responses = testModel("litellm", "responses-model", "openai-responses");
+    const messages = testModel("litellm", "messages-model", "anthropic-messages");
+    const alias = testModel("litellm-dev", "alias-model", "openai-completions");
+    const other = testModel("other", "other-model", "openai-completions");
+    runtime.registerNativeProvider(nativeProvider("litellm", [chat, responses, messages]));
+    runtime.registerNativeProvider(nativeProvider("litellm-dev", [alias]));
+    runtime.registerNativeProvider(nativeProvider("other", [other]));
+
+    const requests: Array<{ api: Api; headers: Headers; body: Record<string, unknown> }> = [];
+    let retryPending = true;
+    const requestFetch: typeof fetch = async (input, init) => {
       const url = String(input);
-      if (url.endsWith("/model/info")) {
-        return jsonResponse(200, {
-          data: [
-            {
-              model_name: "kimi-k2.6",
-              litellm_params: { model: "moonshot/kimi-k2.6" },
-              model_info: { mode: "chat" },
-            },
-            {
-              model_name: "anthropic/claude-3-5-sonnet",
-              model_info: {
-                mode: "chat",
-                input_cost_per_token: 0.000003,
-                output_cost_per_token: 0.000015,
-                cache_read_input_token_cost: 0.0000003,
-                cache_creation_input_token_cost: 0.00000375,
-              },
-            },
-          ],
-        });
+      const api: Api = url.endsWith("/responses")
+        ? "openai-responses"
+        : url.endsWith("/messages")
+          ? "anthropic-messages"
+          : "openai-completions";
+      const headers = new Headers(input instanceof Request ? input.headers : init?.headers);
+      const body = JSON.parse(String(input instanceof Request ? await input.clone().text() : init?.body)) as Record<
+        string,
+        unknown
+      >;
+      requests.push({ api, headers, body });
+      if (retryPending && body.model === "chat-model") {
+        retryPending = false;
+        return jsonResponse(503, { error: { message: "retry", type: "server_error" } });
       }
-      throw new Error(`unexpected URL: ${url}`);
-    });
+      return new Response(successfulStream(api), {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    };
 
-    const extension = await loadExtension(agentDir);
-    const pi = createPi();
-    await extension(pi);
-
-    const beforeRequest = pi.handlers.get("before_provider_request")?.[0];
-    const model = { provider: "litellm", id: "kimi-k2.6", suppressReasoningContent: true };
-    const beforeSessionStart = beforeRequest?.({ payload: { messages: [] } }, { model });
-    expect(beforeSessionStart).toMatchObject({
-      messages: [],
-      include_reasoning: false,
-      reasoning_content: false,
-      merge_reasoning_content_in_choices: true,
-    });
-    expect(beforeSessionStart).not.toHaveProperty("litellm_session_id");
-
-    const getSessionFile = vi.fn(() => join(agentDir, "run-0", "session.jsonl"));
-    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
-    for (const handler of sessionStartHandlers) {
-      await handler(
-        { reason: "reload" },
+    const send = async (model: Model<Api>): Promise<void> => {
+      currentModel = model;
+      await runtime.completeSimple(
+        model,
+        { messages: [] },
         {
-          sessionManager: {
-            getSessionId: () => "canonical-pi-session-id",
-            getSessionFile,
-          },
+          fetch: requestFetch,
+          maxRetries: 1,
+          maxRetryDelayMs: 1,
+          transformHeaders: (headers) => runner.emitBeforeProviderHeaders(headers),
+          onPayload: (payload) => runner.emitBeforeProviderRequest(payload),
         },
       );
-    }
+    };
 
-    const updated = beforeRequest?.({ payload: { messages: [] } }, { model });
-    expect(updated).toMatchObject({
-      messages: [],
-      include_reasoning: false,
-      reasoning_content: false,
-      merge_reasoning_content_in_choices: true,
-      litellm_session_id: "canonical-pi-session-id",
-    });
-    expect(getSessionFile).not.toHaveBeenCalled();
+    await send(chat);
+    await send(responses);
+    await send(messages);
+    await send(alias);
+    await send(other);
+
+    expect(requests.map(({ api, headers }) => [api, headers.get("x-litellm-session-id")])).toEqual([
+      ["openai-completions", "canonical-pi-session-id"],
+      ["openai-completions", "canonical-pi-session-id"],
+      ["openai-responses", "canonical-pi-session-id"],
+      ["anthropic-messages", "canonical-pi-session-id"],
+      ["openai-completions", "canonical-pi-session-id"],
+      ["openai-completions", null],
+    ]);
+    for (const request of requests) {
+      expect(request.body).not.toHaveProperty("litellm_session_id");
+    }
   });
 
   it("does not send thinking for Kimi OpenAI completions requests", async () => {
@@ -1399,11 +1478,6 @@ describe("feature parity", () => {
     const extension = await loadExtension(agentDir);
     const pi = createPi();
     await extension(pi);
-
-    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
-    for (const handler of sessionStartHandlers) {
-      await handler({ reason: "start" }, { sessionManager: { getSessionId: () => "test-session" } });
-    }
 
     const responseHandler = pi.handlers.get("after_provider_response")?.[0];
     responseHandler?.(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -175,7 +175,7 @@ afterEach(() => {
 });
 
 describe("extension startup", () => {
-  it("registers one complete native provider and one session handler", async () => {
+  it("registers one complete native provider and the request hooks", async () => {
     const extension = await loadExtension(await makeAgentDir());
     const pi = createPi();
 
@@ -190,7 +190,8 @@ describe("extension startup", () => {
         refreshModels: expect.any(Function),
       }),
     );
-    expect(pi.handlers.get("session_start")).toHaveLength(1);
+    expect(pi.handlers.get("before_provider_headers")).toHaveLength(1);
+    expect(pi.handlers.get("before_provider_request")).toHaveLength(1);
     expect(pi.commands.has("litellm-refresh")).toBe(false);
   });
 
@@ -764,11 +765,6 @@ describe("extension startup", () => {
     await writeFile(join(agentDir, "auth.json"), JSON.stringify({ litellm: { type: "oauth", ...credential } }), "utf8");
 
     vi.mocked(Date.now).mockReturnValue(loginTime + 25 * 60 * 60 * 1000);
-    const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
-    for (const handler of sessionStartHandlers) {
-      await handler({ reason: "start" }, { sessionManager: { getSessionId: () => "test-session" } });
-    }
-
     expect(callCount).toBe(0);
   });
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -766,7 +766,7 @@ describe("extension startup", () => {
     vi.mocked(Date.now).mockReturnValue(loginTime + 25 * 60 * 60 * 1000);
     const sessionStartHandlers = pi.handlers.get("session_start") ?? [];
     for (const handler of sessionStartHandlers) {
-      await handler({ reason: "start" }, { sessionManager: { getSessionFile: () => undefined } });
+      await handler({ reason: "start" }, { sessionManager: { getSessionId: () => "test-session" } });
     }
 
     expect(callCount).toBe(0);


### PR DESCRIPTION
## Summary

- source `litellm_session_id` from `SessionManager.getSessionId()`
- remove filename-derived session parsing
- keep the metadata optional and scoped to LiteLLM provider requests
- add negative coverage before `session_start` and prove the session filename is never consulted

## Validation

- focused session feature and registration tests
- full check, clean build, package and supply-chain checks
- repo-consistency and clean worktree

## Update — header, not body metadata

Superseding the summary above: LiteLLM requests now carry Pi's canonical session id as an `x-litellm-session-id` header,
set in the `before_provider_headers` hook. Body-level `litellm_session_id` injection is removed along with the
filename-derived session parsing (`src/litellm.ts` is deleted).

The header is scoped to configured LiteLLM provider names, including aliases, so it covers Chat Completions, Responses,
and native Messages, survives model switches and retries, and is never added to non-LiteLLM providers. The runtime test
loads the extension through Pi's real extension loader and asserts the header on each captured request.

Rebased onto `main` after #159. A second follow-up pins that test to its own temp agent directory; it had been reading
the developer's `settings.json`. CI is green.
